### PR TITLE
feat: skip unigram_boost for function words

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -565,7 +565,7 @@ pub extern "C" fn lex_convert_nbest_with_history(
         return LexConversionResultList::empty();
     };
 
-    let cost_fn = LearnedCostFunction::new(conn, &h);
+    let cost_fn = LearnedCostFunction::new(conn, Some(dict), &h);
     pack_conversion_result_list(convert_nbest_with_cost(
         dict, &cost_fn, conn, kana_str, n as usize,
     ))
@@ -670,7 +670,7 @@ pub extern "C" fn lex_convert_with_history(
         return LexConversionResult::empty();
     };
 
-    let cost_fn = LearnedCostFunction::new(conn, &h);
+    let cost_fn = LearnedCostFunction::new(conn, Some(dict), &h);
     pack_conversion_result(convert_with_cost(dict, &cost_fn, conn, kana_str))
 }
 

--- a/engine/src/user_history/cost.rs
+++ b/engine/src/user_history/cost.rs
@@ -1,25 +1,58 @@
 use crate::converter::cost::{conn_cost, CostFunction, SEGMENT_PENALTY};
 use crate::converter::LatticeNode;
 use crate::dict::connection::ConnectionMatrix;
+use crate::dict::Dictionary;
 
 use super::UserHistory;
 
 /// Cost function that incorporates user history for adaptive ranking.
 pub struct LearnedCostFunction<'a> {
     conn: Option<&'a ConnectionMatrix>,
