### PR TITLE
feat: add inline English submode with Tab toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
   swift:
     needs: changes
-    if: needs.changes.outputs.swift == 'true' || needs.changes.outputs.engine == 'true'
+    if: needs.changes.outputs.engine == 'true' && needs.changes.outputs.swift == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/Sources/InputState.swift
+++ b/Sources/InputState.swift
@@ -4,3 +4,8 @@ enum InputState {
     case idle
     case composing
 }
+
+enum InputSubmode {
+    case japanese   // romaji → kana conversion
+    case english    // characters added directly to composedKana
+}

--- a/Sources/MarkedTextManager.swift
+++ b/Sources/MarkedTextManager.swift
@@ -10,7 +10,10 @@ extension LeximeInputController {
         let text = display ?? (composedKana + pendingRomaji)
         currentDisplay = text
         let len = text.utf16.count
-        let attrs: [NSAttributedString.Key: Any] = [.markedClauseSegment: 0]
+        var attrs: [NSAttributedString.Key: Any] = [.markedClauseSegment: 0]
+        if currentSubmode == .english {
+            attrs[.underlineStyle] = NSUnderlineStyle.patternDash.rawValue | NSUnderlineStyle.single.rawValue
+        }
         let attrStr = NSAttributedString(string: text, attributes: attrs)
         client.setMarkedText(attrStr,
                              selectionRange: NSRange(location: len, length: 0),


### PR DESCRIPTION
## Summary

- Tab キーで日本語/英字サブモードをトグル（idle/composing 両方で動作）
- 英字モード中はローマ字変換をバイパスし、大文字小文字を保持したまま composedKana に直接追加
- programmerMode 時は日英境界に自動スペースを挿入（未使用時は再トグルで取消）
- 英字モードは点線下線で視覚的に区別
- 自動確定で連続 ASCII セグメントを単語単位でまとめて確定（1文字ずつの確定を防止）
- CI: swift ジョブを engine/ と Sources/ の両方が変更された場合のみ実行（macOS クレジット節約）

## Key semantics

| キー | 日本語モード | 英字モード |
|---|---|---|
| Tab | 英字モードへ | 日本語モードへ |
| Enter | 変換確定（学習あり） | そのまま確定（学習なし） |
| Space | 候補切替 | スペース文字追加 |
| Escape | ひらがな確定 | そのまま確定 |
| Backspace | 1文字削除 | 1文字削除 |

## Test plan

- [ ] Tab で英字モードに切替 → 点線下線表示を確認
- [ ] 英字モードで "React" 入力 → 大文字保持を確認
- [ ] Enter/Escape/Backspace/Space が英字モードで正しく動作
- [ ] Tab 2回押し → スペースが残らないことを確認
- [ ] programmerMode ON で `kyou` → Tab → `React` → Tab → `no` → Enter → "今日 React の"
- [ ] 自動確定で英字部分が単語単位で確定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)