### PR TITLE
feat: add cost-ranked prediction with user history boost

### DIFF
--- a/Sources/DictBridge.swift
+++ b/Sources/DictBridge.swift
@@ -24,7 +24,7 @@ extension LeximeInputController {
 
     func predictCandidates(_ kana: String) -> [String] {
         guard let dict = sharedDict, !kana.isEmpty else { return [] }
-        let list = lex_dict_predict(dict, kana, 5)
+        let list = lex_dict_predict_ranked(dict, sharedHistory, kana, 9)
         defer { lex_candidates_free(list) }
 
         guard list.len > 0, let candidates = list.candidates else { return [] }

--- a/engine/include/engine.h
+++ b/engine/include/engine.h
@@ -77,6 +77,13 @@ LexCandidateList lex_dict_lookup_with_history(
     const char *reading
 );
 
+LexCandidateList lex_dict_predict_ranked(
+    const LexDict *dict,
+    const LexUserHistory *history,
+    const char *prefix,
+    uint32_t max_results
+);
+
 /* N-best Conversion API */
 
 typedef struct {


### PR DESCRIPTION
## Summary

- `lex_dict_predict`（5 readings、辞書順）を `lex_dict_predict_ranked`（1000 readings スキャン、コスト順ソート、surface 重複排除、学習ブースト）に置き換え
- 予測候補を 5→9 件に増加
- ユーザーが確定した語を予測候補の上位に反映

## 変更内容

- `TrieDictionary::predict_ranked()` 追加（scan_limit/max_results 制御）
- `LexCandidateList::from_flat_entries()` 追加
- `lex_dict_predict_ranked` FFI 追加（nullable history 対応）
- history 非 null 時は 50 件を over-fetch してブースト再ソート後に truncate
- `DictBridge.swift`: `lex_dict_predict_ranked(dict, sharedHistory, kana, 9)` に更新

## 設計判断

- `scan_limit=1000`: 実辞書で「かん」は 6815 readings あり、「かんきょう」は 791 番目。200 では到達不可。1000 なら 3-4ms で実用的
- over-fetch=50: コスト順で上位 9 件に入らない学習済み語を救出するためのバッファ

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 111 passed
- [x] `mise run build && mise run install && mise run reload` — 正常起動
- [x] 「かんきょう」→「環境」確定後、「かん」入力で「環境」が上位に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)