### PR TITLE
feat: improve bunsetsu segmentation with prefix/suffix POS roles

### DIFF
--- a/engine/src/bin/dictool.rs
+++ b/engine/src/bin/dictool.rs
@@ -253,20 +253,30 @@ fn compile_conn(input_txt: &str, output_file: &str, id_def: Option<&str>) {
         "Error reading {input_txt}: {}"
     );
 
-    let (fw_min, fw_max) = if let Some(id_def_path) = id_def {
+    let (fw_min, fw_max, roles) = if let Some(id_def_path) = id_def {
         let (min, max) = die!(
             pos_map::function_word_id_range(Path::new(id_def_path)),
             "Error extracting function-word range: {}"
         );
         eprintln!("Function-word ID range: {min}..={max}");
-        (min, max)
+        let roles = die!(
+            pos_map::morpheme_roles(Path::new(id_def_path)),
+            "Error extracting morpheme roles: {}"
+        );
+        let suffix_count = roles.iter().filter(|&&r| r == 2).count();
+        let prefix_count = roles.iter().filter(|&&r| r == 3).count();
+        eprintln!(
+            "Morpheme roles: {} suffixes, {} prefixes",
+            suffix_count, prefix_count
+        );
+        (min, max, roles)
     } else {
-        (0, 0)
+        (0, 0, Vec::new())
     };
 
     eprintln!("Parsing connection matrix from {input_txt}...");
     let matrix = die!(
-        ConnectionMatrix::from_text_with_metadata(&text, fw_min, fw_max),
+        ConnectionMatrix::from_text_with_roles(&text, fw_min, fw_max, roles),
         "Error parsing connection matrix: {}"
     );
 

--- a/engine/src/converter/testutil.rs
+++ b/engine/src/converter/testutil.rs
@@ -126,3 +126,10 @@ pub fn zero_conn_with_fw(num_ids: u16, fw_min: u16, fw_max: u16) -> ConnectionMa
     let text = format!("{num_ids} {num_ids}\n{}", "0\n".repeat(n * n));
     ConnectionMatrix::from_text_with_metadata(&text, fw_min, fw_max).unwrap()
 }
+
+/// Create a zero-cost connection matrix with roles.
+pub fn zero_conn_with_roles(num_ids: u16, roles: Vec<u8>) -> ConnectionMatrix {
+    let n = num_ids as usize;
+    let text = format!("{num_ids} {num_ids}\n{}", "0\n".repeat(n * n));
+    ConnectionMatrix::from_text_with_roles(&text, 0, 0, roles).unwrap()
+}

--- a/engine/src/dict/connection.rs
+++ b/engine/src/dict/connection.rs
@@ -6,9 +6,10 @@ use memmap2::Mmap;
 use super::DictError;
 
 const MAGIC: &[u8; 4] = b"LXCX";
-const VERSION: u8 = 2;
-const HEADER_SIZE: usize = 4 + 1 + 2 + 2 + 2; // magic + version + num_ids + fw_min + fw_max
+const V2_HEADER_SIZE: usize = 4 + 1 + 2 + 2 + 2; // magic + version + num_ids + fw_min + fw_max
 const V1_HEADER_SIZE: usize = 4 + 1 + 2; // magic + v1 + num_ids (for backward compat)
+                                         // V3 header: V2 header + roles[num_ids]
+                                         // header_size is computed dynamically: V2_HEADER_SIZE + num_ids
 
 /// Backing storage for cost data: either owned or memory-mapped.
 enum CostStorage {
@@ -22,6 +23,7 @@ pub struct ConnectionMatrix {
     num_ids: u16,
     fw_min: u16,
     fw_max: u16,
+    roles: Vec<u8>,
     header_size: usize,
     storage: CostStorage,
 }
@@ -54,6 +56,22 @@ impl ConnectionMatrix {
     /// Returns `false` when no range is set (both 0).
     pub fn is_function_word(&self, id: u16) -> bool {
         self.fw_min != 0 && self.fw_min <= id && id <= self.fw_max
+    }
+
+    /// Get the morpheme role for a POS ID.
+    /// Returns 0 (ContentWord) if roles data is not available (V1/V2 matrices).
+    pub fn role(&self, id: u16) -> u8 {
+        self.roles.get(id as usize).copied().unwrap_or(0)
+    }
+
+    /// Check whether a POS ID is a suffix (接尾, role == 2).
+    pub fn is_suffix(&self, id: u16) -> bool {
+        self.role(id) == 2
+    }
+
+    /// Check whether a POS ID is a prefix (接頭詞, role == 3).
+    pub fn is_prefix(&self, id: u16) -> bool {
+        self.role(id) == 3
     }
 
     /// Build from a text file.
@@ -164,7 +182,8 @@ impl ConnectionMatrix {
             num_ids,
             fw_min: 0,
             fw_max: 0,
-            header_size: HEADER_SIZE,
+            roles: Vec::new(),
+            header_size: V2_HEADER_SIZE,
             storage: CostStorage::Owned(costs),
         })
     }
