### PR TITLE
fix: keep composing on unrecognized character instead of auto-committing

### DIFF
--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -172,9 +172,10 @@ extension LeximeInputController {
             }
         }
 
-        hideCandidatePanel()
-        flush()
-        commitComposed(client: client)
-        return false
+        // Unrecognized non-romaji character — add to composedKana so user can backspace.
+        composedKana.append(text)
+        updateMarkedText(client: client)
+        updateCandidates()
+        return true
     }
 }


### PR DESCRIPTION
## Summary

- Typing an unrecognized non-romaji character (e.g. `^`, `@`, `#`) during composing no longer auto-commits
- The character is added to `composedKana` so the user can Backspace to correct typos
- Example: `ko^` → marked text shows `こ^` → Backspace → `こ` → `-` → `こー`

## Test plan

- [x] Manual: `ko` then `^` → stays in composing, marked text includes `^`
- [x] Manual: Backspace removes `^`, continue typing normally
- [x] Manual: Punctuation auto-commit still works (`.` → `。`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)