### PR TITLE
feat: learned kana promotion and segment auto-commit

### DIFF
--- a/Sources/KeyHandlers.swift
+++ b/Sources/KeyHandlers.swift
@@ -122,6 +122,10 @@ extension LeximeInputController {
 
         case Key.escape: // Escape — commit kana (IMKit forces commitComposition after Escape)
             hideCandidatePanel()
+            flush()
+            if !composedKana.isEmpty {
+                recordToHistory(reading: composedKana, surface: composedKana)
+            }
             predictionCandidates = []
             selectedPredictionIndex = 0
             return true

--- a/engine/src/converter/reranker.rs
+++ b/engine/src/converter/reranker.rs
@@ -339,7 +339,7 @@ mod tests {
     #[test]
     fn test_history_rerank_unigram_boost_reorders() {
         let mut h = UserHistory::new();
-        // Record twice to get 3000 boost (BOOST_PER_USE=1500 × 2), enough to
+        // Record twice to get 6000 boost (BOOST_PER_USE=3000 × 2), enough to
         // overcome the 2000 cost gap (5000 - 3000).
         h.record(&[("きょう".into(), "京".into())]);
         h.record(&[("きょう".into(), "京".into())]);

--- a/engine/src/user_history/mod.rs
+++ b/engine/src/user_history/mod.rs
@@ -12,8 +12,8 @@ const MAGIC: &[u8; 4] = b"LXUD";
 const VERSION: u8 = 1;
 const MAX_UNIGRAMS: usize = 10_000;
 const MAX_BIGRAMS: usize = 10_000;
-const BOOST_PER_USE: i64 = 1500;
-const MAX_BOOST: i64 = 10000;
+const BOOST_PER_USE: i64 = 3000;
+const MAX_BOOST: i64 = 15000;
 const HALF_LIFE_HOURS: f64 = 168.0;
 
 pub struct UserHistory {


### PR DESCRIPTION
## Summary
- Promote learned kana to position 0 (inline preview) so repeated hiragana selections become the default candidate
- Record kana to history on Escape commit and remove surface != reading guard to learn all selections
- Increase boost constants (BOOST_PER_USE=3000, MAX_BOOST=15000) for faster learning response
- Add segment-stability-based auto-commit: first Viterbi segment auto-commits when stable for 3 keystrokes and 4+ bunsetsu exist
- Move candidate generation to background queue for responsive input

## Test plan
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (196 passed)
- [x] Manual: type "doredore" repeatedly, confirm kana rises to position 0 after learning
- [x] Manual: type long sentence, confirm auto-commit fires after 4+ bunsetsu stabilize
- [x] Manual: short input (e.g., "kyou") does not auto-commit
- [x] Manual: Space candidate selection suppresses auto-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)