### PR TITLE
feat: switch default dictionary from Mozc to SudachiDict

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -17,41 +17,35 @@ lipo -create \
 """
 
 [tasks.fetch-dict]
-description = "Download Mozc dictionary data"
-sources = ["engine/src/bin/dictool.rs", "engine/src/dict/source/mozc.rs"]
-outputs = ["engine/data/mozc-raw/.stamp"]
-run = "cd engine && cargo run --bin dictool -- fetch --source mozc data/mozc-raw"
-
-[tasks.fetch-sudachi-dict]
 description = "Download SudachiDict dictionary data"
 sources = ["engine/src/bin/dictool.rs", "engine/src/dict/source/sudachi.rs"]
 outputs = ["engine/data/sudachi-raw/.stamp"]
 run = "cd engine && cargo run --bin dictool -- fetch --source sudachi data/sudachi-raw"
 
 [tasks.dict]
-description = "Compile binary dictionary from Mozc TSV"
+description = "Compile binary dictionary from SudachiDict"
 depends = ["fetch-dict"]
-sources = ["engine/data/mozc-raw/.stamp"]
+sources = ["engine/data/sudachi-raw/.stamp"]
 outputs = ["engine/data/lexime.dict"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 cd engine
 cargo build --release --bin dictool
-target/release/dictool compile data/mozc-raw data/lexime.dict
+target/release/dictool compile --source sudachi data/sudachi-raw data/lexime.dict
 """
 
 [tasks.conn]
 description = "Compile connection cost matrix"
 depends = ["fetch-dict"]
-sources = ["engine/data/mozc-raw/connection_single_column.txt"]
+sources = ["engine/data/sudachi-raw/matrix.def"]
 outputs = ["engine/data/lexime.conn"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 cd engine
 cargo build --release --bin dictool
-target/release/dictool compile-conn data/mozc-raw/connection_single_column.txt data/lexime.conn
+target/release/dictool compile-conn data/sudachi-raw/matrix.def data/lexime.conn
 """
 
 [tasks.build]


### PR DESCRIPTION
## Summary

- Switch default dictionary source from Mozc to SudachiDict (MeCab-compatible format)
- Download dict ZIPs and matrix.def from CloudFront CDN (S3 listing API only for version discovery)
- Add MeCab triplet format (`right_id left_id cost`) auto-detection to `ConnectionMatrix::from_text()`, keeping Mozc single-column support
- Extract `download_and_extract()` helper to deduplicate ZIP download/extraction logic
- Update mise.toml tasks (`fetch-dict`, `dict`, `conn`) to use SudachiDict as default

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 74 tests pass including 3 new MeCab triplet tests
- [x] `mise run fetch-dict` — downloads SudachiDict CSVs + matrix.def from CDN
- [x] `mise run dict` — compiles dictionary (68.7MB, 895k readings)
- [x] `mise run conn` — compiles connection matrix (68.2MB, 5981x5981)
- [x] `mise run build && mise run install && mise run reload` — builds and installs successfully
- [x] Manual conversion test confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)