### PR TITLE
feat: Phase 2 — predictive input, Viterbi conversion, custom candidate panel

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -30,5 +30,30 @@
     </array>
     <key>tsInputMethodIconFileKey</key>
     <string>icon.tiff</string>
+    <key>ComponentInputModeDict</key>
+    <dict>
+        <key>tsInputModeListKey</key>
+        <dict>
+            <key>dev.sendsh.inputmethod.Lexime.Japanese</key>
+            <dict>
+                <key>TISIntendedLanguage</key>
+                <string>ja</string>
+                <key>tsInputModeDefaultStateKey</key>
+                <true/>
+                <key>tsInputModeScriptKey</key>
+                <string>smJapanese</string>
+                <key>tsInputModeMenuIconFileKey</key>
+                <string>icon.tiff</string>
+                <key>tsInputModeIsVisibleKey</key>
+                <true/>
+                <key>tsInputModePrimaryInScriptKey</key>
+                <true/>
+            </dict>
+        </dict>
+        <key>tsVisibleInputModeOrderedArrayKey</key>
+        <array>
+            <string>dev.sendsh.inputmethod.Lexime.Japanese</string>
+        </array>
+    </dict>
 </dict>
 </plist>

--- a/Sources/CandidatePanel.swift
+++ b/Sources/CandidatePanel.swift
@@ -1,0 +1,141 @@
+import Cocoa
+
+// MARK: - CandidateListView
+
+class CandidateListView: NSView {
+
+    var candidates: [String] = []
+    var selectedIndex: Int = 0
+
+    override var isFlipped: Bool { true }
+
+    private let font = NSFont.systemFont(ofSize: 14)
+    private let numberFont = NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .regular)
+    private let rowHeight: CGFloat = 24
+    private let horizontalPadding: CGFloat = 8
+    private let numberWidth: CGFloat = 20
+
+    var desiredSize: NSSize {
+        guard !candidates.isEmpty else { return .zero }
+        let attrs: [NSAttributedString.Key: Any] = [.font: font]
+        var maxTextWidth: CGFloat = 0
+        for c in candidates {
+            let w = (c as NSString).size(withAttributes: attrs).width
+            if w > maxTextWidth { maxTextWidth = w }
+        }
+        let width = horizontalPadding + numberWidth + horizontalPadding + maxTextWidth + horizontalPadding
+        let height = rowHeight * CGFloat(candidates.count)
+        return NSSize(width: ceil(width), height: ceil(height))
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let bg = NSColor.windowBackgroundColor
+        bg.setFill()
+        NSBezierPath(roundedRect: bounds, xRadius: 4, yRadius: 4).fill()
+
+        let numberAttrs: [NSAttributedString.Key: Any] = [
+            .font: numberFont,
+            .foregroundColor: NSColor.secondaryLabelColor,
+        ]
+
+        for (i, candidate) in candidates.enumerated() {
+            let y = CGFloat(i) * rowHeight
+            let rowRect = NSRect(x: 0, y: y, width: bounds.width, height: rowHeight)
+
+            if i == selectedIndex {
+                NSColor.selectedContentBackgroundColor.setFill()
+                NSBezierPath(roundedRect: rowRect.insetBy(dx: 2, dy: 1), xRadius: 3, yRadius: 3).fill()
+            }
+
+            let textColor: NSColor = i == selectedIndex
+                ? .alternateSelectedControlTextColor
+                : .labelColor
+
+            let textAttrs: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: textColor,
+            ]
+
+            let numStr = "\(i + 1)" as NSString
+            let numRect = NSRect(x: horizontalPadding, y: y + 3, width: numberWidth, height: rowHeight)
+            numStr.draw(in: numRect, withAttributes: i == selectedIndex
+                ? [.font: numberFont, .foregroundColor: textColor]
+                : numberAttrs)
+
+            let textX = horizontalPadding + numberWidth + horizontalPadding
+            let textRect = NSRect(x: textX, y: y + 3, width: bounds.width - textX - horizontalPadding, height: rowHeight)
+            (candidate as NSString).draw(in: textRect, withAttributes: textAttrs)
+        }
+    }
+}
+
+// MARK: - CandidatePanel
+
+class CandidatePanel: NSPanel {
+
+    private let listView = CandidateListView()
+
+    init() {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        level = .popUpMenu
+        hasShadow = true
+        isOpaque = false
+        backgroundColor = .clear
+
+        let content = NSView()
+        content.wantsLayer = true
+        content.layer?.cornerRadius = 4
+        content.layer?.masksToBounds = true
+        contentView = content
+
+        content.addSubview(listView)
+    }
+
+    func show(candidates: [String], selectedIndex: Int, cursorRect: NSRect) {
+        guard !candidates.isEmpty else {
+            hide()
+            return
+        }
+
+        listView.candidates = candidates
+        listView.selectedIndex = selectedIndex
+
+        let size = listView.desiredSize
+        listView.frame = NSRect(origin: .zero, size: size)
+
+        let panelSize = size
+        var origin = NSPoint(x: cursorRect.origin.x, y: cursorRect.origin.y - panelSize.height)
+
+        // Clamp to screen
+        if let screen = NSScreen.main ?? NSScreen.screens.first {
+            let screenFrame = screen.visibleFrame
+
+            // If below screen bottom, flip above cursor
+            if origin.y < screenFrame.minY {
+                origin.y = cursorRect.maxY
+            }
+            // Clamp right edge
+            if origin.x + panelSize.width > screenFrame.maxX {
+                origin.x = screenFrame.maxX - panelSize.width
+            }
+            // Clamp left edge
+            if origin.x < screenFrame.minX {
+                origin.x = screenFrame.minX
+            }
+        }
+
+        setContentSize(panelSize)
+        setFrameOrigin(origin)
+        listView.needsDisplay = true
+        orderFront(nil)
+    }
+
+    func hide() {
+        orderOut(nil)
+    }
+}

--- a/Sources/DictBridge.swift
+++ b/Sources/DictBridge.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+extension LeximeInputController {
+
+    func lookupCandidates(_ kana: String) -> [String] {
+        guard let dict = sharedDict else { return [] }
+        let list = lex_dict_lookup(dict, kana)
+        defer { lex_candidates_free(list) }
+
+        guard list.len > 0, let candidates = list.candidates else { return [] }
+        var results: [String] = []
+        for i in 0..<Int(list.len) {
+            if let surface = candidates[i].surface {
+                results.append(String(cString: surface))
+            }
+        }
+        return results
+    }
+
+    func predictCandidates(_ kana: String) -> [String] {
+        guard let dict = sharedDict, !kana.isEmpty else { return [] }
+        let list = lex_dict_predict(dict, kana, 5)
+        defer { lex_candidates_free(list) }
+
+        guard list.len > 0, let candidates = list.candidates else { return [] }
+        var seen = Set<String>()
+        var results: [String] = []
+        for i in 0..<Int(list.len) {
+            if let surface = candidates[i].surface {
+                let s = String(cString: surface)
+                if !s.isEmpty && seen.insert(s).inserted {
+                    results.append(s)
+                }
+            }
+        }
+        NSLog("Lexime: predict('%@') → [%@]", kana, results.joined(separator: ", "))
+        return results
+    }
+
+    func convertKana(_ kana: String) -> [ConversionSegment] {
+        guard let dict = sharedDict else { return [] }
+
+        let result = lex_convert(dict, sharedConn, kana)
+        defer { lex_conversion_free(result) }
+
+        guard result.len > 0, let segments = result.segments else { return [] }
+
+        var converted: [ConversionSegment] = []
+        for i in 0..<Int(result.len) {
+            let reading = String(cString: segments[i].reading)
+            let surface = String(cString: segments[i].surface)
+            let candidates = lookupCandidates(reading)
+            var orderedCandidates = [surface]
+            var seen: Set<String> = [surface]
+            for c in candidates where seen.insert(c).inserted {
+                orderedCandidates.append(c)
+            }
+            converted.append(ConversionSegment(
+                reading: reading,
+                surface: surface,
+                candidates: orderedCandidates,
+                selectedIndex: 0
+            ))
+        }
+        return converted
+    }
+}

--- a/Sources/InputState.swift
+++ b/Sources/InputState.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum InputState {
+    case idle
+    case composing
+    case converting
+}
+
+struct ConversionSegment {
+    let reading: String
+    var surface: String
+    var candidates: [String]
+    var selectedIndex: Int
+}

