### PR TITLE
refactor: unify dictionary to single merged dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,6 @@ mise run install
 | `z/` | ・ | `z-` | 〜 |
 | `z[` | 『 | `z]` | 』 |
 
-### 辞書ソース切り替え
-
-統合辞書（Mozc + SudachiDict）をデフォルトで使用。`defaults write` で個別辞書にも切り替え可能。
-
-```sh
-# Mozc 単体に切り替え
-defaults write sh.send.inputmethod.Lexime dictSource mozc
-mise run reload
-
-# 統合辞書に戻す
-defaults write sh.send.inputmethod.Lexime dictSource merged
-mise run reload
-```
-
 ### プログラマモード
 
 JIS キーボードの ¥ キーでバックスラッシュ `\` を入力するモード。

--- a/SPEC.md
+++ b/SPEC.md
@@ -59,19 +59,12 @@ PRIME にインスパイアされた予測変換型の入力体験を、軽量�
 
 ### 辞書データ
 
-ビルド時にソースごとの辞書ファイルを生成し、ランタイムで切り替え可能:
-
-| ソース | 辞書 | 接続行列 |
-|---|---|---|
-| Merged（デフォルト） | `lexime-merged.dict` | `lexime-merged.conn`（= Mozc） |
-| Mozc | `lexime-mozc.dict` | `lexime-mozc.conn` |
-| SudachiDict | `lexime-sudachi.dict` | `lexime-sudachi.conn` |
+統合辞書（Mozc + SudachiDict Full）のみを使用。ファイル名は `lexime.dict` / `lexime.conn`。
 
 - **辞書**: TSV/CSV → `TrieDictionary`（bincode シリアライズ、マジック `LXDC`）
 - **接続行列**: バイナリ行列（マジック `LXCX`、i16 配列）
 - POS ID ペアの遷移コストを O(1) で参照
 - **統合辞書**: Mozc + SudachiDict Full を merge。Sudachi エントリは `pos_map` で Mozc の POS ID 体系にリマップし、Mozc の接続行列で統一的に動作
-- **ソース選択**: `UserDefaults` の `dictSource` キー（デフォルト: `merged`）で起動時に決定
 
 ### FFI (C ABI)
 
@@ -294,14 +287,11 @@ macOS で動作する最小限の IME を構築。
 | `fetch-dict-sudachi` | SudachiDict データのダウンロード |
 | `fetch-dict-sudachi-full` | SudachiDict Full データのダウンロード（core + notcore） |
 | `fetch-dict-mozc` | Mozc 辞書データのダウンロード |
-| `dict-sudachi` | SudachiDict 辞書バイナリのコンパイル |
 | `dict-sudachi-full` | SudachiDict Full 辞書のコンパイル（Mozc POS ID にリマップ） |
 | `dict-mozc` | Mozc 辞書バイナリのコンパイル |
-| `dict-merged` | Mozc + SudachiDict Full の統合辞書（フィルタ付き merge） |
-| `conn-sudachi` | SudachiDict 接続行列のコンパイル |
-| `conn-mozc` | Mozc 接続行列のコンパイル |
-| `conn-merged` | 統合辞書用接続行列（= Mozc conn のコピー） |
-| `build` | Lexime.app ユニバーサルバイナリのビルド（depends: dict-merged, conn-merged） |
+| `dict` | Mozc + SudachiDict Full の統合辞書（フィルタ付き merge） |
+| `conn` | Mozc 接続行列のコンパイル |
+| `build` | Lexime.app ユニバーサルバイナリのビルド（depends: dict, conn） |
 | `install` | `~/Library/Input Methods` へコピー |
 | `reload` | Lexime プロセスを再起動 |
 | `log` | ログストリーミング |

--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -14,11 +14,8 @@ class AppContext {
             fatalError("Lexime: Bundle.main.resourcePath is nil")
         }
 
-        let dictSource = UserDefaults.standard.string(forKey: "dictSource") ?? "merged"
-        NSLog("Lexime: dictSource = %@", dictSource)
-
         // Load dictionary
-        let dictPath = resourcePath + "/lexime-\(dictSource).dict"
+        let dictPath = resourcePath + "/lexime.dict"
         if let d = lex_dict_open(dictPath) {
             NSLog("Lexime: Dictionary loaded from %@", dictPath)
             let list = lex_dict_lookup(d, "かんじ")
@@ -31,7 +28,7 @@ class AppContext {
         }
 
         // Load connection matrix (optional — falls back to unigram if not found)
-        let connPath = resourcePath + "/lexime-\(dictSource).conn"
+        let connPath = resourcePath + "/lexime.conn"
         if let c = lex_conn_open(connPath) {
             NSLog("Lexime: Connection matrix loaded from %@", connPath)
             self.conn = c

--- a/engine/examples/debug_convert.rs
+++ b/engine/examples/debug_convert.rs
@@ -6,8 +6,8 @@ use lex_engine::dict::connection::ConnectionMatrix;
 use lex_engine::dict::{Dictionary, TrieDictionary};
 
 fn main() {
-    let dict = TrieDictionary::open(Path::new("data/lexime-sudachi.dict")).expect("dict");
-    let conn = ConnectionMatrix::open(Path::new("data/lexime-sudachi.conn")).expect("conn");
+    let dict = TrieDictionary::open(Path::new("data/lexime.dict")).expect("dict");
+    let conn = ConnectionMatrix::open(Path::new("data/lexime.conn")).expect("conn");
 
     let input = "けんとうしたいです";
 

--- a/mise.toml
+++ b/mise.toml
@@ -28,19 +28,6 @@ sources = ["engine/src/bin/dictool.rs", "engine/src/dict/source/mozc.rs"]
 outputs = ["engine/data/mozc-raw/.stamp"]
 run = "cd engine && cargo run --bin dictool -- fetch --source mozc data/mozc-raw"
 
-[tasks.dict-sudachi]
-description = "Compile binary dictionary from SudachiDict"
-depends = ["fetch-dict-sudachi"]
-sources = ["engine/data/sudachi-raw/.stamp"]
-outputs = ["engine/data/lexime-sudachi.dict"]
-run = """
-#!/usr/bin/env bash
-set -euo pipefail
-cd engine
-cargo build --release --bin dictool
-target/release/dictool compile --source sudachi data/sudachi-raw data/lexime-sudachi.dict
-"""
-
 [tasks.dict-mozc]
 description = "Compile binary dictionary from Mozc"
 depends = ["fetch-dict-mozc"]
@@ -54,30 +41,17 @@ cargo build --release --bin dictool
 target/release/dictool compile --source mozc data/mozc-raw data/lexime-mozc.dict
 """
 
-[tasks.conn-sudachi]
-description = "Compile SudachiDict connection cost matrix"
-depends = ["fetch-dict-sudachi"]
-sources = ["engine/data/sudachi-raw/matrix.def"]
-outputs = ["engine/data/lexime-sudachi.conn"]
-run = """
-#!/usr/bin/env bash
-set -euo pipefail
-cd engine
-cargo build --release --bin dictool
-target/release/dictool compile-conn data/sudachi-raw/matrix.def data/lexime-sudachi.conn
-"""
-
-[tasks.conn-mozc]
+[tasks.conn]
 description = "Compile Mozc connection cost matrix"
 depends = ["fetch-dict-mozc"]
 sources = ["engine/data/mozc-raw/connection_single_column.txt"]
-outputs = ["engine/data/lexime-mozc.conn"]
+outputs = ["engine/data/lexime.conn"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 cd engine
 cargo build --release --bin dictool
-target/release/dictool compile-conn data/mozc-raw/connection_single_column.txt data/lexime-mozc.conn
+target/release/dictool compile-conn data/mozc-raw/connection_single_column.txt data/lexime.conn
 """
 
 [tasks.fetch-dict-sudachi-full]
@@ -101,32 +75,26 @@ target/release/dictool compile --source sudachi --remap-ids data/mozc-raw/id.def
   data/sudachi-full-raw data/lexime-sudachi-full.dict
 """
 
-[tasks.dict-merged]
+[tasks.dict]
 description = "Merge Mozc + SudachiDict full into filtered dictionary"
 depends = ["dict-mozc", "dict-sudachi-full"]
-outputs = ["engine/data/lexime-merged.dict"]
+outputs = ["engine/data/lexime.dict"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 cd engine
 cargo build --release --bin dictool
-target/release/dictool merge --max-cost 15000 --max-reading-len 15 data/lexime-mozc.dict data/lexime-sudachi-full.dict data/lexime-merged.dict
+target/release/dictool merge --max-cost 15000 --max-reading-len 15 data/lexime-mozc.dict data/lexime-sudachi-full.dict data/lexime.dict
 """
-
-[tasks.conn-merged]
-description = "Copy Mozc connection matrix for merged dictionary"
-depends = ["conn-mozc"]
-outputs = ["engine/data/lexime-merged.conn"]
-run = "cp engine/data/lexime-mozc.conn engine/data/lexime-merged.conn"
 
 [tasks.build]
 description = "Build Lexime.app (universal binary)"
-depends = ["engine-lib", "dict-merged", "conn-merged"]
+depends = ["engine-lib", "dict", "conn"]
 sources = [
   "Sources/*.swift",
   "build/liblex_engine.a",
-  "engine/data/lexime-*.dict",
-  "engine/data/lexime-*.conn",
+  "engine/data/lexime.dict",
+  "engine/data/lexime.conn",
   "Info.plist",
   "Resources/icon.tiff",
   "Resources/en.lproj/InfoPlist.strings",
@@ -154,10 +122,8 @@ cp Info.plist "$APP/Contents/Info.plist"
 cp Resources/icon.tiff "$RES/icon.tiff"
 cp -R Resources/en.lproj "$RES/en.lproj"
 cp -R Resources/ja.lproj "$RES/ja.lproj"
-# Copy all available dictionary files (sudachi is always built; mozc is optional)
-for f in engine/data/lexime-*.dict engine/data/lexime-*.conn; do
-  [ -f "$f" ] && cp "$f" "$RES/"
-done
+cp engine/data/lexime.dict "$RES/"
+cp engine/data/lexime.conn "$RES/"
 codesign -f -s - "$APP"
 echo "Build complete: $APP"
 """


### PR DESCRIPTION
## Summary

- Remove dict source switching (`UserDefaults` `dictSource`) — always use merged dictionary
- Simplify file names: `lexime-merged.dict/conn` → `lexime.dict/conn`
- Rename mise tasks: `dict-merged` → `dict`, `conn-mozc` → `conn`
- Remove unused tasks: `dict-sudachi`, `conn-sudachi`, `conn-merged`
- Update docs (README, SPEC) to reflect single-dict architecture

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — all 114 tests pass
- [x] `mise run build && mise run install && mise run reload` — successful
- [x] `mise run log` — confirms `lexime.dict` / `lexime.conn` loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)