+    dict: Option<&'a dyn Dictionary>,
     history: &'a UserHistory,
 }
 
 impl<'a> LearnedCostFunction<'a> {
-    pub fn new(conn: Option<&'a ConnectionMatrix>, history: &'a UserHistory) -> Self {
-        Self { conn, history }
+    pub fn new(
+        conn: Option<&'a ConnectionMatrix>,
+        dict: Option<&'a dyn Dictionary>,
+        history: &'a UserHistory,
+    ) -> Self {
+        Self {
+            conn,
+            dict,
+            history,
+        }
+    }
+
+    /// Check whether (reading, surface) has any dictionary entry with a
+    /// function-word POS ID. This ensures that surfaces like "し" which
+    /// appear as both 助動詞 (L=96) and 動詞 (L=537) are treated as
+    /// function words for boost purposes.
+    fn is_function_word_surface(&self, reading: &str, surface: &str) -> bool {
+        let Some(conn) = self.conn else {
+            return false;
+        };
+        let Some(dict) = self.dict else {
+            return conn.is_function_word(0); // unreachable in practice
+        };
+        let Some(entries) = dict.lookup(reading) else {
+            return false;
+        };
+        entries
+            .iter()
+            .any(|e| e.surface == surface && conn.is_function_word(e.left_id))
     }
 }
 
 impl CostFunction for LearnedCostFunction<'_> {
     fn word_cost(&self, node: &LatticeNode) -> i64 {
-        node.cost as i64 + SEGMENT_PENALTY
-            - self.history.unigram_boost(&node.reading, &node.surface)
+        let boost = if self.is_function_word_surface(&node.reading, &node.surface) {
+            0
+        } else {
+            self.history.unigram_boost(&node.reading, &node.surface)
+        };
+        node.cost as i64 + SEGMENT_PENALTY - boost
     }
 
     fn transition_cost(&self, prev: &LatticeNode, next: &LatticeNode) -> i64 {
@@ -50,7 +83,7 @@ mod tests {
         let mut history = UserHistory::new();
 
         // Without history: "今日" has cost 3000, "京" has cost 5000
-        let default_cost_fn = LearnedCostFunction::new(None, &history);
+        let default_cost_fn = LearnedCostFunction::new(None, None, &history);
         let result = convert_with_cost(&dict, &default_cost_fn, None, "きょう");
         assert_eq!(result[0].surface, "今日");
 
@@ -59,7 +92,7 @@ mod tests {
             history.record(&[("きょう".into(), "京".into())]);
         }
 
-        let learned_cost_fn = LearnedCostFunction::new(None, &history);
+        let learned_cost_fn = LearnedCostFunction::new(None, None, &history);
         let node_kyou = LatticeNode {
             start: 0,
             end: 3,
@@ -87,7 +120,7 @@ mod tests {
         let mut history = UserHistory::new();
         history.record(&[("きょう".into(), "今日".into()), ("は".into(), "は".into())]);
 
-        let learned_cost_fn = LearnedCostFunction::new(None, &history);
+        let learned_cost_fn = LearnedCostFunction::new(None, None, &history);
         let prev = LatticeNode {
             start: 0,
             end: 3,
@@ -111,6 +144,64 @@ mod tests {
     }
 
     #[test]
+    fn test_function_word_no_boost() {
+        use crate::dict::{DictEntry, TrieDictionary};
+
+        let mut history = UserHistory::new();
+        // Record "し" many times
+        for _ in 0..10 {
+            history.record(&[("し".into(), "し".into())]);
+        }
+
+        // fw range 100..=500; "し" has both fw entry (L=300) and non-fw (L=600)
+        let text = "2 2\n0\n0\n0\n0\n";
+        let conn = ConnectionMatrix::from_text_with_metadata(text, 100, 500).unwrap();
+
+        // Dict: "し"/"し" has a function-word entry (L=300, in range)
+        // and a non-function-word entry (L=600, out of range)
+        let dict = TrieDictionary::from_entries(
+            [(
+                "し".to_string(),
+                vec![
+                    DictEntry {
+                        surface: "し".into(),
+                        cost: 0,
+                        left_id: 300, // in fw range
+                        right_id: 300,
+                    },
+                    DictEntry {
+                        surface: "し".into(),
+                        cost: 0,
+                        left_id: 600, // NOT in fw range
+                        right_id: 600,
+                    },
+                ],
+            )]
+            .into_iter(),
+        );
+
+        let cost_fn = LearnedCostFunction::new(Some(&conn), Some(&dict), &history);
+
+        // Even the non-fw node (L=600) should NOT get boost because
+        // the same (reading, surface) has a fw entry in the dict
+        let non_fw_node = LatticeNode {
+            start: 0,
+            end: 1,
+            reading: "し".into(),
+            surface: "し".into(),
+            cost: 2000,
+            left_id: 600, // outside fw range
+            right_id: 600,
+        };
+        let expected_no_boost = 2000 + SEGMENT_PENALTY;
+        assert_eq!(
+            cost_fn.word_cost(&non_fw_node),
+            expected_no_boost,
+            "node sharing (reading, surface) with a fw entry should get no boost"
+        );
+    }
+
+    #[test]
     fn test_viterbi_with_history() {
         let dict = test_dict();
         let mut history = UserHistory::new();
@@ -121,7 +212,7 @@ mod tests {
             history.record(&[("きょう".into(), "京".into())]);
         }
 
-        let cost_fn = LearnedCostFunction::new(None, &history);
+        let cost_fn = LearnedCostFunction::new(None, None, &history);
         let result = convert_with_cost(&dict, &cost_fn, None, "きょう");
         assert_eq!(result[0].surface, "京");
     }

--- a/mise.toml
+++ b/mise.toml
@@ -44,14 +44,16 @@ target/release/dictool compile --source mozc data/mozc-raw data/lexime-mozc.dict
 [tasks.conn]
 description = "Compile Mozc connection cost matrix"
 depends = ["fetch-dict-mozc"]
-sources = ["engine/data/mozc-raw/connection_single_column.txt"]
+sources = ["engine/data/mozc-raw/connection_single_column.txt", "engine/data/mozc-raw/id.def"]
 outputs = ["engine/data/lexime.conn"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 cd engine
 cargo build --release --bin dictool
-target/release/dictool compile-conn data/mozc-raw/connection_single_column.txt data/lexime.conn
+target/release/dictool compile-conn \
+  --id-def data/mozc-raw/id.def \
+  data/mozc-raw/connection_single_column.txt data/lexime.conn
 """
 
 [tasks.fetch-dict-sudachi-full]


### PR DESCRIPTION
## Summary

- 機能語（助詞・助動詞）に対する `unigram_boost` をスキップし、`の|鼓|し|て` のような断片化パスが `残し|て` に勝つ問題を修正
- ConnectionMatrix V2 フォーマットに機能語 ID 範囲 (fw_min/fw_max) を埋め込み、`id.def` からビルド時に抽出
- 辞書ベースの判定: 同一 (reading, surface) に機能語 POS エントリが1つでもあれば、全エントリで boost をスキップ（「し」が助動詞 L=96 と動詞 L=537 の両方を持つケースに対応）
- dictool に `lookup`, `prefix`, `convert` サブコマンドを追加

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 全 123 テスト pass
- [x] `dictool convert "のこして" --history` で「残して」が1位を確認
- [x] `mise run build && mise run install && mise run reload` で IME 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)