### PR TITLE
refactor: move script_cost from Viterbi to reranker

### DIFF
--- a/engine/src/converter/cost.rs
+++ b/engine/src/converter/cost.rs
@@ -81,7 +81,7 @@ impl<'a> DefaultCostFunction<'a> {
 
 impl CostFunction for DefaultCostFunction<'_> {
     fn word_cost(&self, node: &LatticeNode) -> i64 {
-        node.cost as i64 + SEGMENT_PENALTY + script_cost(&node.surface)
+        node.cost as i64 + SEGMENT_PENALTY
     }
 
     fn transition_cost(&self, prev: &LatticeNode, next: &LatticeNode) -> i64 {

--- a/engine/src/user_history/cost.rs
+++ b/engine/src/user_history/cost.rs
@@ -1,4 +1,4 @@
-use crate::converter::cost::{conn_cost, script_cost, CostFunction, SEGMENT_PENALTY};
+use crate::converter::cost::{conn_cost, CostFunction, SEGMENT_PENALTY};
 use crate::converter::LatticeNode;
 use crate::dict::connection::ConnectionMatrix;
 
@@ -18,7 +18,7 @@ impl<'a> LearnedCostFunction<'a> {
 
 impl CostFunction for LearnedCostFunction<'_> {
     fn word_cost(&self, node: &LatticeNode) -> i64 {
-        node.cost as i64 + SEGMENT_PENALTY + script_cost(&node.surface)
+        node.cost as i64 + SEGMENT_PENALTY
             - self.history.unigram_boost(&node.reading, &node.surface)
     }
 


### PR DESCRIPTION
## Summary

- Removed `script_cost` from `DefaultCostFunction::word_cost()` and `LearnedCostFunction::word_cost()` in Viterbi
- Added per-segment `script_cost` application in `reranker::rerank()`, preserving the same ranking behavior on complete paths
- `SEGMENT_PENALTY` remains in Viterbi (search-quality parameter that prevents N-best fragmentation)

## Test plan

- [x] All 116 existing tests pass (`cargo test`)
- [x] New `test_rerank_applies_script_cost` verifies katakana penalty in reranker
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean
- [x] Manual test: 「きょうはいいてんき」→「今日はいい天気」OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)