### PR TITLE
fix: always enter converting state on Space

### DIFF
--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -89,8 +89,6 @@ extension LeximeInputController {
             let segments = convertKana(composedKana)
             if segments.isEmpty {
                 commitComposed(client: client)
-            } else if segments.count == 1 && segments[0].candidates.count <= 1 {
-                commitText(segments[0].surface, client: client)
             } else {
                 originalKana = composedKana
                 conversionSegments = segments


### PR DESCRIPTION
## Summary

- Space で変換時、単一セグメント・単一候補の場合に即確定していたのを修正
- 常に変換状態に入り、Enter で確定する流れに統一

## Test plan

- [ ] 「レビュー」等の単一候補語をSpaceで変換 → 変換状態に入り即確定されない
- [ ] Enter で確定できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)