### PR TITLE
feat: real-time Viterbi display and punctuation auto-commit

### DIFF
--- a/Sources/MarkedTextManager.swift
+++ b/Sources/MarkedTextManager.swift
@@ -8,6 +8,7 @@ extension LeximeInputController {
     /// applying its own transformations (e.g. Shift-triggered katakana conversion).
     func updateMarkedText(_ display: String? = nil, client: IMKTextInput) {
         let text = display ?? (composedKana + pendingRomaji)
+        currentDisplay = text
         let len = text.utf16.count
         let attrs: [NSAttributedString.Key: Any] = [.markedClauseSegment: 0]
         let attrStr = NSAttributedString(string: text, attributes: attrs)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1490,9 +1490,16 @@ mod tests {
 
         unsafe {
             let surfaces = std::slice::from_raw_parts(resp.surfaces, resp.surfaces_len as usize);
-            // First candidate should be the reading itself (kana passthrough)
-            let s0 = CStr::from_ptr(surfaces[0]).to_str().unwrap();
-            assert_eq!(s0, "かんじ");
+            // First candidate is Viterbi #1 (conversion result); kana should also be present
+            let all: Vec<&str> = surfaces
+                .iter()
+                .map(|&p| CStr::from_ptr(p).to_str().unwrap())
+                .collect();
+            assert!(
+                all.contains(&"かんじ"),
+                "kana should be present in candidates: {:?}",
+                all,
+            );
         }
 
         lex_candidate_response_free(resp);


### PR DESCRIPTION
## Summary

- Show Viterbi #1 inline as marked text during typing (instead of kana)
- Reorder candidates: [Viterbi#1, kana, predictions, Viterbi#2+, lookup]
- Auto-commit current conversion on punctuation input + insert punctuation directly
- Track `currentDisplay` to keep `composedString` in sync with IMKit
- Update SPEC.md to reflect new key semantics and candidate ordering

## Key semantics

| Key | Behavior |
|---|---|
| Enter | 変換確定 (index 0 = Viterbi #1 も学習付き) |
| Escape | ひらがな確定 (IMKit の制約) |
| Tab | カタカナ確定 |
| Space | 候補切替 (index 1 から開始) |
| 句読点 | 変換確定 + 句読点直接挿入 |

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (194 passed)
- [x] Manual: `kyou` → marked text shows 「今日」(not きょう)
- [x] Manual: Space → cycles to kana then other candidates
- [x] Manual: Enter → commits Viterbi result with learning
- [x] Manual: `kyou.` → commits 「今日。」(punctuation auto-commit)
- [x] Manual: Escape → commits kana

🤖 Generated with [Claude Code](https://claude.com/claude-code)