--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -1,0 +1,342 @@
+import Cocoa
+import InputMethodKit
+
+extension LeximeInputController {
+
+    // MARK: - Idle State
+
+    func handleIdle(keyCode: UInt16, text: String, client: IMKTextInput) -> Bool {
+        guard let scalar = text.unicodeScalars.first else { return false }
+
+        if let candidates = Self.punctuationCandidates[text] {
+            composePunctuation(candidates, client: client)
+            return true
+        }
+
+        if CharacterSet.lowercaseLetters.contains(scalar) ||
+           CharacterSet.uppercaseLetters.contains(scalar) {
+            state = .composing
+            let ch = text.lowercased()
+            appendAndConvert(ch, client: client)
+            return true
+        }
+
+        if text == "-" {
+            state = .composing
+            appendAndConvert("-", client: client)
+            return true
+        }
+
+        return false
+    }
+
+    // MARK: - Composing State
+
+    func handleComposing(keyCode: UInt16, text: String, client: IMKTextInput) -> Bool {
+        switch keyCode {
+        case 36: // Enter — commit selected prediction, or kana as-is
+            hideCandidatePanel()
+            if !predictionCandidates.isEmpty {
+                let idx = min(selectedPredictionIndex, predictionCandidates.count - 1)
+                commitText(predictionCandidates[idx], client: client)
+            } else {
+                flush()
+                commitComposed(client: client)
+            }
+            return true
+
+        case 125: // Down arrow — next prediction candidate
+            if !predictionCandidates.isEmpty {
+                selectedPredictionIndex = (selectedPredictionIndex + 1) % predictionCandidates.count
+                updateMarkedTextWithCandidate(predictionCandidates[selectedPredictionIndex], client: client)
+                showCandidatePanel(client: client)
+            }
+            return true
+
+        case 126: // Up arrow — previous prediction candidate
+            if !predictionCandidates.isEmpty {
+                selectedPredictionIndex = (selectedPredictionIndex - 1 + predictionCandidates.count) % predictionCandidates.count
+                updateMarkedTextWithCandidate(predictionCandidates[selectedPredictionIndex], client: client)
+                showCandidatePanel(client: client)
+            }
+            return true
+
+        case 48: // Tab — accept selected prediction candidate
+            if !predictionCandidates.isEmpty {
+                hideCandidatePanel()
+                let idx = min(selectedPredictionIndex, predictionCandidates.count - 1)
+                commitText(predictionCandidates[idx], client: client)
+                return true
+            }
+            return false
+
+        case 49: // Space — convert kana (or next candidate for punctuation)
+            if isPunctuationComposing && predictionCandidates.count > 1 {
+                selectedPredictionIndex = (selectedPredictionIndex + 1) % predictionCandidates.count
+                composedKana = predictionCandidates[selectedPredictionIndex]
+                updateMarkedTextWithCandidate(composedKana, client: client)
+                showCandidatePanel(client: client)
+                return true
+            }
+            if sharedDict == nil {
+                hideCandidatePanel()
+                flush()
+                commitComposed(client: client)
+                return true
+            }
+            hideCandidatePanel()
+            flush()
+            let segments = convertKana(composedKana)
+            if segments.isEmpty {
+                commitComposed(client: client)
+            } else if segments.count == 1 && segments[0].candidates.count <= 1 {
+                commitText(segments[0].surface, client: client)
+            } else {
+                originalKana = composedKana
+                conversionSegments = segments
+                activeSegmentIndex = 0
+                state = .converting
+                updateConvertingMarkedText(client: client)
+                showCandidatePanel(client: client)
+            }
+            return true
+
+        case 51: // Backspace
+            if !pendingRomaji.isEmpty {
+                pendingRomaji.removeLast()
+            } else if !composedKana.isEmpty {
+                composedKana.removeLast()
+            }
+            if composedKana.isEmpty && pendingRomaji.isEmpty {
+                hideCandidatePanel()
+                state = .idle
+                client.setMarkedText("",
+                                    selectionRange: NSRange(location: 0, length: 0),
+                                    replacementRange: NSRange(location: NSNotFound, length: 0))
+            } else {
+                updateMarkedText(client: client)
+                updatePredictions()
+            }
+            return true
+
+        case 53: // Escape — dismiss predictions, keep kana; second Esc cancels
+            if !predictionCandidates.isEmpty {
+                hideCandidatePanel()
+                predictionCandidates = []
+                selectedPredictionIndex = 0
+                updateMarkedText(client: client)
+            } else {
+                hideCandidatePanel()
+                resetState()
+                client.setMarkedText("",
+                                     selectionRange: NSRange(location: 0, length: 0),
+                                     replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+            return true
+
+        case 98: // F7 — katakana conversion
+            hideCandidatePanel()
+            flush()
+            let katakana = composedKana.applyingTransform(.hiraganaToKatakana, reverse: false)
+                ?? composedKana
+            commitText(katakana, client: client)
+            return true
+
+        default:
+            break
+        }
+
+        guard let scalar = text.unicodeScalars.first else { return false }
+
+        if let candidates = Self.punctuationCandidates[text] {
+            hideCandidatePanel()
+            flush()
+            commitComposed(client: client)
+            composePunctuation(candidates, client: client)
+            return true
+        }
+
+        if CharacterSet.lowercaseLetters.contains(scalar) ||
+           CharacterSet.uppercaseLetters.contains(scalar) {
+            let ch = text.lowercased()
+            appendAndConvert(ch, client: client)
+            return true
+        }
+
+        if text == "-" {
+            appendAndConvert("-", client: client)
+            return true
+        }
+
+        hideCandidatePanel()
+        flush()
+        commitComposed(client: client)
+        return false
+    }
+
+    // MARK: - Converting State (multi-segment)
+
+    func handleConverting(keyCode: UInt16, text: String, client: IMKTextInput) -> Bool {
+        switch keyCode {
+        case 36: // Enter — confirm all segments
+            hideCandidatePanel()
+            let fullText = conversionSegments.map { $0.surface }.joined()
+            commitText(fullText, client: client)
+            return true
+
+        case 49: // Space — next candidate for active segment
+            if activeSegmentIndex < conversionSegments.count {
+                let seg = conversionSegments[activeSegmentIndex]
+                if !seg.candidates.isEmpty {
+                    let newIdx = (seg.selectedIndex + 1) % seg.candidates.count
+                    conversionSegments[activeSegmentIndex].selectedIndex = newIdx
+                    conversionSegments[activeSegmentIndex].surface = seg.candidates[newIdx]
+                    updateConvertingMarkedText(client: client)
+                    showCandidatePanel(client: client)
+                }
+            }
+            return true
+
+        case 51, 53: // Backspace or Escape — back to composing with original kana
+            hideCandidatePanel()
+            composedKana = originalKana
+            conversionSegments = []
+            activeSegmentIndex = 0
+            state = .composing
+            updateMarkedText(client: client)
+            return true
+
+        case 123: // Left arrow — previous segment
+            if activeSegmentIndex > 0 {
+                activeSegmentIndex -= 1
+                updateConvertingMarkedText(client: client)
+                showCandidatePanel(client: client)
+            }
+            return true
+
+        case 124: // Right arrow — next segment
+            if activeSegmentIndex < conversionSegments.count - 1 {
+                activeSegmentIndex += 1
+                updateConvertingMarkedText(client: client)
+                showCandidatePanel(client: client)
+            }
+            return true
+
+        case 126: // Up arrow — previous candidate
+            if activeSegmentIndex < conversionSegments.count {
+                let seg = conversionSegments[activeSegmentIndex]
+                if !seg.candidates.isEmpty {
+                    let newIdx = (seg.selectedIndex - 1 + seg.candidates.count) % seg.candidates.count
+                    conversionSegments[activeSegmentIndex].selectedIndex = newIdx
+                    conversionSegments[activeSegmentIndex].surface = seg.candidates[newIdx]
+                    updateConvertingMarkedText(client: client)
+                    showCandidatePanel(client: client)
+                }
+            }
+            return true
+
+        case 125: // Down arrow — next candidate
+            if activeSegmentIndex < conversionSegments.count {
+                let seg = conversionSegments[activeSegmentIndex]
+                if !seg.candidates.isEmpty {
+                    let newIdx = (seg.selectedIndex + 1) % seg.candidates.count
+                    conversionSegments[activeSegmentIndex].selectedIndex = newIdx
+                    conversionSegments[activeSegmentIndex].surface = seg.candidates[newIdx]
+                    updateConvertingMarkedText(client: client)
+                    showCandidatePanel(client: client)
+                }
+            }
+            return true
+
+        default:
+            break
+        }
+
+        guard let scalar = text.unicodeScalars.first else { return false }
+
+        // U3: Number keys 1-9 for direct candidate selection
+        if let num = text.first?.wholeNumberValue, num >= 1, num <= 9 {
+            let idx = num - 1
+            if activeSegmentIndex < conversionSegments.count {
+                let seg = conversionSegments[activeSegmentIndex]
+                if idx < seg.candidates.count {
+                    conversionSegments[activeSegmentIndex].selectedIndex = idx
+                    conversionSegments[activeSegmentIndex].surface = seg.candidates[idx]
+                    updateConvertingMarkedText(client: client)
+                    showCandidatePanel(client: client)
+                }
+            }
+            return true
+        }
+
+        // Alphabetic: confirm all segments and start new input
+        if CharacterSet.lowercaseLetters.contains(scalar) ||
+           CharacterSet.uppercaseLetters.contains(scalar) {
+            hideCandidatePanel()
+            let fullText = conversionSegments.map { $0.surface }.joined()
+            commitText(fullText, client: client)
+            state = .composing
+            let ch = text.lowercased()
+            appendAndConvert(ch, client: client)
+            return true
+        }
+
+        // Punctuation: confirm all segments, then insert
+        if let candidates = Self.punctuationCandidates[text] {
+            hideCandidatePanel()
+            let fullText = conversionSegments.map { $0.surface }.joined()
+            commitText(fullText, client: client)
+            composePunctuation(candidates, client: client)
+            return true
+        }
+
+        // Other: confirm and pass through
+        hideCandidatePanel()
+        let fullText = conversionSegments.map { $0.surface }.joined()
+        commitText(fullText, client: client)
+        return false
+    }
+
+    // MARK: - Segment Boundary Adjustment (U2)
+
+    func handleSegmentBoundaryAdjust(shrink: Bool, client: IMKTextInput) -> Bool {
+        guard activeSegmentIndex < conversionSegments.count else { return true }
+        let activeReading = conversionSegments[activeSegmentIndex].reading
+
+        if shrink {
+            guard activeReading.count > 1 else { return true }
+            let newReading = String(activeReading.dropLast())
+            let movedChar = String(activeReading.suffix(1))
+            var nextReading = movedChar
+            if activeSegmentIndex + 1 < conversionSegments.count {
+                nextReading += conversionSegments[activeSegmentIndex + 1].reading
+            }
+            let newActive = convertKana(newReading)
+            let newNext = convertKana(nextReading)
+            rebuildSegments(activeReplace: newActive, nextReplace: newNext)
+        } else {
+            guard activeSegmentIndex + 1 < conversionSegments.count else { return true }
+            let nextReading = conversionSegments[activeSegmentIndex + 1].reading
+            guard !nextReading.isEmpty else { return true }
+            let expandedReading = activeReading + String(nextReading.prefix(1))
+            let remainderReading = String(nextReading.dropFirst())
+            let newActive = convertKana(expandedReading)
+            let newNext = remainderReading.isEmpty ? [] : convertKana(remainderReading)
+            rebuildSegments(activeReplace: newActive, nextReplace: newNext)
+        }
+        updateConvertingMarkedText(client: client)
+        showCandidatePanel(client: client)
+        return true
+    }
+
+    private func rebuildSegments(activeReplace: [ConversionSegment], nextReplace: [ConversionSegment]) {
+        var newSegments = Array(conversionSegments[..<activeSegmentIndex])
+        newSegments += activeReplace
+        newSegments += nextReplace
+        let skipCount = activeSegmentIndex + (activeSegmentIndex + 1 < conversionSegments.count ? 2 : 1)
+        if skipCount < conversionSegments.count {
+            newSegments += Array(conversionSegments[skipCount...])
+        }
+        conversionSegments = newSegments
+    }
+}

--- a/Sources/MarkedTextManager.swift
+++ b/Sources/MarkedTextManager.swift
@@ -1,0 +1,47 @@
+import Cocoa
+import InputMethodKit
+
+extension LeximeInputController {
+
+    func updateMarkedText(client: IMKTextInput) {
+        let display = composedKana + pendingRomaji
+        let len = display.utf16.count
+        client.setMarkedText(display,
+                             selectionRange: NSRange(location: len, length: 0),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    func updateMarkedTextWithCandidate(_ candidate: String, client: IMKTextInput) {
+        let len = candidate.utf16.count
+        let attrs: [NSAttributedString.Key: Any] = [
+            .markedClauseSegment: 0
+        ]
+        let attrStr = NSAttributedString(string: candidate, attributes: attrs)
+        client.setMarkedText(attrStr,
+                             selectionRange: NSRange(location: len, length: 0),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    func updateConvertingMarkedText(client: IMKTextInput) {
+        let attributed = NSMutableAttributedString()
+        var cursorOffset = 0
+
+        for (i, seg) in conversionSegments.enumerated() {
+            let attrs: [NSAttributedString.Key: Any] = [
+                .markedClauseSegment: i
+            ]
+            attributed.append(NSAttributedString(string: seg.surface, attributes: attrs))
+
+            if i < activeSegmentIndex {
+                cursorOffset += seg.surface.utf16.count
+            }
+        }
+
+        if activeSegmentIndex < conversionSegments.count {
+            let activeLen = conversionSegments[activeSegmentIndex].surface.utf16.count
+            client.setMarkedText(attributed,
+                                 selectionRange: NSRange(location: cursorOffset, length: activeLen),
+                                 replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+    }
+}

--- a/Sources/RomajiConverter.swift
+++ b/Sources/RomajiConverter.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+struct RomajiConvertResult {
+    var composedKana: String
+    var pendingRomaji: String
+}
+
+private let vowels: Set<Character> = ["a", "i", "u", "e", "o"]
+
+func drainPendingRomaji(
+    composedKana: String,
+    pendingRomaji: String,
+    trie: RomajiTrie,
+    force: Bool
+) -> RomajiConvertResult {
+    var composedKana = composedKana
+    var pendingRomaji = pendingRomaji
+
+    var changed = true
+    while !pendingRomaji.isEmpty && changed {
+        changed = false
+        let result = trie.lookup(pendingRomaji)
+
+        switch result {
+        case .exact(let kana):
+            composedKana += kana
+            pendingRomaji = ""
+            changed = true
+
+        case .exactAndPrefix(let kana):
+            if force {
+                composedKana += kana
+                pendingRomaji = ""
+                changed = true
+            }
+
+        case .prefix:
+            if !force { break }
+            fallthrough
+
+        case .none:
+            var found = false
+            for len in stride(from: pendingRomaji.count - 1, through: 1, by: -1) {
+                let subEnd = pendingRomaji.index(pendingRomaji.startIndex, offsetBy: len)
+                let sub = String(pendingRomaji[..<subEnd])
+                let subResult = trie.lookup(sub)
+
+                switch subResult {
+                case .exact(let kana), .exactAndPrefix(let kana):
+                    composedKana += kana
+                    pendingRomaji = String(pendingRomaji[subEnd...])
+                    found = true
+                    changed = true
+                default:
+                    break
+                }
+                if found { break }
+            }
+
+            if !found {
+                if pendingRomaji.count >= 2 {
+                    let chars = Array(pendingRomaji)
+                    let first = chars[0]
+                    let second = chars[1]
+                    if first == second && first != "n" && !vowels.contains(first) {
+                        composedKana += "っ"
+                        pendingRomaji = String(pendingRomaji.dropFirst())
+                        changed = true
+                    } else if first == "n" && !vowels.contains(second) &&
+                              second != "n" && second != "y" {
+                        composedKana += "ん"
+                        pendingRomaji = String(pendingRomaji.dropFirst())
+                        changed = true
+                    } else if force {
+                        composedKana += String(pendingRomaji.removeFirst())
+                        changed = true
+                    } else {
+                        // R1 fix: preserve unrecognized characters in composedKana
+                        // instead of silently discarding them
+                        composedKana += String(pendingRomaji.first!)
+                        pendingRomaji = String(pendingRomaji.dropFirst())
+                        changed = true
+                    }
+                } else {
+                    // Single character remaining
+                    if pendingRomaji == "n" {
+                        if force {
+                            composedKana += "ん"
+                        }
+                        // When not forced, "n" stays as pending (could be prefix of "na", "ni", etc.)
+                    } else {
+                        // R1 fix: preserve unrecognized single chars in composedKana
+                        composedKana += pendingRomaji
+                    }
+                    pendingRomaji = ""
+                    changed = true
+                }
+            }
+        }
+    }
+
+    return RomajiConvertResult(composedKana: composedKana, pendingRomaji: pendingRomaji)
+}

--- a/Tests/TestRomajiConverter.swift
+++ b/Tests/TestRomajiConverter.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+func testRomajiConverter() {
+    print("--- RomajiConverter Tests ---")
+    let trie = RomajiTrie.shared
+
+    // T1: Basic "ka" → か
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "ka", trie: trie, force: false)
+        assertEqual(r.composedKana, "か", "ka → か")
+        assertEqual(r.pendingRomaji, "", "ka pending empty")
+    }
+
+    // T1: Sokuon "kk" → っ + pending k
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "kk", trie: trie, force: false)
+        assertEqual(r.composedKana, "っ", "kk → っ")
+        assertEqual(r.pendingRomaji, "k", "kk pending k")
+    }
+
+    // T1: Hatsuon "nk" → ん + pending k
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "nk", trie: trie, force: false)
+        assertEqual(r.composedKana, "ん", "nk → ん")
+        assertEqual(r.pendingRomaji, "k", "nk pending k")
+    }
+
+    // T1: "n" force=true → ん
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "n", trie: trie, force: true)
+        assertEqual(r.composedKana, "ん", "n force → ん")
+        assertEqual(r.pendingRomaji, "", "n force pending empty")
+    }
+
+    // T1: "n" force=false → pending n
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "n", trie: trie, force: false)
+        assertEqual(r.composedKana, "", "n no-force composedKana empty")
+        assertEqual(r.pendingRomaji, "n", "n no-force pending n")
+    }
+
+    // T1: Consecutive conversion "kakiku"
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "kakiku", trie: trie, force: false)
+        assertEqual(r.composedKana, "かきく", "kakiku → かきく")
+        assertEqual(r.pendingRomaji, "", "kakiku pending empty")
+    }
+
+    // T1: R1 fix — unrecognized character "q" preserved in composedKana
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "q", trie: trie, force: false)
+        assertEqual(r.composedKana, "q", "q → composedKana q (R1 fix)")
+        assertEqual(r.pendingRomaji, "", "q pending empty")
+    }
+
+    // T1: 3-char match "shi" → し
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "shi", trie: trie, force: false)
+        assertEqual(r.composedKana, "し", "shi → し")
+        assertEqual(r.pendingRomaji, "", "shi pending empty")
+    }
+
+    // T1: Existing composedKana is preserved
+    do {
+        let r = drainPendingRomaji(composedKana: "あ", pendingRomaji: "ka", trie: trie, force: false)
+        assertEqual(r.composedKana, "あか", "あ + ka → あか")
+    }
+
+    // T1: "sha" → しゃ (拗音)
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "sha", trie: trie, force: false)
+        assertEqual(r.composedKana, "しゃ", "sha → しゃ")
+        assertEqual(r.pendingRomaji, "", "sha pending empty")
+    }
+
+    // T1: Mixed "kyouhaii" — partial conversion
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "kyouha", trie: trie, force: false)
+        assertEqual(r.composedKana, "きょうは", "kyouha → きょうは")
+        assertEqual(r.pendingRomaji, "", "kyouha pending empty")
+    }
+
+    // T1: Sokuon with subsequent kana "kka" → っか
+    do {
+        let r = drainPendingRomaji(composedKana: "", pendingRomaji: "kka", trie: trie, force: false)
+        assertEqual(r.composedKana, "っか", "kka → っか")
+        assertEqual(r.pendingRomaji, "", "kka pending empty")
+    }
+}

