### PR TITLE
feat: N-best Viterbi and Latin script penalty

### DIFF
--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -115,7 +115,7 @@ extension LeximeInputController {
                 originalKana = composedKana
                 viterbiSegments = segments
 
-                // Build single-segment view: predictions first, then Viterbi, then lookups
+                // Build single-segment view: predictions, N-best Viterbi, lookups
                 let viterbiSurface = segments.map { $0.surface }.joined()
                 var candidates: [String] = []
                 var seen = Set<String>()
@@ -123,7 +123,12 @@ extension LeximeInputController {
                 for pred in predictionCandidates where pred != composedKana && seen.insert(pred).inserted {
                     candidates.append(pred)
                 }
-                // Viterbi result
+                // N-best Viterbi surfaces (includes 1-best as first element)
+                let nbestSurfaces = convertKanaNbest(composedKana, n: 5)
+                for surface in nbestSurfaces where seen.insert(surface).inserted {
+                    candidates.append(surface)
+                }
+                // Viterbi 1-best as fallback (in case N-best was empty)
                 if seen.insert(viterbiSurface).inserted {
                     candidates.append(viterbiSurface)
                 }

--- a/engine/include/engine.h
+++ b/engine/include/engine.h
@@ -77,4 +77,29 @@ LexCandidateList lex_dict_lookup_with_history(
     const char *reading
 );
 
+/* N-best Conversion API */
+
+typedef struct {
+    const LexConversionResult *results;
+    uint32_t len;
+    void *_owned;
+} LexConversionResultList;
+
+LexConversionResultList lex_convert_nbest(
+    const LexDict *dict,
+    const LexConnectionMatrix *conn,
+    const char *kana,
+    uint32_t n
+);
+
+LexConversionResultList lex_convert_nbest_with_history(
+    const LexDict *dict,
+    const LexConnectionMatrix *conn,
+    const LexUserHistory *history,
+    const char *kana,
+    uint32_t n
+);
+
+void lex_conversion_result_list_free(LexConversionResultList list);
+
 #endif

--- a/engine/src/converter/cost.rs
+++ b/engine/src/converter/cost.rs
@@ -2,6 +2,64 @@ use crate::dict::connection::ConnectionMatrix;
 
 use super::lattice::LatticeNode;
 
+/// Per-segment penalty added to each node's word cost.
+/// Discourages the Viterbi algorithm from choosing paths with many short segments
+/// over paths with fewer, longer (and usually more natural) segments.
+pub const SEGMENT_PENALTY: i64 = 5000;
+
+/// Bonus subtracted from word cost for mixed-script surfaces (kanji + kana).
+/// Verb conjugations like 通っ, 食べ, 走る contain both kanji and kana — these are
+/// the primary conversion targets for an IME and should be preferred.
+const MIXED_SCRIPT_BONUS: i64 = 3000;
+
+/// Penalty added to word cost when the surface is all katakana.
+/// Katakana noun forms (e.g. タラ) often have low dictionary costs but are rarely
+/// the intended conversion for grammatical words (e.g. たら as 助動詞).
+const KATAKANA_PENALTY: i64 = 5000;
+
+/// Penalty for surfaces containing ASCII/Latin characters.
+/// SudachiDict includes English surface forms (e.g. death for です, tie for たい)
+/// with low costs intended for morphological analysis, not IME conversion.
+const LATIN_PENALTY: i64 = 20000;
+
+/// Cost adjustment based on the surface script.
+/// - Mixed-script (kanji+kana, e.g. 通っ, 食べる): bonus (negative)
+/// - Contains Latin/ASCII (e.g. death, tie, thai): heavy penalty
+/// - All-katakana (e.g. タラ, オッ): penalty (positive)
+/// - Otherwise (pure kanji, hiragana, etc.): no adjustment
+pub fn script_cost(surface: &str) -> i64 {
+    if surface.chars().any(is_latin) {
+        return LATIN_PENALTY;
+    }
+    let has_kanji = surface.chars().any(is_kanji);
+    let has_kana = surface.chars().any(|c| is_hiragana(c) || is_katakana(c));
+    if has_kanji && has_kana {
+        -MIXED_SCRIPT_BONUS
+    } else if !surface.is_empty() && surface.chars().all(is_katakana) {
+        KATAKANA_PENALTY
+    } else {
+        0
+    }
+}
+
+fn is_kanji(c: char) -> bool {
+    ('\u{4E00}'..='\u{9FFF}').contains(&c)
+        || ('\u{3400}'..='\u{4DBF}').contains(&c)
+        || ('\u{20000}'..='\u{2A6DF}').contains(&c)
+}
+
+fn is_hiragana(c: char) -> bool {
+    ('\u{3040}'..='\u{309F}').contains(&c)
+}
+
+fn is_katakana(c: char) -> bool {
+    ('\u{30A0}'..='\u{30FF}').contains(&c)
+}
+
+fn is_latin(c: char) -> bool {
+    c.is_ascii_alphabetic()
+}
+
 /// Trait for scoring lattice paths during Viterbi search.
 pub trait CostFunction: Send + Sync {
     fn word_cost(&self, node: &LatticeNode) -> i64;
@@ -28,7 +86,7 @@ impl<'a> DefaultCostFunction<'a> {
 
 impl CostFunction for DefaultCostFunction<'_> {
     fn word_cost(&self, node: &LatticeNode) -> i64 {
-        node.cost as i64
+        node.cost as i64 + SEGMENT_PENALTY + script_cost(&node.surface)
     }
 
     fn transition_cost(&self, prev: &LatticeNode, next: &LatticeNode) -> i64 {

--- a/engine/src/converter/mod.rs
+++ b/engine/src/converter/mod.rs
@@ -4,5 +4,7 @@ pub(crate) mod testutil;
 mod viterbi;
 
 pub use cost::CostFunction;
-pub use lattice::{Lattice, LatticeNode};
-pub use viterbi::{convert, convert_with_cost, ConvertedSegment};
+pub use lattice::{build_lattice, Lattice, LatticeNode};
+pub use viterbi::{
+    convert, convert_nbest, convert_nbest_with_cost, convert_with_cost, ConvertedSegment,
+};

--- a/engine/src/user_history/cost.rs
+++ b/engine/src/user_history/cost.rs
@@ -1,4 +1,4 @@
-use crate::converter::cost::{conn_cost, CostFunction};
+use crate::converter::cost::{conn_cost, script_cost, CostFunction, SEGMENT_PENALTY};
 use crate::converter::LatticeNode;
 use crate::dict::connection::ConnectionMatrix;
 
@@ -18,7 +18,8 @@ impl<'a> LearnedCostFunction<'a> {
 
 impl CostFunction for LearnedCostFunction<'_> {
     fn word_cost(&self, node: &LatticeNode) -> i64 {
-        node.cost as i64 - self.history.unigram_boost(&node.reading, &node.surface)
+        node.cost as i64 + SEGMENT_PENALTY + script_cost(&node.surface)
+            - self.history.unigram_boost(&node.reading, &node.surface)
     }
 
     fn transition_cost(&self, prev: &LatticeNode, next: &LatticeNode) -> i64 {


### PR DESCRIPTION
## Summary
- Top-K per node N-best Viterbi アルゴリズムを実装し、複数のセグメンテーション候補を返せるようにした
- FFI + Swift ブリッジを追加し、スペース押下時の候補一覧に N-best surface を統合
- SudachiDict 由来の英語 surface（death, tie, thai 等）に `LATIN_PENALTY=20000` を適用して抑制
- `LearnedCostFunction` を `DefaultCostFunction` と整合（`SEGMENT_PENALTY + script_cost`）

## 候補の優先順序
1. Prediction candidates（ユーザー学習）
2. N-best Viterbi surfaces（異なるセグメンテーション）
3. Lookup candidates（同一読みの辞書引き）
4. Raw kana（フォールバック）

## Test plan
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (83/83 pass)
- [x] `mise run build && mise run install && mise run reload`
- [x] 「けんとうしたいです」で death/tie が出ないことを確認
- [x] N-best で複数候補が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)