### PR TITLE
feat: add Mozc-compatible z-sequences

### DIFF
--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -200,6 +200,18 @@ extension LeximeInputController {
             break
         }
 
+        // z-sequences: composing 中、pendingRomaji + text が trie にマッチする場合は通す
+        if !pendingRomaji.isEmpty {
+            let candidate = pendingRomaji + text
+            switch RomajiTrie.shared.lookup(candidate) {
+            case .exact, .exactAndPrefix, .prefix:
+                appendAndConvert(text, client: client)
+                return true
+            case .none:
+                break
+            }
+        }
+
         if let candidates = Self.punctuationCandidates[text] {
             hideCandidatePanel()
             flush()

--- a/Sources/RomajiTable.swift
+++ b/Sources/RomajiTable.swift
@@ -301,6 +301,18 @@ class RomajiTrie {
 
         // 記号
         insert("-", "ー")
+
+        // z-sequences (Mozc 互換)
+        insert("zh", "←")
+        insert("zj", "↓")
+        insert("zk", "↑")
+        insert("zl", "→")
+        insert("z.", "…")
+        insert("z,", "‥")
+        insert("z/", "・")
+        insert("z-", "〜")
+        insert("z[", "『")
+        insert("z]", "』")
     }
 
     func lookup(_ romaji: String) -> TrieLookupResult {


### PR DESCRIPTION
## Summary
- Add 10 z-sequence entries to RomajiTable (arrows, punctuation, brackets)
- Handle non-letter second characters (`.` `,` `/` `-` `[` `]`) in composing state by checking trie before punctuation dispatch

## Test plan
- [x] `zh/zj/zk/zl` → `←↓↑→`
- [x] `z.` → `…`, `z,` → `‥`, `z/` → `・`, `z-` → `〜`
- [x] `z[` → `『`, `z]` → `』`
- [x] Existing `za/zi/zu` etc. still produce `ざ/じ/ず`
- [x] Idle `.` still produces `。` (punctuation unchanged)
- [x] Swift tests pass (32/32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)