### PR TITLE
refactor: consolidate global state into AppContext singleton

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+class AppContext {
+    static let shared = AppContext()
+
+    let dict: OpaquePointer?
+    let conn: OpaquePointer?
+    let history: OpaquePointer?
+    let historyPath: String
+    let candidatePanel = CandidatePanel()
+
+    private init() {
+        guard let resourcePath = Bundle.main.resourcePath else {
+            fatalError("Lexime: Bundle.main.resourcePath is nil")
+        }
+
+        let dictSource = UserDefaults.standard.string(forKey: "dictSource") ?? "merged"
+        NSLog("Lexime: dictSource = %@", dictSource)
+
+        // Load dictionary
+        let dictPath = resourcePath + "/lexime-\(dictSource).dict"
+        if let d = lex_dict_open(dictPath) {
+            NSLog("Lexime: Dictionary loaded from %@", dictPath)
+            let list = lex_dict_lookup(d, "かんじ")
+            NSLog("Lexime: Sample lookup 'かんじ' → %d candidates", list.len)
+            lex_candidates_free(list)
+            self.dict = d
+        } else {
+            NSLog("Lexime: Failed to load dictionary at %@", dictPath)
+            self.dict = nil
+        }
+
+        // Load connection matrix (optional — falls back to unigram if not found)
+        let connPath = resourcePath + "/lexime-\(dictSource).conn"
+        if let c = lex_conn_open(connPath) {
+            NSLog("Lexime: Connection matrix loaded from %@", connPath)
+            self.conn = c
+        } else {
+            NSLog("Lexime: Connection matrix not found at %@ (using unigram fallback)", connPath)
+            self.conn = nil
+        }
+
+        // Load user history (learning data)
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask).first!
+        self.historyPath = appSupport.appendingPathComponent("Lexime/user_history.lxud").path
+
+        if let h = lex_history_open(self.historyPath) {
+            NSLog("Lexime: User history loaded from %@", self.historyPath)
+            self.history = h
+        } else {
+            NSLog("Lexime: Failed to open user history at %@", self.historyPath)
+            self.history = nil
+        }
+    }
+}

