### PR TITLE
fix: deduplicate commit+learn pattern and improve user_history

### DIFF
--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -59,20 +59,7 @@ extension LeximeInputController {
     func handleComposing(keyCode: UInt16, text: String, client: IMKTextInput) -> Bool {
         switch keyCode {
         case Key.enter: // Enter — commit selected candidate with learning, or kana as-is
-            hideCandidatePanel()
-            let reading = composedKana
-            flush()
-            if !predictionCandidates.isEmpty {
-                let idx = min(selectedPredictionIndex,
-                              predictionCandidates.count - 1)
-                let surface = predictionCandidates[idx]
-                if surface != reading {
-                    recordToHistory(reading: reading, surface: surface)
-                }
-                commitText(surface, client: client)
-            } else {
-                commitComposed(client: client)
-            }
+            commitCurrentState(client: client)
             return true
 
         case Key.space: // Space — next candidate
@@ -155,12 +142,7 @@ extension LeximeInputController {
         if isRomajiInput(text) {
             if selectedPredictionIndex > 0,
                selectedPredictionIndex < predictionCandidates.count {
-                hideCandidatePanel()
-                let reading = composedKana
-                let surface = predictionCandidates[selectedPredictionIndex]
-                flush()
-                recordToHistory(reading: reading, surface: surface)
-                commitText(surface, client: client)
+                commitCurrentState(client: client)
                 state = .composing
             }
             appendAndConvert(text.lowercased(), client: client)
@@ -172,18 +154,7 @@ extension LeximeInputController {
         if !isRomajiInput(text) {
             switch lookupRomaji(text) {
             case .exact, .exactAndPrefix:
-                hideCandidatePanel()
-                if selectedPredictionIndex > 0,
-                   selectedPredictionIndex < predictionCandidates.count {
-                    let reading = composedKana
-                    let surface = predictionCandidates[selectedPredictionIndex]
-                    flush()
-                    recordToHistory(reading: reading, surface: surface)
-                    commitText(surface, client: client)
-                } else {
-                    flush()
-                    commitComposed(client: client)
-                }
+                commitCurrentState(client: client)
                 state = .composing
                 appendAndConvert(text, client: client)
                 return true


### PR DESCRIPTION
## Summary

- **KeyHandlers**: 3箇所の commit+学習パターンを `commitCurrentState()` に統一 (-56行)
- **bigram_boost**: `iter().find()` O(n) → `HashMap::get()` O(1)
- **evict**: unigram/bigram の退避処理をジェネリックな `evict_map()` に抽出

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings` pass
- [x] `cargo test` — 194 tests pass
- [ ] `mise run build && mise run install && mise run reload` — manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)