### PR TITLE
refactor: replace trie-rs with lexime-trie

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -157,51 +157,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "fid-rs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6956a1e60e2d1412b44b4169d44a03dae518f8583d3e10090c912c105e48447"
-dependencies = [
- "rayon",
- "serde",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -287,14 +246,20 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "clap",
+ "lexime-trie",
  "memmap2",
  "serde",
  "serde_json",
  "thiserror",
- "trie-rs",
  "ureq",
  "zip",
 ]
+
+[[package]]
+name = "lexime-trie"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e45689eeee370d0325077fd078c2a254e340953c808e8e5d9167167383e5c"
 
 [[package]]
 name = "libc"
@@ -307,16 +272,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "louds-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936de6c22f08e7135a921f8ada907acd0d88880c4f42b5591f634b9f1dd8e07f"
-dependencies = [
- "fid-rs",
- "serde",
-]
 
 [[package]]
 name = "memchr"
@@ -377,26 +332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -544,16 +479,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "trie-rs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f88f4b0a1ebd6c3d16be3e45eb0e8089372ccadd88849b7ca162ba64b5e6f6"
-dependencies = [
- "louds-rs",
- "serde",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -11,7 +11,7 @@ name = "dictool"
 path = "src/bin/dictool.rs"
 
 [dependencies]
-trie-rs = { version = "0.4", features = ["serde"] }
+lexime-trie = "0.1"
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 serde_json = "1"

--- a/engine/src/dict/mod.rs
+++ b/engine/src/dict/mod.rs
@@ -37,6 +37,16 @@ pub enum DictError {
     Parse(String),
 }
 
+impl From<lexime_trie::TrieError> for DictError {
+    fn from(e: lexime_trie::TrieError) -> Self {
+        match e {
+            lexime_trie::TrieError::InvalidMagic => DictError::InvalidMagic,
+            lexime_trie::TrieError::InvalidVersion => DictError::UnsupportedVersion(0),
+            lexime_trie::TrieError::TruncatedData => DictError::InvalidHeader,
+        }
+    }
+}
+
 pub struct SearchResult<'a> {
     pub reading: String,
     pub entries: &'a [DictEntry],

--- a/engine/src/dict/trie_dict.rs
+++ b/engine/src/dict/trie_dict.rs
@@ -1,50 +1,55 @@
 use std::fs::{self, File};
 use std::path::Path;
 
+use lexime_trie::DoubleArray;
 use memmap2::Mmap;
-use serde::{Deserialize, Serialize};
-use trie_rs::map::{Trie, TrieBuilder};
 
 use super::{DictEntry, DictError, Dictionary, SearchResult};
 
 const MAGIC: &[u8; 4] = b"LXDX";
-const VERSION: u8 = 1;
-const HEADER_SIZE: usize = 5; // 4 bytes magic + 1 byte version
-
-#[derive(Serialize, Deserialize)]
-struct TrieData {
-    trie: Trie<u8, Vec<DictEntry>>,
-}
+const VERSION: u8 = 2;
+const HEADER_SIZE: usize = 4 + 1 + 4 + 4; // magic + version + trie_len + values_len = 13
 
 pub struct TrieDictionary {
-    data: TrieData,
+    trie: DoubleArray<u8>,
+    values: Vec<Vec<DictEntry>>,
 }
 
 impl TrieDictionary {
     pub fn from_entries(entries: impl IntoIterator<Item = (String, Vec<DictEntry>)>) -> Self {
-        let mut builder = TrieBuilder::new();
-        for (reading, mut candidates) in entries {
+        let mut pairs: Vec<(String, Vec<DictEntry>)> = entries.into_iter().collect();
+        for (_, candidates) in &mut pairs {
             candidates.sort_by_key(|e| e.cost);
-            builder.push(reading.as_bytes(), candidates);
         }
-        Self {
-            data: TrieData {
-                trie: builder.build(),
-            },
-        }
+        pairs.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+
+        let keys: Vec<&[u8]> = pairs.iter().map(|(r, _)| r.as_bytes()).collect();
+        let trie = DoubleArray::<u8>::build(&keys);
+        let values: Vec<Vec<DictEntry>> = pairs.into_iter().map(|(_, v)| v).collect();
+
+        Self { trie, values }
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, DictError> {
-        let mut buf = Vec::new();
+        let trie_data = self.trie.as_bytes();
+        let values_data = bincode::serialize(&self.values).map_err(DictError::Serialize)?;
+
+        let trie_len = trie_data.len() as u32;
+        let values_len = values_data.len() as u32;
+
+        let mut buf = Vec::with_capacity(HEADER_SIZE + trie_data.len() + values_data.len());
         buf.extend_from_slice(MAGIC);
         buf.push(VERSION);
-        let encoded = bincode::serialize(&self.data).map_err(DictError::Serialize)?;
-        buf.extend_from_slice(&encoded);
+        buf.extend_from_slice(&trie_len.to_le_bytes());
+        buf.extend_from_slice(&values_len.to_le_bytes());
+        buf.extend_from_slice(&trie_data);
+        buf.extend_from_slice(&values_data);
+
         Ok(buf)
     }
 
     pub fn from_bytes(data: &[u8]) -> Result<Self, DictError> {
-        if data.len() < HEADER_SIZE {
+        if data.len() < 5 {
             return Err(DictError::InvalidHeader);
         }
         if &data[..4] != MAGIC {
@@ -53,9 +58,27 @@ impl TrieDictionary {
         if data[4] != VERSION {
             return Err(DictError::UnsupportedVersion(data[4]));
         }
-        let trie_data: TrieData =
-            bincode::deserialize(&data[HEADER_SIZE..]).map_err(DictError::Deserialize)?;
-        Ok(Self { data: trie_data })
+        if data.len() < HEADER_SIZE {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_len = u32::from_le_bytes(data[5..9].try_into().unwrap()) as usize;
+        let values_len = u32::from_le_bytes(data[9..13].try_into().unwrap()) as usize;
+
+        let expected = HEADER_SIZE + trie_len + values_len;
+        if data.len() < expected {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_start = HEADER_SIZE;
+        let values_start = trie_start + trie_len;
+
+        let trie = DoubleArray::<u8>::from_bytes(&data[trie_start..trie_start + trie_len])?;
+        let values: Vec<Vec<DictEntry>> =
+            bincode::deserialize(&data[values_start..values_start + values_len])
+                .map_err(DictError::Deserialize)?;
+
+        Ok(Self { trie, values })
     }
 
     /// Open a dictionary file, using mmap to avoid doubling peak memory.
@@ -76,7 +99,10 @@ impl TrieDictionary {
 
     /// Iterate over all `(reading, entries)` pairs in the trie.
     pub fn iter(&self) -> impl Iterator<Item = (String, &Vec<DictEntry>)> {
-        self.data.trie.iter()
+        self.trie.predictive_search(b"").map(move |m| {
+            let reading = String::from_utf8(m.key).expect("invalid UTF-8 in trie key");
+            (reading, &self.values[m.value_id as usize])
+        })
     }
 
     /// Return prediction candidates ranked by cost (lowest first).
@@ -90,21 +116,20 @@ impl TrieDictionary {
         max_results: usize,
         scan_limit: usize,
     ) -> Vec<(String, DictEntry)> {
-        // Flatten all (reading, entry) pairs from up to scan_limit readings
         let mut flat: Vec<(String, DictEntry)> = self
-            .data
             .trie
             .predictive_search(prefix.as_bytes())
             .take(scan_limit)
-            .flat_map(|(reading, entries): (String, &Vec<DictEntry>)| {
-                entries.iter().map(move |e| (reading.clone(), e.clone()))
+            .flat_map(|m| {
+                let reading = String::from_utf8(m.key).expect("invalid UTF-8 in trie key");
+                self.values[m.value_id as usize]
+                    .iter()
+                    .map(move |e| (reading.clone(), e.clone()))
             })
             .collect();
 
-        // Sort by cost ascending (low cost = high frequency)
         flat.sort_by_key(|(_, e)| e.cost);
 
-        // Deduplicate by surface, keeping the lowest-cost entry
         let mut seen = std::collections::HashSet::new();
         flat.retain(|(_, e)| seen.insert(e.surface.clone()));
 
@@ -112,45 +137,41 @@ impl TrieDictionary {
         flat
     }
 
-    /// Returns (reading_count, entry_count) by iterating the trie.
+    /// Returns (reading_count, entry_count).
     pub fn stats(&self) -> (usize, usize) {
-        let mut readings = 0usize;
-        let mut entries = 0usize;
-        for (_key, vals) in self.iter() {
-            readings += 1;
-            entries += vals.len();
-        }
+        let readings = self.values.len();
+        let entries: usize = self.values.iter().map(|v| v.len()).sum();
         (readings, entries)
     }
 }
 
 impl Dictionary for TrieDictionary {
     fn lookup(&self, reading: &str) -> Option<&[DictEntry]> {
-        self.data
-            .trie
+        self.trie
             .exact_match(reading.as_bytes())
-            .map(|v| v.as_slice())
+            .map(|id| self.values[id as usize].as_slice())
     }
 
     fn predict(&self, prefix: &str, max_results: usize) -> Vec<SearchResult<'_>> {
-        self.data
-            .trie
+        self.trie
             .predictive_search(prefix.as_bytes())
             .take(max_results)
-            .map(|(key, entries): (String, &Vec<DictEntry>)| SearchResult {
-                reading: key,
-                entries,
+            .map(|m| SearchResult {
+                reading: String::from_utf8(m.key).expect("invalid UTF-8 in trie key"),
+                entries: self.values[m.value_id as usize].as_slice(),
             })
             .collect()
     }
 
     fn common_prefix_search(&self, query: &str) -> Vec<SearchResult<'_>> {
-        self.data
-            .trie
-            .common_prefix_search(query.as_bytes())
-            .map(|(key, entries): (String, &Vec<DictEntry>)| SearchResult {
-                reading: key,
-                entries,
+        let query_bytes = query.as_bytes();
+        self.trie
+            .common_prefix_search(query_bytes)
+            .map(|m| SearchResult {
+                reading: std::str::from_utf8(&query_bytes[..m.len])
+                    .expect("invalid UTF-8 boundary in common prefix")
+                    .to_string(),
+                entries: self.values[m.value_id as usize].as_slice(),
             })
             .collect()
     }
@@ -306,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_invalid_magic() {
-        let result = TrieDictionary::from_bytes(b"XXXX\x01data");
+        let result = TrieDictionary::from_bytes(b"XXXX\x02data");
         assert!(matches!(result, Err(DictError::InvalidMagic)));
     }
 

--- a/mise.toml
+++ b/mise.toml
@@ -87,6 +87,16 @@ set -euo pipefail
 cp engine/data/lexime-mozc.dict engine/data/lexime.dict
 """
 
+[tasks.dict-clean]
+description = "Remove compiled dictionaries (forces rebuild on next dict/build)"
+run = """
+#!/usr/bin/env bash
+rm -f engine/data/lexime-mozc.dict engine/data/lexime-sudachi.dict \
+      engine/data/lexime-sudachi-full.dict engine/data/lexime.dict \
+      engine/data/lexime.conn
+echo "Removed compiled dictionaries"
+"""
+
 [tasks.build]
 description = "Build Lexime.app (universal binary)"
 depends = ["engine-lib", "dict", "conn"]


### PR DESCRIPTION
## Summary
- Replace `trie-rs` crate and hand-rolled `HashMap` trie with `lexime-trie` (`DoubleArray`)
- Bump LXDX dictionary format to V2 (separate trie binary + bincode values sections)
- Add `mise run dict-clean` task to force dictionary recompilation

## Test plan
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 196 tests pass
- [x] `mise run build && mise run install && mise run reload` — candidate panel works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)