--- a/Tests/TestRomajiTrie.swift
+++ b/Tests/TestRomajiTrie.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+func testRomajiTrie() {
+    print("--- RomajiTrie Tests ---")
+    let trie = RomajiTrie.shared
+
+    // T2: Vowel exact match
+    if case .exact(let kana) = trie.lookup("a") {
+        assertEqual(kana, "あ", "vowel 'a'")
+    } else {
+        testsFailed += 1
+        print("FAIL (vowel 'a'): expected .exact")
+    }
+
+    // T2: Prefix match
+    if case .prefix = trie.lookup("k") {
+        testsPassed += 1
+    } else {
+        testsFailed += 1
+        print("FAIL (prefix 'k'): expected .prefix")
+    }
+
+    // T2: No match
+    if case .none = trie.lookup("q") {
+        testsPassed += 1
+    } else {
+        testsFailed += 1
+        print("FAIL (none 'q'): expected .none")
+    }
+
+    // T2: Symbol
+    if case .exact(let kana) = trie.lookup("-") {
+        assertEqual(kana, "ー", "symbol '-'")
+    } else {
+        testsFailed += 1
+        print("FAIL (symbol '-'): expected .exact")
+    }
+
+    // T2: 拗音
+    if case .exact(let kana) = trie.lookup("sha") {
+        assertEqual(kana, "しゃ", "youon 'sha'")
+    } else {
+        testsFailed += 1
+        print("FAIL (youon 'sha'): expected .exact")
+    }
+
+    // T2: exactAndPrefix — "chi" matches ち but is also prefix for "cho" etc.
+    switch trie.lookup("chi") {
+    case .exact(let kana):
+        assertEqual(kana, "ち", "chi exact")
+    case .exactAndPrefix(let kana):
+        assertEqual(kana, "ち", "chi exactAndPrefix")
+    default:
+        testsFailed += 1
+        print("FAIL (chi): expected .exact or .exactAndPrefix")
+    }
+
+    // T2: "ka" exact match
+    if case .exact(let kana) = trie.lookup("ka") {
+        assertEqual(kana, "か", "ka")
+    } else {
+        testsFailed += 1
+        print("FAIL (ka): expected .exact")
+    }
+
+    // T2: "sh" should be prefix
+    if case .prefix = trie.lookup("sh") {
+        testsPassed += 1
+    } else {
+        testsFailed += 1
+        print("FAIL (prefix 'sh'): expected .prefix")
+    }
+
+    // T2: "nn" exact match for ん
+    if case .exact(let kana) = trie.lookup("nn") {
+        assertEqual(kana, "ん", "nn")
+    } else {
+        testsFailed += 1
+        print("FAIL (nn): expected .exact")
+    }
+}

