### PR TITLE
refactor: address code review findings

### DIFF
--- a/Sources/DictBridge.swift
+++ b/Sources/DictBridge.swift
@@ -33,7 +33,6 @@ extension LeximeInputController {
                 }
             }
         }
-        NSLog("Lexime: predict('%@') → [%@]", kana, results.joined(separator: ", "))
         return results
     }
 
@@ -47,8 +46,10 @@ extension LeximeInputController {
 
         var converted: [ConversionSegment] = []
         for i in 0..<Int(result.len) {
-            let reading = String(cString: segments[i].reading)
-            let surface = String(cString: segments[i].surface)
+            guard let readingPtr = segments[i].reading,
+                  let surfacePtr = segments[i].surface else { continue }
+            let reading = String(cString: readingPtr)
+            let surface = String(cString: surfacePtr)
             let candidates = lookupCandidates(reading)
             var orderedCandidates = [surface]
             var seen: Set<String> = [surface]

--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -1,6 +1,23 @@
 import Cocoa
 import InputMethodKit
 
+// MARK: - Key Codes (macOS virtual key codes)
+
+enum Key {
+    static let enter:     UInt16 = 36
+    static let tab:       UInt16 = 48
+    static let space:     UInt16 = 49
+    static let backspace: UInt16 = 51
+    static let escape:    UInt16 = 53
+    static let f7:        UInt16 = 98
+    static let eisu:      UInt16 = 102
+    static let kana:      UInt16 = 104
+    static let left:      UInt16 = 123
+    static let right:     UInt16 = 124
+    static let down:      UInt16 = 125
+    static let up:        UInt16 = 126
+}
+
 extension LeximeInputController {
 
     // MARK: - Idle State
@@ -34,7 +51,7 @@ extension LeximeInputController {
 
     func handleComposing(keyCode: UInt16, text: String, client: IMKTextInput) -> Bool {
         switch keyCode {
-        case 36: // Enter — commit selected prediction, or kana as-is
+        case Key.enter: // Enter — commit selected prediction, or kana as-is
             hideCandidatePanel()
             if !predictionCandidates.isEmpty {
                 let idx = min(selectedPredictionIndex, predictionCandidates.count - 1)
@@ -45,7 +62,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 125: // Down arrow — next prediction candidate
+        case Key.down: // Down arrow — next prediction candidate
             if !predictionCandidates.isEmpty {
                 selectedPredictionIndex = (selectedPredictionIndex + 1) % predictionCandidates.count
                 updateMarkedTextWithCandidate(predictionCandidates[selectedPredictionIndex], client: client)
@@ -53,7 +70,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 126: // Up arrow — previous prediction candidate
+        case Key.up: // Up arrow — previous prediction candidate
             if !predictionCandidates.isEmpty {
                 selectedPredictionIndex = (selectedPredictionIndex - 1 + predictionCandidates.count) % predictionCandidates.count
                 updateMarkedTextWithCandidate(predictionCandidates[selectedPredictionIndex], client: client)
@@ -61,7 +78,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 48: // Tab — accept selected prediction candidate
+        case Key.tab: // Tab — accept selected prediction candidate
             if !predictionCandidates.isEmpty {
                 hideCandidatePanel()
                 let idx = min(selectedPredictionIndex, predictionCandidates.count - 1)
@@ -70,7 +87,7 @@ extension LeximeInputController {
             }
             return false
 
-        case 49: // Space — convert kana (or next candidate for punctuation)
+        case Key.space: // Space — convert kana (or next candidate for punctuation)
             if isPunctuationComposing && predictionCandidates.count > 1 {
                 selectedPredictionIndex = (selectedPredictionIndex + 1) % predictionCandidates.count
                 composedKana = predictionCandidates[selectedPredictionIndex]
@@ -99,7 +116,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 51: // Backspace
+        case Key.backspace: // Backspace
             if !pendingRomaji.isEmpty {
                 pendingRomaji.removeLast()
             } else if !composedKana.isEmpty {
@@ -117,7 +134,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 53: // Escape — dismiss predictions, keep kana; second Esc cancels
+        case Key.escape: // Escape — dismiss predictions, keep kana; second Esc cancels
             if !predictionCandidates.isEmpty {
                 hideCandidatePanel()
                 predictionCandidates = []
@@ -132,7 +149,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 98: // F7 — katakana conversion
+        case Key.f7: // F7 — katakana conversion
             hideCandidatePanel()
             flush()
             let katakana = composedKana.applyingTransform(.hiraganaToKatakana, reverse: false)
@@ -176,13 +193,13 @@ extension LeximeInputController {
 
     func handleConverting(keyCode: UInt16, text: String, client: IMKTextInput) -> Bool {
         switch keyCode {
-        case 36: // Enter — confirm all segments
+        case Key.enter: // Enter — confirm all segments
             hideCandidatePanel()
             let fullText = conversionSegments.map { $0.surface }.joined()
             commitText(fullText, client: client)
             return true
 
-        case 49: // Space — next candidate for active segment
+        case Key.space: // Space — next candidate for active segment
             if activeSegmentIndex < conversionSegments.count {
                 let seg = conversionSegments[activeSegmentIndex]
                 if !seg.candidates.isEmpty {
@@ -195,7 +212,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 51, 53: // Backspace or Escape — back to composing with original kana
+        case Key.backspace, Key.escape: // Backspace or Escape — back to composing with original kana
             hideCandidatePanel()
             composedKana = originalKana
             conversionSegments = []
@@ -204,7 +221,7 @@ extension LeximeInputController {
             updateMarkedText(client: client)
             return true
 
-        case 123: // Left arrow — previous segment
+        case Key.left: // Left arrow — previous segment
             if activeSegmentIndex > 0 {
                 activeSegmentIndex -= 1
                 updateConvertingMarkedText(client: client)
@@ -212,7 +229,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 124: // Right arrow — next segment
+        case Key.right: // Right arrow — next segment
             if activeSegmentIndex < conversionSegments.count - 1 {
                 activeSegmentIndex += 1
                 updateConvertingMarkedText(client: client)
@@ -220,7 +237,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 126: // Up arrow — previous candidate
+        case Key.up: // Up arrow — previous candidate
             if activeSegmentIndex < conversionSegments.count {
                 let seg = conversionSegments[activeSegmentIndex]
                 if !seg.candidates.isEmpty {
@@ -233,7 +250,7 @@ extension LeximeInputController {
             }
             return true
 
-        case 125: // Down arrow — next candidate
+        case Key.down: // Down arrow — next candidate
             if activeSegmentIndex < conversionSegments.count {
                 let seg = conversionSegments[activeSegmentIndex]
                 if !seg.candidates.isEmpty {

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -98,13 +98,13 @@ class LeximeInputController: IMKInputController {
         }
 
         // Eisu key (102) → switch to ABC input source
-        if event.keyCode == 102 {
+        if event.keyCode == Key.eisu {
             if isComposing { commitCurrentState(client: client) }
             selectABCInputSource()
             return true
         }
         // Kana key (104) → already in Japanese mode, consume the event
-        if event.keyCode == 104 {
+        if event.keyCode == Key.kana {
             return true
         }
 
@@ -113,9 +113,9 @@ class LeximeInputController: IMKInputController {
 
         // Shift+Arrow in converting state: segment boundary adjustment (U2)
         if dominated == .shift && state == .converting {
-            if event.keyCode == 123 || event.keyCode == 124 {
+            if event.keyCode == Key.left || event.keyCode == Key.right {
                 return handleSegmentBoundaryAdjust(
-                    shrink: event.keyCode == 123, client: client)
+                    shrink: event.keyCode == Key.left, client: client)
             }
         }
 

--- a/Sources/RomajiConverter.swift
+++ b/Sources/RomajiConverter.swift
@@ -77,8 +77,7 @@ func drainPendingRomaji(
                     } else {
                         // R1 fix: preserve unrecognized characters in composedKana
                         // instead of silently discarding them
-                        composedKana += String(pendingRomaji.first!)
-                        pendingRomaji = String(pendingRomaji.dropFirst())
+                        composedKana += String(pendingRomaji.removeFirst())
                         changed = true
                     }
                 } else {

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -3,9 +3,19 @@ import InputMethodKit
 
 let kConnectionName = "dev.sendsh.inputmethod.Lexime_Connection"
 
+guard let resourcePath = Bundle.main.resourcePath else {
+    NSLog("Lexime: Bundle.main.resourcePath is nil")
+    exit(1)
+}
+
+guard let bundleId = Bundle.main.bundleIdentifier else {
+    NSLog("Lexime: Bundle.main.bundleIdentifier is nil")
+    exit(1)
+}
+
 // Load dictionary once at startup
 let sharedDict: OpaquePointer? = {
-    let dictPath = Bundle.main.resourcePath! + "/lexime.dict"
+    let dictPath = resourcePath + "/lexime.dict"
     guard let dict = lex_dict_open(dictPath) else {
         NSLog("Lexime: Failed to load dictionary at %@", dictPath)
         return nil
@@ -22,7 +32,7 @@ let sharedDict: OpaquePointer? = {
 
 // Load connection matrix (optional — falls back to unigram if not found)
 let sharedConn: OpaquePointer? = {
-    let connPath = Bundle.main.resourcePath! + "/lexime.conn"
+    let connPath = resourcePath + "/lexime.conn"
     guard let conn = lex_conn_open(connPath) else {
         NSLog("Lexime: Connection matrix not found at %@ (using unigram fallback)", connPath)
         return nil
@@ -31,8 +41,7 @@ let sharedConn: OpaquePointer? = {
     return conn
 }()
 
-guard let server = IMKServer(name: kConnectionName,
-                             bundleIdentifier: Bundle.main.bundleIdentifier!) else {
+guard let server = IMKServer(name: kConnectionName, bundleIdentifier: bundleId) else {
     NSLog("Lexime: Failed to create IMKServer")
     exit(1)
 }

--- a/engine/src/dict/connection.rs
+++ b/engine/src/dict/connection.rs
@@ -15,8 +15,12 @@ pub struct ConnectionMatrix {
 
 impl ConnectionMatrix {
     /// Look up the connection cost between two morphemes.
+    /// Index: left_id * num_ids + right_id. Max index with u16 is ~4.3B,
+    /// which fits in usize on 64-bit targets. Out-of-bounds returns 0.
     pub fn cost(&self, left_id: u16, right_id: u16) -> i16 {
-        let idx = left_id as usize * self.num_ids as usize + right_id as usize;
+        let idx = (left_id as usize)
+            .saturating_mul(self.num_ids as usize)
+            .saturating_add(right_id as usize);
         self.costs.get(idx).copied().unwrap_or(0)
     }
 

--- a/engine/src/dict/source/mozc.rs
+++ b/engine/src/dict/source/mozc.rs
@@ -49,8 +49,10 @@ fn parse_remote_files(json: &str) -> Result<Vec<(String, String)>, DictSourceErr
 
     let mut files: Vec<(String, String)> = Vec::new();
     for entry in &entries {
-        let raw_name = entry["name"].as_str().unwrap_or_default();
-        let url = entry["download_url"].as_str().unwrap_or_default();
+        let (Some(raw_name), Some(url)) = (entry["name"].as_str(), entry["download_url"].as_str())
+        else {
+            continue; // skip entries with missing name or download_url
+        };
         if url.is_empty() {
             continue;
         }


### PR DESCRIPTION
## Summary
- Replace force unwraps with guard-let in main.swift
- Use safer `removeFirst()` instead of `first!` in RomajiConverter
- Add saturating arithmetic in connection matrix index calculation
- Add SAFETY comments to unsafe blocks in FFI layer
- Add null pointer guards for FFI segment data in DictBridge
- Use let-else pattern for CString construction in lib.rs
- Make `to_bytes()` return `Result` instead of panicking in trie_dict
- Validate JSON fields with pattern matching in mozc source
- Extract `die!` macro for consistent error handling in dictool
- Replace magic key code numbers with named `Key` constants
- Remove verbose predict logging

## Test plan
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` all pass (51 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)