### PR TITLE
refactor: extract parse_dict_files helper for Mozc/Sudachi parsers

### DIFF
--- a/engine/src/dict/source/mod.rs
+++ b/engine/src/dict/source/mod.rs
@@ -74,6 +74,64 @@ pub(super) fn parse_id_cost(fields: &[&str]) -> Option<(u16, u16, i16)> {
     Some((left_id, right_id, cost))
 }
 
+/// A single parsed dictionary line, returned by the per-line parser closure
+/// passed to [`parse_dict_files`].
+pub(super) struct ParsedLine {
+    pub reading: String,
+    pub surface: String,
+    pub left_id: u16,
+    pub right_id: u16,
+    pub cost: i16,
+}
+
+/// Parse dictionary files with shared boilerplate: file listing, line iteration,
+/// empty/comment skipping, and stats logging.
+///
+/// `parse_line` receives the split fields for each non-empty, non-comment line.
+/// Return `Some(ParsedLine)` to add the entry, `None` to skip.
+pub(super) fn parse_dict_files(
+    dir: &Path,
+    label: &str,
+    predicate: impl Fn(&str) -> bool,
+    delimiter: char,
+    parse_line: impl Fn(&[&str]) -> Option<ParsedLine>,
+) -> Result<HashMap<String, Vec<DictEntry>>, DictSourceError> {
+    let files = list_dict_files(dir, label, predicate)?;
+    let mut entries: HashMap<String, Vec<DictEntry>> = HashMap::new();
+    let mut total_lines = 0u64;
+    let mut skipped = 0u64;
+
+    for file_entry in &files {
+        let path = file_entry.path();
+        eprintln!("Reading {}...", path.display());
+        let content = fs::read_to_string(&path).map_err(DictSourceError::Io)?;
+
+        for line in content.lines() {
+            total_lines += 1;
+            if line.is_empty() || line.starts_with('#') {
+                skipped += 1;
+                continue;
+            }
+
+            let fields: Vec<&str> = line.split(delimiter).collect();
+            let Some(parsed) = parse_line(&fields) else {
+                skipped += 1;
+                continue;
+            };
+
+            entries.entry(parsed.reading).or_default().push(DictEntry {
+                surface: parsed.surface,
+                cost: parsed.cost,
+                left_id: parsed.left_id,
+                right_id: parsed.right_id,
+            });
+        }
+    }
+
+    eprintln!("  (skipped {skipped} of {total_lines} lines)");
+    Ok(entries)
+}
+
 /// Create a `DictSource` by name. Returns `None` for unknown source names.
 pub fn from_name(name: &str) -> Option<Box<dyn DictSource>> {
     match name {


### PR DESCRIPTION
## Summary
- Extract shared `ParsedLine` struct and `parse_dict_files()` helper into `dict/source/mod.rs`
- Replace duplicated boilerplate in `MozcSource::parse_dir` and `SudachiSource::parse_dir` with calls to the shared helper
- Each source now only provides a format-specific closure for field extraction (Mozc: tab-delimited, 5+ fields; Sudachi: comma-delimited, 12+ fields with kata→hira conversion)

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 114 tests pass (including `test_parse_mozc_tsv`, `test_parse_sudachi_csv`, empty dir tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)