### PR TITLE
feat: group morphemes into phrase-level segments

### DIFF
--- a/engine/src/converter/testutil.rs
+++ b/engine/src/converter/testutil.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use crate::dict::connection::ConnectionMatrix;
 use crate::dict::{DictEntry, TrieDictionary};
 
 /// Shared test dictionary for converter tests.
@@ -117,4 +118,11 @@ pub fn test_dict() -> TrieDictionary {
         ),
     ];
     TrieDictionary::from_entries(entries)
+}
+
+/// Create a zero-cost connection matrix with the given function-word ID range.
+pub fn zero_conn_with_fw(num_ids: u16, fw_min: u16, fw_max: u16) -> ConnectionMatrix {
+    let n = num_ids as usize;
+    let text = format!("{num_ids} {num_ids}\n{}", "0\n".repeat(n * n));
+    ConnectionMatrix::from_text_with_metadata(&text, fw_min, fw_max).unwrap()
 }


### PR DESCRIPTION
## Summary
- Group Viterbi morpheme-level output into phrase-level segments (content word + trailing function words) using `is_function_word()`
- Integrated into `postprocess()` pipeline after rewriters
- Added `zero_conn_with_fw()` test helper and 6 unit tests

## Test plan
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (143 passed)
- [x] Build, install, reload — verified "今日はいい天気ですね" converts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)