--- a/Tests/TestRunner.swift
+++ b/Tests/TestRunner.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+var testsPassed = 0
+var testsFailed = 0
+
+func assertEqual<T: Equatable>(_ actual: T, _ expected: T,
+                                _ message: String = "",
+                                file: String = #file, line: Int = #line) {
+    if actual == expected {
+        testsPassed += 1
+    } else {
+        testsFailed += 1
+        let label = message.isEmpty ? "" : " (\(message))"
+        print("FAIL\(label): expected \(expected), got \(actual) [\(file):\(line)]")
+    }
+}
+
+func assertTrue(_ condition: Bool,
+                _ message: String = "",
+                file: String = #file, line: Int = #line) {
+    if condition {
+        testsPassed += 1
+    } else {
+        testsFailed += 1
+        let label = message.isEmpty ? "" : " (\(message))"
+        print("FAIL\(label): condition was false [\(file):\(line)]")
+    }
+}
+
+@main
+struct TestMain {
+    static func main() {
+        testRomajiTrie()
+        testRomajiConverter()
+
+        print("\nResults: \(testsPassed) passed, \(testsFailed) failed")
+        exit(testsFailed > 0 ? 1 : 0)
+    }
+}

--- a/engine/include/engine.h
+++ b/engine/include/engine.h
@@ -28,4 +28,31 @@ LexCandidateList lex_dict_lookup(const LexDict *dict, const char *reading);
 LexCandidateList lex_dict_predict(const LexDict *dict, const char *prefix, uint32_t max_results);
 void lex_candidates_free(LexCandidateList list);
 
+/* Connection matrix API */
+
+typedef struct LexConnectionMatrix LexConnectionMatrix;
+
+LexConnectionMatrix *lex_conn_open(const char *path);
+void lex_conn_close(LexConnectionMatrix *conn);
+
+/* Conversion API (lattice + Viterbi) */
+
+typedef struct {
+    const char *reading;
+    const char *surface;
+} LexSegment;
+
+typedef struct {
+    const LexSegment *segments;
+    uint32_t len;
+    void *_owned;
+} LexConversionResult;
+
+LexConversionResult lex_convert(
+    const LexDict *dict,
+    const LexConnectionMatrix *conn,
+    const char *kana
+);
+void lex_conversion_free(LexConversionResult result);
+
 #endif

--- a/engine/src/converter/cost.rs
+++ b/engine/src/converter/cost.rs
@@ -1,0 +1,46 @@
+use crate::dict::connection::ConnectionMatrix;
+
+use super::lattice::LatticeNode;
+
+/// Trait for scoring lattice paths during Viterbi search.
+pub trait CostFunction: Send + Sync {
+    fn word_cost(&self, node: &LatticeNode) -> i64;
+    fn transition_cost(&self, prev: &LatticeNode, next: &LatticeNode) -> i64;
+    fn bos_cost(&self, node: &LatticeNode) -> i64;
+    fn eos_cost(&self, node: &LatticeNode) -> i64;
+}
+
+/// Default cost function using word costs and optional connection matrix.
+pub struct DefaultCostFunction<'a> {
+    conn: Option<&'a ConnectionMatrix>,
+}
+
+impl<'a> DefaultCostFunction<'a> {
+    pub fn new(conn: Option<&'a ConnectionMatrix>) -> Self {
+        Self { conn }
+    }
+}
+
+impl CostFunction for DefaultCostFunction<'_> {
+    fn word_cost(&self, node: &LatticeNode) -> i64 {
+        node.cost as i64
+    }
+
+    fn transition_cost(&self, prev: &LatticeNode, next: &LatticeNode) -> i64 {
+        self.conn
+            .map(|c| c.cost(prev.right_id, next.left_id) as i64)
+            .unwrap_or(0)
+    }
+
+    fn bos_cost(&self, node: &LatticeNode) -> i64 {
+        self.conn
+            .map(|c| c.cost(0, node.left_id) as i64)
+            .unwrap_or(0)
+    }
+
+    fn eos_cost(&self, node: &LatticeNode) -> i64 {
+        self.conn
+            .map(|c| c.cost(node.right_id, 0) as i64)
+            .unwrap_or(0)
+    }
+}