@@ -181,8 +200,21 @@ impl ConnectionMatrix {
         Ok(m)
     }
 
-    /// Validate the binary header and return `(num_ids, fw_min, fw_max, header_size)`.
-    fn validate_header(data: &[u8]) -> Result<(u16, u16, u16, usize), DictError> {
+    /// Build from a text file with function-word range and morpheme roles.
+    pub fn from_text_with_roles(
+        text: &str,
+        fw_min: u16,
+        fw_max: u16,
+        roles: Vec<u8>,
+    ) -> Result<Self, DictError> {
+        let mut m = Self::from_text(text)?;
+        m.fw_min = fw_min;
+        m.fw_max = fw_max;
+        m.roles = roles;
+        Ok(m)
+    }
+
+    fn validate_header(data: &[u8]) -> Result<(u16, u16, u16, Vec<u8>, usize), DictError> {
         if data.len() < V1_HEADER_SIZE {
             return Err(DictError::InvalidHeader);
         }
@@ -190,19 +222,33 @@ impl ConnectionMatrix {
             return Err(DictError::InvalidMagic);
         }
         let version = data[4];
-        let (num_ids, fw_min, fw_max, hdr_size) = match version {
+        let (num_ids, fw_min, fw_max, roles, hdr_size) = match version {
             1 => {
                 let num_ids = u16::from_le_bytes([data[5], data[6]]);
-                (num_ids, 0u16, 0u16, V1_HEADER_SIZE)
+                (num_ids, 0u16, 0u16, Vec::new(), V1_HEADER_SIZE)
             }
             2 => {
-                if data.len() < HEADER_SIZE {
+                if data.len() < V2_HEADER_SIZE {
                     return Err(DictError::InvalidHeader);
                 }
                 let num_ids = u16::from_le_bytes([data[5], data[6]]);
                 let fw_min = u16::from_le_bytes([data[7], data[8]]);
                 let fw_max = u16::from_le_bytes([data[9], data[10]]);
-                (num_ids, fw_min, fw_max, HEADER_SIZE)
+                (num_ids, fw_min, fw_max, Vec::new(), V2_HEADER_SIZE)
+            }
+            3 => {
+                if data.len() < V2_HEADER_SIZE {
+                    return Err(DictError::InvalidHeader);
+                }
+                let num_ids = u16::from_le_bytes([data[5], data[6]]);
+                let fw_min = u16::from_le_bytes([data[7], data[8]]);
+                let fw_max = u16::from_le_bytes([data[9], data[10]]);
+                let roles_end = V2_HEADER_SIZE + num_ids as usize;
+                if data.len() < roles_end {
+                    return Err(DictError::InvalidHeader);
+                }
+                let roles = data[V2_HEADER_SIZE..roles_end].to_vec();
+                (num_ids, fw_min, fw_max, roles, roles_end)
             }
             _ => return Err(DictError::UnsupportedVersion(version)),
         };
@@ -213,7 +259,7 @@ impl ConnectionMatrix {
                 "expected {expected_bytes} bytes of cost data, got {actual_bytes}",
             )));
         }
-        Ok((num_ids, fw_min, fw_max, hdr_size))
+        Ok((num_ids, fw_min, fw_max, roles, hdr_size))
     }
 
     /// Load from compiled binary format using memory-mapped I/O.