--- a/Sources/DictBridge.swift
+++ b/Sources/DictBridge.swift
@@ -3,9 +3,9 @@ import Foundation
 extension LeximeInputController {
 
     func lookupCandidates(_ kana: String) -> [String] {
-        guard let dict = sharedDict else { return [] }
+        guard let dict = AppContext.shared.dict else { return [] }
         let list: LexCandidateList
-        if let history = sharedHistory {
+        if let history = AppContext.shared.history {
             list = lex_dict_lookup_with_history(dict, history, kana)
         } else {
             list = lex_dict_lookup(dict, kana)
@@ -23,8 +23,8 @@ extension LeximeInputController {
     }
 
     func predictCandidates(_ kana: String) -> [String] {
-        guard let dict = sharedDict, !kana.isEmpty else { return [] }
-        let list = lex_dict_predict_ranked(dict, sharedHistory, kana, 9)
+        guard let dict = AppContext.shared.dict, !kana.isEmpty else { return [] }
+        let list = lex_dict_predict_ranked(dict, AppContext.shared.history, kana, 9)
         defer { lex_candidates_free(list) }
 
         guard list.len > 0, let candidates = list.candidates else { return [] }
@@ -45,13 +45,13 @@ extension LeximeInputController {
     /// (no per-segment dictionary lookup).  Candidates are loaded lazily via
     /// `ensureCandidatesLoaded(segmentIndex:)` when the user enters multi-segment mode.
     func convertKana(_ kana: String) -> [ConversionSegment] {
-        guard let dict = sharedDict else { return [] }
+        guard let dict = AppContext.shared.dict else { return [] }
 
         let result: LexConversionResult
-        if let history = sharedHistory {
-            result = lex_convert_with_history(dict, sharedConn, history, kana)
+        if let history = AppContext.shared.history {
+            result = lex_convert_with_history(dict, AppContext.shared.conn, history, kana)
         } else {
-            result = lex_convert(dict, sharedConn, kana)
+            result = lex_convert(dict, AppContext.shared.conn, kana)
         }
         defer { lex_conversion_free(result) }
 
@@ -78,13 +78,13 @@ extension LeximeInputController {
     func convertKanaCombined(_ kana: String, n: Int = 5)
         -> (segments: [ConversionSegment], nbestSurfaces: [String])
     {
-        guard let dict = sharedDict, !kana.isEmpty else { return ([], []) }
+        guard let dict = AppContext.shared.dict, !kana.isEmpty else { return ([], []) }
 
         let list: LexConversionResultList
-        if let history = sharedHistory {
-            list = lex_convert_nbest_with_history(dict, sharedConn, history, kana, UInt32(n))
+        if let history = AppContext.shared.history {
+            list = lex_convert_nbest_with_history(dict, AppContext.shared.conn, history, kana, UInt32(n))
         } else {
-            list = lex_convert_nbest(dict, sharedConn, kana, UInt32(n))
+            list = lex_convert_nbest(dict, AppContext.shared.conn, kana, UInt32(n))
         }
         defer { lex_conversion_result_list_free(list) }
 

--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -100,7 +100,7 @@ extension LeximeInputController {
                 showCandidatePanel(client: client)
                 return true
             }
-            if sharedDict == nil {
+            if AppContext.shared.dict == nil {
                 hideCandidatePanel()
                 flush()
                 commitComposed(client: client)

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -43,7 +43,7 @@ class LeximeInputController: IMKInputController {
         super.init(server: server, delegate: delegate, client: inputClient)
         let version = String(cString: lex_engine_version())
         NSLog("Lexime: InputController initialized (engine: %@)", version)
-        if sharedDict == nil && !Self.hasShownDictWarning {
+        if AppContext.shared.dict == nil && !Self.hasShownDictWarning {
             Self.hasShownDictWarning = true
             NSLog("Lexime: WARNING - dictionary not loaded. Conversion is unavailable.")
         }
@@ -88,11 +88,11 @@ class LeximeInputController: IMKInputController {
         let pageSelectedIndex = selectedIndex - pageStart
 
         let rect = cursorRect(client: client)
-        sharedCandidatePanel.show(candidates: pageCandidates, selectedIndex: pageSelectedIndex, cursorRect: rect)
+        AppContext.shared.candidatePanel.show(candidates: pageCandidates, selectedIndex: pageSelectedIndex, cursorRect: rect)
     }
 
     func hideCandidatePanel() {
-        sharedCandidatePanel.hide()
+        AppContext.shared.candidatePanel.hide()
     }
 
     // MARK: - Key Handling
@@ -273,7 +273,7 @@ class LeximeInputController: IMKInputController {
     private static let historySaveQueue = DispatchQueue(label: "sh.send.lexime.history-save")
 
     private func recordToHistory() {
-        guard let history = sharedHistory else { return }
+        guard let history = AppContext.shared.history else { return }
 
         // strdup ensures C string pointers remain valid independent of Swift string lifetimes
         var cStrings: [UnsafeMutablePointer<CChar>] = []
@@ -292,7 +292,7 @@ class LeximeInputController: IMKInputController {
         }
 
         // Save asynchronously to avoid blocking key handling
-        let path = userHistoryPath
+        let path = AppContext.shared.historyPath
         Self.historySaveQueue.async {
             let result = lex_history_save(history, path)
             if result != 0 {

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -3,65 +3,13 @@ import InputMethodKit
 
 let kConnectionName = "sh.send.inputmethod.Lexime_Connection"
 
-guard let resourcePath = Bundle.main.resourcePath else {
-    NSLog("Lexime: Bundle.main.resourcePath is nil")
-    exit(1)
-}
+// Initialize shared app context (loads dictionary, connection matrix, user history)
+_ = AppContext.shared
 
 guard let bundleId = Bundle.main.bundleIdentifier else {
     NSLog("Lexime: Bundle.main.bundleIdentifier is nil")
     exit(1)
 }
-
-// Dictionary source selection via `defaults write sh.send.inputmethod.Lexime dictSource merged|mozc|sudachi`
-let dictSource: String = {
-    let source = UserDefaults.standard.string(forKey: "dictSource") ?? "merged"
-    NSLog("Lexime: dictSource = %@", source)
-    return source
-}()
-
-// Load dictionary once at startup
-let sharedDict: OpaquePointer? = {
-    let dictPath = resourcePath + "/lexime-\(dictSource).dict"
-    guard let dict = lex_dict_open(dictPath) else {
-        NSLog("Lexime: Failed to load dictionary at %@", dictPath)
-        return nil
-    }
-    NSLog("Lexime: Dictionary loaded from %@", dictPath)
-
-    // Verify with a sample lookup
-    let list = lex_dict_lookup(dict, "かんじ")
-    NSLog("Lexime: Sample lookup 'かんじ' → %d candidates", list.len)
-    lex_candidates_free(list)
-
-    return dict
-}()
-
-// Load connection matrix (optional — falls back to unigram if not found)
-let sharedConn: OpaquePointer? = {
-    let connPath = resourcePath + "/lexime-\(dictSource).conn"
-    guard let conn = lex_conn_open(connPath) else {
-        NSLog("Lexime: Connection matrix not found at %@ (using unigram fallback)", connPath)
-        return nil
-    }
-    NSLog("Lexime: Connection matrix loaded from %@", connPath)
-    return conn
-}()
-
-// Load user history (learning data)
-let userHistoryPath: String = {
-    let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    return appSupport.appendingPathComponent("Lexime/user_history.lxud").path
-}()
-
-let sharedHistory: OpaquePointer? = {
-    guard let history = lex_history_open(userHistoryPath) else {
-        NSLog("Lexime: Failed to open user history at %@", userHistoryPath)
-        return nil
-    }
-    NSLog("Lexime: User history loaded from %@", userHistoryPath)
-    return history
-}()
 
 guard let server = IMKServer(name: kConnectionName, bundleIdentifier: bundleId) else {
     NSLog("Lexime: Failed to create IMKServer")
@@ -69,8 +17,6 @@ guard let server = IMKServer(name: kConnectionName, bundleIdentifier: bundleId) 
 }
 
 NSLog("Lexime: IMKServer started (connection: %@)", kConnectionName)
-
-let sharedCandidatePanel = CandidatePanel()
 
 _ = server  // keep the server alive
 


### PR DESCRIPTION
## Summary
- New `AppContext` class consolidates `sharedDict`, `sharedConn`, `sharedHistory`, `userHistoryPath`, and `sharedCandidatePanel` into a single singleton (`AppContext.shared`)
- `main.swift` reduced from 77 lines to 23 lines — just triggers `AppContext.shared` init, creates `IMKServer`, and runs `NSApplication`
- All references in `DictBridge.swift`, `LeximeInputController.swift`, and `KeyHandlers.swift` updated to use `AppContext.shared.*`

## Test plan
- [x] `mise run build` succeeds
- [x] 36 Swift tests pass (`mise run test-swift`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)