### PR TITLE
feat: use mmap for dictionary and connection matrix loading

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -178,6 +178,7 @@ name = "lex_engine"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "memmap2",
  "serde",
  "serde_json",
  "thiserror",
@@ -213,6 +214,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = "1"
 thiserror = "2"
 ureq = "3"
 zip = { version = "7", default-features = false, features = ["deflate"] }
+memmap2 = "0.9"


### PR DESCRIPTION
## Summary
- **ConnectionMatrix**: `open()` でファイルを mmap し、コストデータを直接マップ済み領域から読み取るように変更。`Vec<i16>` のヒープ確保を排除
- **TrieDictionary**: `open()` で `fs::read` の代わりに mmap を使用し、デシリアライズ中のピークメモリを ~50MB 削減
- `from_bytes()` / `from_text()` など既存の非ファイルパスは `CostStorage::Owned` で従来通り動作

## Test plan
- [x] `cargo test` — connection, trie_dict, FFI 関連テスト全パス
- [x] `cargo clippy -- -D warnings` パス
- [ ] 実機で辞書ロード・変換動作を確認