### PR TITLE
fix: strengthen user history candidate ranking

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -386,7 +386,7 @@ pub extern "C" fn lex_dict_predict_ranked(
     let fetch_limit = if history.is_null() {
         max_results as usize
     } else {
-        (max_results as usize).max(50)
+        (max_results as usize).max(200)
     };
     let mut ranked = dict.predict_ranked(prefix_str, fetch_limit, 1000);
 

--- a/engine/src/user_history/mod.rs
+++ b/engine/src/user_history/mod.rs
@@ -15,8 +15,8 @@ const MAGIC: &[u8; 4] = b"LXUD";
 const VERSION: u8 = 1;
 const MAX_UNIGRAMS: usize = 10_000;
 const MAX_BIGRAMS: usize = 10_000;
-const BOOST_PER_USE: i64 = 500;
-const MAX_BOOST: i64 = 5000;
+const BOOST_PER_USE: i64 = 1500;
+const MAX_BOOST: i64 = 10000;
 const HALF_LIFE_HOURS: f64 = 168.0;
 
 pub struct UserHistory {


### PR DESCRIPTION
## Summary
- ブースト定数を引き上げ (`BOOST_PER_USE`: 500→1500, `MAX_BOOST`: 5000→10000) — 少ない使用回数で履歴候補が上位に来るように
- 予測候補の over-fetch を拡大 (50→200) — ブーストのある低頻度候補が取得漏れしないように
- 予測表示済みテキストと変換1位が同じ場合にスキップし、Spaceで常に視覚的に候補が進むように

## Test plan
- [x] `cargo test` — 全114テスト通過
- [x] `mise run build && mise run install && mise run reload`
- [x] 手動テスト: 同音異義語で確定後、再変換時に履歴候補が上位に来ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)