@@ -227,11 +273,12 @@ impl ConnectionMatrix {
         // We hold the Mmap for the lifetime of this struct, so the data remains
         // valid. The file should not be modified while the IME is running.
         let mmap = unsafe { Mmap::map(&file)? };
-        let (num_ids, fw_min, fw_max, hdr_size) = Self::validate_header(&mmap)?;
+        let (num_ids, fw_min, fw_max, roles, hdr_size) = Self::validate_header(&mmap)?;
         Ok(Self {
             num_ids,
             fw_min,
             fw_max,
+            roles,
             header_size: hdr_size,
             storage: CostStorage::Mapped(mmap),
         })
@@ -239,7 +286,7 @@ impl ConnectionMatrix {
 
     /// Parse from compiled binary format into an owned representation.
     pub fn from_bytes(data: &[u8]) -> Result<Self, DictError> {
-        let (num_ids, fw_min, fw_max, hdr_size) = Self::validate_header(data)?;
+        let (num_ids, fw_min, fw_max, roles, hdr_size) = Self::validate_header(data)?;
         let costs: Vec<i16> = data[hdr_size..]
             .chunks_exact(2)
             .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
@@ -248,46 +295,53 @@ impl ConnectionMatrix {
             num_ids,
             fw_min,
             fw_max,
-            header_size: HEADER_SIZE,
+            roles,
+            header_size: V2_HEADER_SIZE,
             storage: CostStorage::Owned(costs),
         })
     }
 
-    /// Serialize to compiled binary format (always writes V2).
+    /// Serialize to compiled binary format (writes V3 if roles present, V2 otherwise).
     pub fn to_bytes(&self) -> Vec<u8> {
-        match &self.storage {
-            CostStorage::Mapped(mmap) if self.header_size == HEADER_SIZE => mmap.to_vec(),
-            _ => {
-                let costs = match &self.storage {
-                    CostStorage::Owned(c) => c.as_slice(),
-                    CostStorage::Mapped(_) => {
-                        // V1 mmap → re-serialize as V2
-                        return self.to_bytes_from_mapped();
-                    }
-                };
-                let mut buf = Vec::with_capacity(HEADER_SIZE + costs.len() * 2);
-                buf.extend_from_slice(MAGIC);
-                buf.push(VERSION);
-                buf.extend_from_slice(&self.num_ids.to_le_bytes());
-                buf.extend_from_slice(&self.fw_min.to_le_bytes());
-                buf.extend_from_slice(&self.fw_max.to_le_bytes());
-                for &cost in costs {
-                    buf.extend_from_slice(&cost.to_le_bytes());
-                }
-                buf
+        let costs = match &self.storage {
+            CostStorage::Owned(c) => c.as_slice(),
+            CostStorage::Mapped(_) => {
+                return self.to_bytes_from_mapped();
             }
-        }
-    }
-
-    /// Helper: re-serialize a Mapped matrix as V2 bytes.
-    fn to_bytes_from_mapped(&self) -> Vec<u8> {
-        let n = self.num_ids as usize * self.num_ids as usize;
-        let mut buf = Vec::with_capacity(HEADER_SIZE + n * 2);
+        };
+        let has_roles = !self.roles.is_empty();
+        let version = if has_roles { 3u8 } else { 2u8 };
+        let roles_size = if has_roles { self.roles.len() } else { 0 };
+        let mut buf = Vec::with_capacity(V2_HEADER_SIZE + roles_size + costs.len() * 2);
         buf.extend_from_slice(MAGIC);
-        buf.push(VERSION);
+        buf.push(version);
         buf.extend_from_slice(&self.num_ids.to_le_bytes());
         buf.extend_from_slice(&self.fw_min.to_le_bytes());
         buf.extend_from_slice(&self.fw_max.to_le_bytes());
+        if has_roles {
+            buf.extend_from_slice(&self.roles);
+        }
+        for &cost in costs {
+            buf.extend_from_slice(&cost.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Helper: re-serialize a Mapped matrix.
+    fn to_bytes_from_mapped(&self) -> Vec<u8> {
+        let n = self.num_ids as usize * self.num_ids as usize;
+        let has_roles = !self.roles.is_empty();
+        let version = if has_roles { 3u8 } else { 2u8 };
+        let roles_size = if has_roles { self.roles.len() } else { 0 };
+        let mut buf = Vec::with_capacity(V2_HEADER_SIZE + roles_size + n * 2);
+        buf.extend_from_slice(MAGIC);
+        buf.push(version);
+        buf.extend_from_slice(&self.num_ids.to_le_bytes());
+        buf.extend_from_slice(&self.fw_min.to_le_bytes());
+        buf.extend_from_slice(&self.fw_max.to_le_bytes());
+        if has_roles {
+            buf.extend_from_slice(&self.roles);
+        }
         for i in 0..n {
             let left = (i / self.num_ids as usize) as u16;
             let right = (i % self.num_ids as usize) as u16;
@@ -507,7 +561,89 @@ mod tests {
         assert_eq!(m.cost(0, 1), 20);
         assert_eq!(m.cost(1, 0), 30);
         assert_eq!(m.cost(1, 1), 40);
-        // V1 has no function-word range
+        // V1 has no function-word range or roles
         assert!(!m.is_function_word(100));
+        assert_eq!(m.role(0), 0);
+        assert!(!m.is_suffix(0));
+        assert!(!m.is_prefix(0));
+    }
+
+    #[test]
+    fn test_v3_roundtrip_with_roles() {
+        // 4 IDs: 0=content, 1=function, 2=suffix, 3=prefix
+        let text = "4 4\n";
+        let costs_text: String = (0..16).map(|i| format!("{}\n", i * 10)).collect::<String>();
+        let full_text = format!("{text}{costs_text}");
+        let roles = vec![0, 1, 2, 3];
+        let m = ConnectionMatrix::from_text_with_roles(&full_text, 1, 1, roles.clone()).unwrap();
+
+        assert_eq!(m.role(0), 0);
+        assert_eq!(m.role(1), 1);
+        assert_eq!(m.role(2), 2);
+        assert_eq!(m.role(3), 3);
+        assert!(!m.is_prefix(0));
+        assert!(!m.is_suffix(0));
+        assert!(m.is_suffix(2));
+        assert!(m.is_prefix(3));
+        assert!(m.is_function_word(1));
+
+        // Serialize and deserialize
+        let bytes = m.to_bytes();
+        // Check V3 marker
+        assert_eq!(bytes[4], 3);
+
+        let m2 = ConnectionMatrix::from_bytes(&bytes).unwrap();
+        assert_eq!(m2.num_ids(), 4);
+        assert_eq!(m2.role(0), 0);
+        assert_eq!(m2.role(1), 1);
+        assert_eq!(m2.role(2), 2);
+        assert_eq!(m2.role(3), 3);
+        assert!(m2.is_suffix(2));
+        assert!(m2.is_prefix(3));
+        for left in 0..4 {
+            for right in 0..4 {
+                assert_eq!(m.cost(left, right), m2.cost(left, right));
+            }
+        }
+    }
+
+    #[test]
+    fn test_v3_file_roundtrip() {
+        let dir = std::env::temp_dir().join("lexime_test_conn_v3");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("test_v3.conn");
+
+        let text = "3 3\n0\n10\n20\n30\n40\n50\n60\n70\n80\n";
+        let roles = vec![0, 2, 3]; // content, suffix, prefix
+        let m = ConnectionMatrix::from_text_with_roles(text, 0, 0, roles).unwrap();
+        m.save(&path).unwrap();
+
+        let m2 = ConnectionMatrix::open(&path).unwrap();
+        assert_eq!(m2.num_ids(), 3);
+        assert_eq!(m2.role(0), 0);
+        assert_eq!(m2.role(1), 2);
+        assert_eq!(m2.role(2), 3);
+        assert!(m2.is_suffix(1));
+        assert!(m2.is_prefix(2));
+        assert_eq!(m2.cost(0, 1), 10);
+        assert_eq!(m2.cost(2, 2), 80);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_v2_backward_compat_no_roles() {
+        // V2 binary should load with empty roles → role() always returns 0
+        let text = "2 2\n10\n20\n30\n40\n";
+        let m = ConnectionMatrix::from_text_with_metadata(text, 50, 300).unwrap();
+        let bytes = m.to_bytes();
+        // Should write V2 (no roles)
+        assert_eq!(bytes[4], 2);
+
+        let m2 = ConnectionMatrix::from_bytes(&bytes).unwrap();
+        assert_eq!(m2.role(0), 0);
+        assert_eq!(m2.role(1), 0);
+        assert!(!m2.is_suffix(0));
+        assert!(!m2.is_prefix(0));
     }
 }


### PR DESCRIPTION
## Summary

- `group_segments` が助詞/助動詞のみで文節分割していたのを、接尾辞（さん, 的, 都）と接頭詞（お, ご, 新, 旧）にも対応
- ConnectionMatrix を V3 に拡張し、POS ID ごとの役割（ContentWord/FunctionWord/Suffix/Prefix）を埋め込み
- 「田中さん」「お茶」が1文節として正しくグループ化されるように

## Changes

- **`pos_map.rs`**: `morpheme_roles()` 追加 — id.def から各 POS ID の役割を分類
- **`connection.rs`**: V3 バイナリフォーマット（roles 配列追加）、`role()`/`is_suffix()`/`is_prefix()` メソッド、V1/V2 後方互換
- **`dictool.rs`**: `compile-conn` で roles を出力
- **`converter/mod.rs`**: `group_segments` を Suffix（前に結合）/ Prefix（次の CW と結合）に対応拡張

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 252 tests pass
- [x] `dictool convert` で「たなかさん」→「田中さん」1セグメント確認
- [x] `dictool convert` で「おちゃをのむ」→「お茶を」+「飲む」確認
- [x] ベンチマーク: パフォーマンス劣化なし（32文字で 0.1ms）

🤖 Generated with [Claude Code](https://claude.com/claude-code)