--- a/engine/src/converter/lattice.rs
+++ b/engine/src/converter/lattice.rs
@@ -1,0 +1,281 @@
+use crate::dict::Dictionary;
+
+/// A node in the conversion lattice.
+#[derive(Debug, Clone)]
+pub struct LatticeNode {
+    /// Start position (char index, inclusive)
+    pub start: usize,
+    /// End position (char index, exclusive)
+    pub end: usize,
+    /// Kana substring (reading)
+    pub reading: String,
+    /// Surface form (kanji, etc.)
+    pub surface: String,
+    /// Word cost (lower = more preferred)
+    pub cost: i16,
+    /// Left boundary morpheme ID
+    pub left_id: u16,
+    /// Right boundary morpheme ID
+    pub right_id: u16,
+}
+
+/// The lattice: all possible segmentations of a kana string.
+pub struct Lattice {
+    /// The original kana input
+    pub input: String,
+    /// All nodes in the lattice
+    pub nodes: Vec<LatticeNode>,
+    /// nodes_by_end[i] = indices of nodes that end at position i
+    pub nodes_by_end: Vec<Vec<usize>>,
+    /// nodes_by_start[i] = indices of nodes that start at position i
+    pub nodes_by_start: Vec<Vec<usize>>,
+    /// Number of characters in input
+    pub char_count: usize,
+}
+
+const UNKNOWN_WORD_COST: i16 = 10000;
+
+/// Build a lattice from a kana string using dictionary lookups.
+///
+/// Uses `common_prefix_search` for efficient trie traversal: a single trie walk
+/// per starting position finds all matching prefixes, instead of O(n) individual
+/// lookups per position.
+/// Adds an unknown-word fallback node (1-char, high cost) to guarantee connectivity.
+pub fn build_lattice(dict: &dyn Dictionary, kana: &str) -> Lattice {
+    let chars: Vec<char> = kana.chars().collect();
+    let char_count = chars.len();
+    let mut nodes = Vec::new();
+    // nodes_by_end has char_count + 1 slots (position 0 through char_count)
+    let mut nodes_by_end: Vec<Vec<usize>> = vec![Vec::new(); char_count + 1];
+    let mut nodes_by_start: Vec<Vec<usize>> = vec![Vec::new(); char_count];
+
+    for start in 0..char_count {
+        let mut has_single_char_match = false;
+
+        let suffix: String = chars[start..].iter().collect();
+        let matches = dict.common_prefix_search(&suffix);
+
+        for result in &matches {
+            let reading_char_count = result.reading.chars().count();
+            let end = start + reading_char_count;
+            for entry in &result.entries {
+                let idx = nodes.len();
+                nodes.push(LatticeNode {
+                    start,
+                    end,
+                    reading: result.reading.clone(),
+                    surface: entry.surface.clone(),
+                    cost: entry.cost,
+                    left_id: entry.left_id,
+                    right_id: entry.right_id,
+                });
+                nodes_by_end[end].push(idx);
+                nodes_by_start[start].push(idx);
+                if reading_char_count == 1 {
+                    has_single_char_match = true;
+                }
+            }
+        }
+
+        // Add a 1-char fallback node when no dictionary entry covers exactly
+        // this single character. This guarantees connectivity: even positions
+        // spanned only by longer matches remain reachable via the fallback.
+        if !has_single_char_match {
+            let ch: String = chars[start..start + 1].iter().collect();
+            let idx = nodes.len();
+            nodes.push(LatticeNode {
+                start,
+                end: start + 1,
+                reading: ch.clone(),
+                surface: ch,
+                cost: UNKNOWN_WORD_COST,
+                left_id: 0,
+                right_id: 0,
+            });
+            nodes_by_end[start + 1].push(idx);
+            nodes_by_start[start].push(idx);
+        }
+    }
+
+    Lattice {
+        input: kana.to_string(),
+        nodes,
+        nodes_by_end,
+        nodes_by_start,
+        char_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dict::TrieDictionary;
+
+    fn sample_dict() -> TrieDictionary {
+        use crate::dict::DictEntry;
+        let entries = vec![
+            (
+                "きょう".to_string(),
+                vec![
+                    DictEntry {
+                        surface: "今日".to_string(),
+                        cost: 3000,
+                        left_id: 100,
+                        right_id: 100,
+                    },
+                    DictEntry {
+                        surface: "京".to_string(),
+                        cost: 5000,
+                        left_id: 100,
+                        right_id: 100,
+                    },
+                ],
+            ),
+            (
+                "は".to_string(),
+                vec![DictEntry {
+                    surface: "は".to_string(),
+                    cost: 2000,
+                    left_id: 200,
+                    right_id: 200,
+                }],
+            ),
+            (
+                "いい".to_string(),
+                vec![DictEntry {
+                    surface: "良い".to_string(),
+                    cost: 3500,
+                    left_id: 300,
+                    right_id: 300,
+                }],
+            ),
+            (
+                "てんき".to_string(),
+                vec![DictEntry {
+                    surface: "天気".to_string(),
+                    cost: 4000,
+                    left_id: 400,
+                    right_id: 400,
+                }],
+            ),
+            (
+                "き".to_string(),
+                vec![DictEntry {
+                    surface: "木".to_string(),
+                    cost: 4500,
+                    left_id: 500,
+                    right_id: 500,
+                }],
+            ),
+            (
+                "い".to_string(),
+                vec![DictEntry {
+                    surface: "胃".to_string(),
+                    cost: 6000,
+                    left_id: 600,
+                    right_id: 600,
+                }],
+            ),
+            (
+                "てん".to_string(),
+                vec![DictEntry {
+                    surface: "天".to_string(),
+                    cost: 5000,
+                    left_id: 700,
+                    right_id: 700,
+                }],
+            ),
+        ];
+        TrieDictionary::from_entries(entries)
+    }
+
+    #[test]
+    fn test_build_lattice_basic() {
+        let dict = sample_dict();
+        let lattice = build_lattice(&dict, "きょうは");
+
+        // Should have nodes for "きょう" (2 entries), "は" (1 entry), and "き" (1 entry)
+        assert!(!lattice.nodes.is_empty());
+        assert_eq!(lattice.char_count, 4); // き, ょ, う, は
+
+        // Check that "きょう" nodes exist
+        let kyou_nodes: Vec<_> = lattice
+            .nodes
+            .iter()
+            .filter(|n| n.reading == "きょう")
+            .collect();
+        assert_eq!(kyou_nodes.len(), 2);
+        assert!(kyou_nodes.iter().any(|n| n.surface == "今日"));
+        assert!(kyou_nodes.iter().any(|n| n.surface == "京"));
+    }
+
+    #[test]
+    fn test_unknown_word_fallback() {
+        let dict = sample_dict();
+        // "zzz" is not in dictionary — each char gets an unknown node
+        let lattice = build_lattice(&dict, "ぬ");
+
+        assert!(!lattice.nodes.is_empty());
+        let unknown = &lattice.nodes[0];
+        assert_eq!(unknown.reading, "ぬ");
+        assert_eq!(unknown.surface, "ぬ");
+        assert_eq!(unknown.cost, 10000);
+    }
+
+    #[test]
+    fn test_lattice_connectivity() {
+        let dict = sample_dict();
+        let lattice = build_lattice(&dict, "きょうはいいてんき");
+
+        // Every position should be reachable: nodes_by_end[i] should be non-empty
+        // for all i in 1..=char_count
+        for pos in 1..=lattice.char_count {
+            assert!(
+                !lattice.nodes_by_end[pos].is_empty(),
+                "no nodes end at position {pos}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_nodes_by_start_end_consistency() {
+        let dict = sample_dict();
+        let lattice = build_lattice(&dict, "きょうはいいてんき");
+
+        // All nodes are correctly indexed in nodes_by_start and nodes_by_end
+        for (idx, node) in lattice.nodes.iter().enumerate() {
+            assert!(
+                lattice.nodes_by_start[node.start].contains(&idx),
+                "node {idx} not in nodes_by_start[{}]",
+                node.start
+            );
+            assert!(
+                lattice.nodes_by_end[node.end].contains(&idx),
+                "node {idx} not in nodes_by_end[{}]",
+                node.end
+            );
+        }
+
+        // Reverse: indices in nodes_by_start point to nodes with correct start
+        for (pos, indices) in lattice.nodes_by_start.iter().enumerate() {
+            for &idx in indices {
+                assert_eq!(
+                    lattice.nodes[idx].start, pos,
+                    "nodes_by_start[{pos}] contains node {idx} with start={}",
+                    lattice.nodes[idx].start
+                );
+            }
+        }
+
+        // Reverse: indices in nodes_by_end point to nodes with correct end
+        for (pos, indices) in lattice.nodes_by_end.iter().enumerate() {
+            for &idx in indices {
+                assert_eq!(
+                    lattice.nodes[idx].end, pos,
+                    "nodes_by_end[{pos}] contains node {idx} with end={}",
+                    lattice.nodes[idx].end
+                );
+            }
+        }
+    }
+}

--- a/engine/src/converter/mod.rs
+++ b/engine/src/converter/mod.rs
@@ -1,0 +1,7 @@
+pub mod cost;
+mod lattice;
+mod viterbi;
+
+pub use cost::CostFunction;
+pub use lattice::{Lattice, LatticeNode};
+pub use viterbi::{convert, convert_with_cost, ConvertedSegment};

--- a/engine/src/converter/viterbi.rs
+++ b/engine/src/converter/viterbi.rs
@@ -1,0 +1,385 @@
+use crate::dict::connection::ConnectionMatrix;
+use crate::dict::Dictionary;
+
+use super::cost::{CostFunction, DefaultCostFunction};
+use super::lattice::{build_lattice, Lattice};
+
+/// A segment in the conversion result.
+#[derive(Debug, Clone)]
+pub struct ConvertedSegment {
+    /// The kana reading of this segment
+    pub reading: String,
+    /// The converted surface form (kanji, etc.)
+    pub surface: String,
+}
+
+/// Convert a kana string to the best segmentation using Viterbi algorithm.
+///
+/// If `conn` is provided, uses connection costs for scoring transitions.
+/// Otherwise, falls back to unigram-only scoring (sum of word costs).
+pub fn convert(
+    dict: &dyn Dictionary,
+    conn: Option<&ConnectionMatrix>,
+    kana: &str,
+) -> Vec<ConvertedSegment> {
+    let cost_fn = DefaultCostFunction::new(conn);
+    convert_with_cost(dict, &cost_fn, kana)
+}
+
+/// Convert a kana string using a custom cost function.
+pub fn convert_with_cost(
+    dict: &dyn Dictionary,
+    cost_fn: &dyn CostFunction,
+    kana: &str,
+) -> Vec<ConvertedSegment> {
+    if kana.is_empty() {
+        return Vec::new();
+    }
+
+    let lattice = build_lattice(dict, kana);
+    viterbi(&lattice, cost_fn)
+}
+
+/// Run the Viterbi algorithm on a lattice to find the minimum-cost path.
+fn viterbi(lattice: &Lattice, cost_fn: &dyn CostFunction) -> Vec<ConvertedSegment> {
+    let n = lattice.char_count;
+    if n == 0 {
+        return Vec::new();
+    }
+
+    // best_cost[node_idx] = minimum total cost to reach this node
+    // backpointer[node_idx] = previous node index on the best path (None for start nodes)
+    let num_nodes = lattice.nodes.len();
+    let mut best_cost: Vec<i64> = vec![i64::MAX; num_nodes];
+    let mut backpointer: Vec<Option<usize>> = vec![None; num_nodes];
+
+    // Initialize nodes starting at position 0 (BOS transition)
+    for &idx in &lattice.nodes_by_start[0] {
+        let node = &lattice.nodes[idx];
+        best_cost[idx] = cost_fn.word_cost(node) + cost_fn.bos_cost(node);
+        backpointer[idx] = None;
+    }
+
+    // Forward pass: for each position, update costs of nodes starting there
+    for pos in 1..n {
+        // For each node ending at `pos`
+        for &prev_idx in &lattice.nodes_by_end[pos] {
+            if best_cost[prev_idx] == i64::MAX {
+                continue; // unreachable node
+            }
+            let prev_node = &lattice.nodes[prev_idx];
+
+            // For each node starting at `pos` (O(E) via index)
+            for &next_idx in &lattice.nodes_by_start[pos] {
+                let next_node = &lattice.nodes[next_idx];
+
+                let total = best_cost[prev_idx]
+                    + cost_fn.transition_cost(prev_node, next_node)
+                    + cost_fn.word_cost(next_node);
+
+                if total < best_cost[next_idx] {
+                    best_cost[next_idx] = total;
+                    backpointer[next_idx] = Some(prev_idx);
+                }
+            }
+        }
+    }
+
+    // Find the best node ending at position n (EOS)
+    let mut best_end_idx: Option<usize> = None;
+    let mut best_end_cost = i64::MAX;
+
+    for &node_idx in &lattice.nodes_by_end[n] {
+        if best_cost[node_idx] == i64::MAX {
+            continue;
+        }
+        let node = &lattice.nodes[node_idx];
+        let total = best_cost[node_idx] + cost_fn.eos_cost(node);
+
+        if total < best_end_cost {
+            best_end_cost = total;
+            best_end_idx = Some(node_idx);
+        }
+    }
+
+    // Backtrace
+    let mut path = Vec::new();
+    let mut current = best_end_idx;
+    while let Some(idx) = current {
+        path.push(idx);
+        current = backpointer[idx];
+    }
+    path.reverse();
+
+    path.iter()
+        .map(|&idx| {
+            let node = &lattice.nodes[idx];
+            ConvertedSegment {
+                reading: node.reading.clone(),
+                surface: node.surface.clone(),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dict::connection::ConnectionMatrix;
+    use crate::dict::{DictEntry, TrieDictionary};
+
+    fn test_dict() -> TrieDictionary {
+        let entries = vec![
+            (
+                "きょう".to_string(),
+                vec![
+                    DictEntry {
+                        surface: "今日".to_string(),
+                        cost: 3000,
+                        left_id: 100,
+                        right_id: 100,
+                    },
+                    DictEntry {
+                        surface: "京".to_string(),
+                        cost: 5000,
+                        left_id: 101,
+                        right_id: 101,
+                    },
+                ],
+            ),
+            (
+                "は".to_string(),
+                vec![DictEntry {
+                    surface: "は".to_string(),
+                    cost: 2000,
+                    left_id: 200,
+                    right_id: 200,
+                }],
+            ),
+            (
+                "いい".to_string(),
+                vec![DictEntry {
+                    surface: "良い".to_string(),
+                    cost: 3500,
+                    left_id: 300,
+                    right_id: 300,
+                }],
+            ),
+            (
+                "てんき".to_string(),
+                vec![DictEntry {
+                    surface: "天気".to_string(),
+                    cost: 4000,
+                    left_id: 400,
+                    right_id: 400,
+                }],
+            ),
+            (
+                "き".to_string(),
+                vec![DictEntry {
+                    surface: "木".to_string(),
+                    cost: 4500,
+                    left_id: 500,
+                    right_id: 500,
+                }],
+            ),
+            (
+                "い".to_string(),
+                vec![DictEntry {
+                    surface: "胃".to_string(),
+                    cost: 6000,
+                    left_id: 600,
+                    right_id: 600,
+                }],
+            ),
+            (
+                "てん".to_string(),
+                vec![DictEntry {
+                    surface: "天".to_string(),
+                    cost: 5000,
+                    left_id: 700,
+                    right_id: 700,
+                }],
+            ),
+            (
+                "です".to_string(),
+                vec![DictEntry {
+                    surface: "です".to_string(),
+                    cost: 2500,
+                    left_id: 800,
+                    right_id: 800,
+                }],
+            ),
+            (
+                "ね".to_string(),
+                vec![DictEntry {
+                    surface: "ね".to_string(),
+                    cost: 2000,
+                    left_id: 900,
+                    right_id: 900,
+                }],
+            ),
+            (
+                "わたし".to_string(),
+                vec![DictEntry {
+                    surface: "私".to_string(),
+                    cost: 3000,
+                    left_id: 1000,
+                    right_id: 1000,
+                }],
+            ),
+            (
+                "がくせい".to_string(),
+                vec![DictEntry {
+                    surface: "学生".to_string(),
+                    cost: 4000,
+                    left_id: 1100,
+                    right_id: 1100,
+                }],
+            ),
+        ];
+        TrieDictionary::from_entries(entries)
+    }
+
+    #[test]
+    fn test_convert_unigram() {
+        let dict = test_dict();
+        let result = convert(&dict, None, "きょうはいいてんき");
+
+        let surfaces: Vec<&str> = result.iter().map(|s| s.surface.as_str()).collect();
+        // Without connection costs, should pick lowest-cost words
+        // Expected: 今日(3000) + は(2000) + 良い(3500) + 天気(4000) = 12500
+        assert_eq!(surfaces, vec!["今日", "は", "良い", "天気"]);
+    }
+
+    #[test]
+    fn test_convert_empty() {
+        let dict = test_dict();
+        let result = convert(&dict, None, "");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_convert_single_word() {
+        let dict = test_dict();
+        let result = convert(&dict, None, "きょう");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "今日");
+        assert_eq!(result[0].reading, "きょう");
+    }
+
+    #[test]
+    fn test_convert_unknown_chars() {
+        let dict = test_dict();
+        let result = convert(&dict, None, "ぬ");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].surface, "ぬ");
+    }
+
+    #[test]
+    fn test_convert_watashi() {
+        let dict = test_dict();
+        let result = convert(&dict, None, "わたしはがくせいです");
+
+        let surfaces: Vec<&str> = result.iter().map(|s| s.surface.as_str()).collect();
+        assert_eq!(surfaces, vec!["私", "は", "学生", "です"]);
+    }
+
+    #[test]
+    fn test_convert_with_connection_costs() {
+        // Build a dict where "きょう" has two entries with similar word costs:
+        //   "今日" (cost=5000, id=10) and "京" (cost=4900, id=20)
+        // Without connection costs, "京" wins (lower cost).
+        // With connection costs that penalize id=20→id=30 ("は") heavily,
+        // "今日" should win instead.
+        let entries = vec![
+            (
+                "きょう".to_string(),
+                vec![
+                    DictEntry {
+                        surface: "今日".to_string(),
+                        cost: 5000,
+                        left_id: 10,
+                        right_id: 10,
+                    },
+                    DictEntry {
+                        surface: "京".to_string(),
+                        cost: 4900,
+                        left_id: 20,
+                        right_id: 20,
+                    },
+                ],
+            ),
+            (
+                "は".to_string(),
+                vec![DictEntry {
+                    surface: "は".to_string(),
+                    cost: 2000,
+                    left_id: 30,
+                    right_id: 30,
+                }],
+            ),
+        ];
+        let dict = TrieDictionary::from_entries(entries);
+
+        // Without connection costs, "京" (4900) wins over "今日" (5000)
+        let result_unigram = convert(&dict, None, "きょうは");
+        assert_eq!(result_unigram[0].surface, "京");
+
+        // Build a connection matrix (31×31 to cover ids 0..30)
+        // Set high penalty for id 20→30 transition, low for id 10→30
+        let num_ids = 31;
+        let mut text = format!("{num_ids} {num_ids}\n");
+        for left in 0..num_ids {
+            for right in 0..num_ids {
+                let cost = if left == 20 && right == 30 {
+                    500 // heavy penalty: 京→は
+                } else {
+                    0
+                };
+                text.push_str(&format!("{cost}\n"));
+            }
+        }
+        let conn = ConnectionMatrix::from_text(&text).unwrap();
+
+        // With connection costs: "京"(4900) + conn(20→30=500) = 5400
+        //                        "今日"(5000) + conn(10→30=0) = 5000
+        // "今日" should now win
+        let result_bigram = convert(&dict, Some(&conn), "きょうは");
+        assert_eq!(result_bigram[0].surface, "今日");
+        assert_eq!(result_bigram[1].surface, "は");
+    }
+
+    #[test]
+    fn test_viterbi_tiebreak_deterministic() {
+        let entries = vec![(
+            "あ".to_string(),
+            vec![
+                DictEntry {
+                    surface: "亜".to_string(),
+                    cost: 5000,
+                    left_id: 0,
+                    right_id: 0,
+                },
+                DictEntry {
+                    surface: "阿".to_string(),
+                    cost: 5000,
+                    left_id: 0,
+                    right_id: 0,
+                },
+            ],
+        )];
+        let dict = TrieDictionary::from_entries(entries);
+        let first = convert(&dict, None, "あ");
+        assert_eq!(first.len(), 1);
+        for _ in 0..10 {
+            let result = convert(&dict, None, "あ");
+            assert_eq!(
+                result[0].surface, first[0].surface,
+                "Viterbi tie-breaking must be deterministic"
+            );
+        }
+    }
+}

--- a/engine/src/dict/connection.rs
+++ b/engine/src/dict/connection.rs
@@ -1,0 +1,265 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+const MAGIC: &[u8; 4] = b"LXCX";
+const VERSION: u8 = 1;
+const HEADER_SIZE: usize = 4 + 1 + 2; // magic + version + num_ids
+
+/// A connection cost matrix mapping (left_id, right_id) → cost.
+/// Used by the Viterbi algorithm to score morpheme transitions.
+pub struct ConnectionMatrix {
+    num_ids: u16,
+    costs: Vec<i16>,
+}
+
+impl ConnectionMatrix {
+    /// Look up the connection cost between two morphemes.
+    pub fn cost(&self, left_id: u16, right_id: u16) -> i16 {
+        let idx = left_id as usize * self.num_ids as usize + right_id as usize;
+        self.costs.get(idx).copied().unwrap_or(0)
+    }
+
+    /// Number of morpheme IDs in this matrix.
+    pub fn num_ids(&self) -> u16 {
+        self.num_ids
+    }
+
+    /// Build from a TSV file (Mozc connection_single_column.txt format).
+    ///
+    /// Format:
+    /// - Line 1: `num_left num_right` (both should be equal)
+    /// - Remaining lines: one cost (i16) per line, row-major order
+    pub fn from_text(text: &str) -> Result<Self, ConnectionError> {
+        let mut lines = text.lines();
+
+        let header = lines
+            .next()
+            .ok_or_else(|| ConnectionError::Parse("empty file".to_string()))?;
+        let parts: Vec<&str> = header.split_whitespace().collect();
+        let num_left: u16 = match parts.len() {
+            1 => parts[0]
+                .parse()
+                .map_err(|e| ConnectionError::Parse(format!("invalid num_ids: {e}")))?,
+            2 => {
+                let nl: u16 = parts[0]
+                    .parse()
+                    .map_err(|e| ConnectionError::Parse(format!("invalid num_left: {e}")))?;
+                let nr: u16 = parts[1]
+                    .parse()
+                    .map_err(|e| ConnectionError::Parse(format!("invalid num_right: {e}")))?;
+                if nl != nr {
+                    return Err(ConnectionError::Parse(format!(
+                        "num_left ({nl}) != num_right ({nr})"
+                    )));
+                }
+                nl
+            }
+            _ => {
+                return Err(ConnectionError::Parse(format!(
+                    "expected 1 or 2 values in header, got {}",
+                    parts.len()
+                )));
+            }
+        };
+
+        let expected = num_left as usize * num_left as usize;
+        let mut costs = Vec::with_capacity(expected);
+
+        for line in lines {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let cost: i16 = line
+                .parse()
+                .map_err(|e| ConnectionError::Parse(format!("invalid cost '{line}': {e}")))?;
+            costs.push(cost);
+        }
+
+        if costs.len() != expected {
+            return Err(ConnectionError::Parse(format!(
+                "expected {expected} costs, got {}",
+                costs.len()
+            )));
+        }
+
+        Ok(Self {
+            num_ids: num_left,
+            costs,
+        })
+    }
+
+    /// Load from compiled binary format.
+    pub fn open(path: &Path) -> Result<Self, ConnectionError> {
+        let data = fs::read(path).map_err(ConnectionError::Io)?;
+        Self::from_bytes(&data)
+    }
+
+    /// Parse from compiled binary format.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, ConnectionError> {
+        if data.len() < HEADER_SIZE {
+            return Err(ConnectionError::InvalidHeader);
+        }
+        if &data[..4] != MAGIC {
+            return Err(ConnectionError::InvalidMagic);
+        }
+        if data[4] != VERSION {
+            return Err(ConnectionError::UnsupportedVersion(data[4]));
+        }
+
+        let num_ids = u16::from_le_bytes([data[5], data[6]]);
+        let expected_len = num_ids as usize * num_ids as usize;
+        let costs_bytes = &data[HEADER_SIZE..];
+
+        if costs_bytes.len() != expected_len * 2 {
+            return Err(ConnectionError::Parse(format!(
+                "expected {} bytes of cost data, got {}",
+                expected_len * 2,
+                costs_bytes.len()
+            )));
+        }
+
+        let costs: Vec<i16> = costs_bytes
+            .chunks_exact(2)
+            .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect();
+
+        Ok(Self { num_ids, costs })
+    }
+
+    /// Serialize to compiled binary format.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(HEADER_SIZE + self.costs.len() * 2);
+        buf.extend_from_slice(MAGIC);
+        buf.push(VERSION);
+        buf.extend_from_slice(&self.num_ids.to_le_bytes());
+        for &cost in &self.costs {
+            buf.extend_from_slice(&cost.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Save compiled binary to file.
+    pub fn save(&self, path: &Path) -> Result<(), ConnectionError> {
+        fs::write(path, self.to_bytes()).map_err(ConnectionError::Io)
+    }
+}
+
+#[derive(Debug)]
+pub enum ConnectionError {
+    Io(io::Error),
+    InvalidHeader,
+    InvalidMagic,
+    UnsupportedVersion(u8),
+    Parse(String),
+}
+
+impl std::fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "IO error: {e}"),
+            Self::InvalidHeader => write!(f, "invalid connection matrix header"),
+            Self::InvalidMagic => write!(f, "invalid magic bytes (expected LXCX)"),
+            Self::UnsupportedVersion(v) => write!(f, "unsupported version: {v}"),
+            Self::Parse(msg) => write!(f, "parse error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ConnectionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_matrix() -> ConnectionMatrix {
+        let text = "3 3\n0\n10\n20\n30\n40\n50\n60\n70\n80\n";
+        ConnectionMatrix::from_text(text).unwrap()
+    }
+
+    #[test]
+    fn test_from_text() {
+        let m = sample_matrix();
+        assert_eq!(m.num_ids(), 3);
+        // Row 0: [0, 10, 20]
+        assert_eq!(m.cost(0, 0), 0);
+        assert_eq!(m.cost(0, 1), 10);
+        assert_eq!(m.cost(0, 2), 20);
+        // Row 1: [30, 40, 50]
+        assert_eq!(m.cost(1, 0), 30);
+        assert_eq!(m.cost(1, 1), 40);
+        assert_eq!(m.cost(1, 2), 50);
+        // Row 2: [60, 70, 80]
+        assert_eq!(m.cost(2, 0), 60);
+        assert_eq!(m.cost(2, 1), 70);
+        assert_eq!(m.cost(2, 2), 80);
+    }
+
+    #[test]
+    fn test_serialize_roundtrip() {
+        let m = sample_matrix();
+        let bytes = m.to_bytes();
+        let m2 = ConnectionMatrix::from_bytes(&bytes).unwrap();
+        assert_eq!(m2.num_ids(), m.num_ids());
+        for left in 0..m.num_ids() {
+            for right in 0..m.num_ids() {
+                assert_eq!(m.cost(left, right), m2.cost(left, right));
+            }
+        }
+    }
+
+    #[test]
+    fn test_file_roundtrip() {
+        let dir = std::env::temp_dir().join("lexime_test_conn");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("test.conn");
+
+        let m = sample_matrix();
+        m.save(&path).unwrap();
+
+        let m2 = ConnectionMatrix::open(&path).unwrap();
+        assert_eq!(m2.num_ids(), 3);
+        assert_eq!(m.cost(1, 2), m2.cost(1, 2));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_invalid_magic() {
+        let result = ConnectionMatrix::from_bytes(b"XXXX\x01\x03\x00");
+        assert!(matches!(result, Err(ConnectionError::InvalidMagic)));
+    }
+
+    #[test]
+    fn test_header_too_short() {
+        let result = ConnectionMatrix::from_bytes(b"LXC");
+        assert!(matches!(result, Err(ConnectionError::InvalidHeader)));
+    }
+
+    #[test]
+    fn test_unsupported_version() {
+        let result = ConnectionMatrix::from_bytes(b"LXCX\x99\x01\x00");
+        assert!(matches!(
+            result,
+            Err(ConnectionError::UnsupportedVersion(0x99))
+        ));
+    }
+
+    #[test]
+    fn test_negative_costs() {
+        let text = "2 2\n-100\n200\n-300\n400\n";
+        let m = ConnectionMatrix::from_text(text).unwrap();
+        assert_eq!(m.cost(0, 0), -100);
+        assert_eq!(m.cost(0, 1), 200);
+        assert_eq!(m.cost(1, 0), -300);
+        assert_eq!(m.cost(1, 1), 400);
+    }
+
+    #[test]
+    fn test_wrong_count() {
+        let text = "2 2\n0\n10\n20\n"; // only 3 costs instead of 4
+        let result = ConnectionMatrix::from_text(text);
+        assert!(matches!(result, Err(ConnectionError::Parse(_))));
+    }
+}

--- a/engine/src/dict/mod.rs
+++ b/engine/src/dict/mod.rs
@@ -1,3 +1,4 @@
+pub mod connection;
 mod entry;
 pub mod source;
 mod trie_dict;
@@ -13,4 +14,5 @@ pub struct SearchResult {
 pub trait Dictionary: Send + Sync {
     fn lookup(&self, reading: &str) -> Option<&[DictEntry]>;
     fn predict(&self, prefix: &str, max_results: usize) -> Vec<SearchResult>;
+    fn common_prefix_search(&self, query: &str) -> Vec<SearchResult>;
 }

--- a/engine/src/dict/source/mozc.rs
+++ b/engine/src/dict/source/mozc.rs
@@ -8,6 +8,7 @@ use crate::dict::DictEntry;
 const MOZC_CONTENTS_URL: &str =
     "https://api.github.com/repos/google/mozc/contents/src/data/dictionary_oss";
 const MOZC_LICENSE_URL: &str = "https://raw.githubusercontent.com/google/mozc/master/LICENSE";
+const MOZC_CONNECTION_URL: &str = "https://raw.githubusercontent.com/google/mozc/master/src/data/dictionary_oss/connection_single_column.txt";
 
 /// Mozc TSV dictionary source.
 ///
@@ -168,6 +169,15 @@ impl DictSource for MozcSource {
             }
             eprintln!("  {name}");
             Self::download_file(url, &file_path)?;
+        }
+
+        // Download connection matrix
+        let connection = dest.join("connection_single_column.txt");
+        if connection.exists() {
+            eprintln!("  connection_single_column.txt (already exists, skipping)");
+        } else {
+            eprintln!("  connection_single_column.txt");
+            Self::download_file(MOZC_CONNECTION_URL, &connection)?;
         }
 
         // Download LICENSE

--- a/engine/src/dict/trie_dict.rs
+++ b/engine/src/dict/trie_dict.rs
@@ -102,6 +102,17 @@ impl Dictionary for TrieDictionary {
             })
             .collect()
     }
+
+    fn common_prefix_search(&self, query: &str) -> Vec<SearchResult> {
+        let iter: Box<dyn Iterator<Item = (String, &Vec<DictEntry>)>> =
+            Box::new(self.data.trie.common_prefix_search(query.as_bytes()));
+
+        iter.map(|(key, entries)| SearchResult {
+            reading: key,
+            entries: entries.clone(),
+        })
+        .collect()
+    }
 }
 
 #[derive(Debug)]

--- a/mise.toml
+++ b/mise.toml
@@ -5,8 +5,10 @@ outputs = ["build/liblex_engine.a"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-cd engine && cargo build --release --target x86_64-apple-darwin
-cd engine && cargo build --release --target aarch64-apple-darwin
+cd engine
+cargo build --release --target x86_64-apple-darwin
+cargo build --release --target aarch64-apple-darwin
+cd ..
 mkdir -p build
 lipo -create \
   engine/target/x86_64-apple-darwin/release/liblex_engine.a \
@@ -39,13 +41,27 @@ cargo build --release --bin dictool
 target/release/dictool compile data/mozc-raw data/lexime.dict
 """
 
+[tasks.conn]
+description = "Compile connection cost matrix"
+depends = ["fetch-dict"]
+sources = ["engine/data/mozc-raw/connection_single_column.txt"]
+outputs = ["engine/data/lexime.conn"]
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+cd engine
+cargo build --release --bin dictool
+target/release/dictool compile-conn data/mozc-raw/connection_single_column.txt data/lexime.conn
+"""
+
 [tasks.build]
 description = "Build Lexime.app (universal binary)"
-depends = ["engine-lib", "dict"]
+depends = ["engine-lib", "dict", "conn"]
 sources = [
   "Sources/*.swift",
   "build/liblex_engine.a",
   "engine/data/lexime.dict",
+  "engine/data/lexime.conn",
   "Info.plist",
   "Resources/icon.tiff",
 ]
@@ -70,6 +86,7 @@ rm "$MACOS/Lexime-x86_64" "$MACOS/Lexime-arm64"
 cp Info.plist "$APP/Contents/Info.plist"
 cp Resources/icon.tiff "$RES/icon.tiff"
 cp engine/data/lexime.dict "$RES/lexime.dict"
+cp engine/data/lexime.conn "$RES/lexime.conn"
 # TODO: codesign with Lexime.entitlements for distribution builds
 echo "Build complete: $APP"
 """
@@ -102,6 +119,17 @@ run = """log stream --predicate 'process == "Lexime"' --style compact"""
 [tasks.icon]
 description = "Generate icon assets"
 run = "bash scripts/icon.sh"
+
+[tasks.test-swift]
+description = "Run Swift unit tests"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p build
+swiftc Sources/RomajiTable.swift Sources/RomajiConverter.swift \
+  Tests/TestRunner.swift Tests/TestRomajiTrie.swift Tests/TestRomajiConverter.swift \
+  -o build/test-runner && build/test-runner
+"""
 
 [tasks.lint]
 description = "Run cargo fmt --check and clippy"


### PR DESCRIPTION
## Summary

- **Viterbi変換エンジン**: 接続行列を使ったマルチセグメントかな漢字変換（lattice構築 + Viterbi探索）
- **リアルタイム予測候補**: composing中に辞書から予測候補を表示
- **カスタム候補パネル**: IMKCandidatesをNSPanel+自前描画に置き換え（空枠バグ解消、ページング対応）
- **記号変換**: 全角・半角を候補パネルで選択可能に（`。/.`、`「/｢/[` など）
- **セグメント境界調整**: Shift+矢印でセグメント分割を変更
- **数字キー直接選択**: 1-9キーで候補を直接選択（9件ページング）
- **コントローラ分割**: KeyHandlers, DictBridge, MarkedTextManager, InputState, RomajiConverterに分離
- **ローマ字変換テスト**: trie-based変換のユニットテスト追加
- **英数キー**: システムABC入力ソースへの切り替え委譲

## Test plan

- [ ] 「から」と入力 → 予測候補パネル表示（空枠なし）
- [ ] 上下キー・Spaceで候補選択 → ハイライト移動
- [ ] Enter/Tabで候補確定
- [ ] Escで予測候補消去 → 再度Escで入力キャンセル
- [ ] Spaceで変換 → 変換候補パネル表示
- [ ] 変換中の上下・Spaceで候補切替
- [ ] 変換中の左右でセグメント移動
- [ ] 変換中の数字キーで直接選択
- [ ] Shift+矢印でセグメント境界調整
- [ ] 記号キー（`.` `,` `?` `!` `[` `]`）→ 全角/半角候補表示
- [ ] `cargo test` / `mise run test-swift` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)