### PR TITLE
docs: add unrecognized character behavior to SPEC

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -113,6 +113,7 @@ idle ──(ローマ字入力/句読点)──→ composing ──(Enter/Escape
 | Backspace | 1 文字削除（空になれば idle へ） |
 | Escape | ひらがなで確定（IMKit が commitComposition を呼ぶため） |
 | 句読点 | 現在の変換を確定し、句読点を直接挿入 |
+| その他の文字 | composedKana に追加（Backspace で削除可能） |
 
 **全状態共通（programmerMode）**
 


### PR DESCRIPTION
## Summary

- Add "その他の文字" row to composing key table in SPEC.md
- Documents that unrecognized characters are added to composedKana (backspace-recoverable), matching PR #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)