### PR TITLE
refactor: move user history learning to post-Viterbi reranker

### DIFF
--- a/engine/src/converter/mod.rs
+++ b/engine/src/converter/mod.rs
@@ -8,5 +8,6 @@ mod viterbi;
 pub use cost::CostFunction;
 pub use lattice::{build_lattice, Lattice, LatticeNode};
 pub use viterbi::{
-    convert, convert_nbest, convert_nbest_with_cost, convert_with_cost, ConvertedSegment,
+    convert, convert_nbest, convert_nbest_with_cost, convert_nbest_with_history, convert_with_cost,
+    convert_with_history, ConvertedSegment,
 };

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -12,10 +12,9 @@ use std::path::Path;
 use std::ptr;
 use std::sync::RwLock;
 
-use converter::{convert, convert_nbest, convert_nbest_with_cost, convert_with_cost};
+use converter::{convert, convert_nbest, convert_nbest_with_history, convert_with_history};
 use dict::connection::ConnectionMatrix;
 use dict::{Dictionary, TrieDictionary};
-use user_history::cost::LearnedCostFunction;
 use user_history::UserHistory;
 
 // --- Generic owned-pointer helpers for FFI resource management ---
@@ -565,9 +564,8 @@ pub extern "C" fn lex_convert_nbest_with_history(
         return LexConversionResultList::empty();
     };
 
-    let cost_fn = LearnedCostFunction::new(conn, Some(dict), &h);
-    pack_conversion_result_list(convert_nbest_with_cost(
-        dict, &cost_fn, conn, kana_str, n as usize,
+    pack_conversion_result_list(convert_nbest_with_history(
+        dict, conn, &h, kana_str, n as usize,
     ))
 }
 
@@ -670,8 +668,7 @@ pub extern "C" fn lex_convert_with_history(
         return LexConversionResult::empty();
     };
 
-    let cost_fn = LearnedCostFunction::new(conn, Some(dict), &h);
-    pack_conversion_result(convert_with_cost(dict, &cost_fn, conn, kana_str))
+    pack_conversion_result(convert_with_history(dict, conn, &h, kana_str))
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Summary
- LearnedCostFunction が Viterbi の word_cost/transition_cost に直接 boost を注入する方式を廃止
- 新しい `history_rerank()` で N-best パスを post-Viterbi で並べ替え、断片化問題をアーキテクチャレベルで解消
- FFI シグネチャは変更なし（Swift 側の変更不要）

## Pipeline (変更後)
```
lattice → viterbi_nbest(DefaultCostFunction, oversample)
        → rerank(structure/variance/script)
        → history_rerank(unigram/bigram boost)  ← NEW
        → take(n)
        → rewriters (katakana etc.)
        → output
```

## Test plan
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 138 tests pass
- [x] 基本変換:「きょうはいいてんき」→「今日はいい天気」
- [x] 学習:「きょう」で「京」を選択 → 次回「京」が上位
- [x] 断片化テスト:「のこして」→「残して」、「はなして」→ 許容範囲

🤖 Generated with [Claude Code](https://claude.com/claude-code)