### PR TITLE
docs: update README/SPEC for merged dict and POS remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,16 @@ mise run install
 
 ### 辞書ソース切り替え
 
-Mozc と SudachiDict の辞書を `defaults write` で切り替えられる（デフォルト: `sudachi`）。
+統合辞書（Mozc + SudachiDict）をデフォルトで使用。`defaults write` で個別辞書にも切り替え可能。
 
 ```sh
-# Mozc に切り替え
+# Mozc 単体に切り替え
 defaults write sh.send.inputmethod.Lexime dictSource mozc
 mise run reload
 
-# SudachiDict に戻す
-defaults write sh.send.inputmethod.Lexime dictSource sudachi
+# 統合辞書に戻す
+defaults write sh.send.inputmethod.Lexime dictSource merged
 mise run reload
-```
-
-Mozc 辞書は別途ビルドが必要:
-
-```sh
-mise run fetch-dict-mozc && mise run dict-mozc && mise run conn-mozc
 ```
 
 ### プログラマモード


### PR DESCRIPTION
## Summary
- README: デフォルト辞書ソースを `merged` に更新、辞書切り替えの説明を簡略化
- SPEC: 統合辞書・POS リマップ・新 mise タスク（dict-merged, conn-merged 等）を反映、解決済みの未決事項を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)