### PR TITLE
feat: add VoiceOver announcements for candidate panel

### DIFF
--- a/Sources/CandidatePanel.swift
+++ b/Sources/CandidatePanel.swift
@@ -87,7 +87,8 @@ class CandidatePanel: NSPanel {
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
-    func show(candidates: [String], selectedIndex: Int, cursorRect: NSRect?) {
+    func show(candidates: [String], selectedIndex: Int, globalIndex: Int, totalCount: Int,
+              cursorRect: NSRect?) {
         guard !candidates.isEmpty else {
             hide()
             return
@@ -130,9 +131,27 @@ class CandidatePanel: NSPanel {
 
         listView.needsDisplay = true
         orderFront(nil)
+
+        announceCandidate(candidates[selectedIndex], index: globalIndex, total: totalCount)
     }
 
     func hide() {
         orderOut(nil)
+    }
+
+    // MARK: - VoiceOver
+
+    private func announceCandidate(_ candidate: String, index: Int, total: Int) {
+        guard NSWorkspace.shared.isVoiceOverEnabled else { return }
+        let message = "\(candidate) \(index + 1)/\(total)"
+        let userInfo: [NSAccessibility.NotificationUserInfoKey: Any] = [
+            .announcement: message,
+            .priority: NSAccessibilityPriorityLevel.high.rawValue,
+        ]
+        NSAccessibility.post(
+            element: self,
+            notification: .announcementRequested,
+            userInfo: userInfo
+        )
     }
 }

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -96,10 +96,13 @@ class LeximeInputController: IMKInputController {
 
         let panel = AppContext.shared.candidatePanel
 
+        let totalCount = allCandidates.count
+
         // Mozc style: don't recalculate position while panel is visible (prevents jitter)
         // But if cursor moved (auto-commit), force reposition.
         if panel.isVisible && !panelNeedsReposition {
-            panel.show(candidates: pageCandidates, selectedIndex: pageSelectedIndex, cursorRect: nil)
+            panel.show(candidates: pageCandidates, selectedIndex: pageSelectedIndex,
+                       globalIndex: clampedIndex, totalCount: totalCount, cursorRect: nil)
             return
         }
         // Reset early: if the async block below is cancelled (generation mismatch),
@@ -112,7 +115,8 @@ class LeximeInputController: IMKInputController {
         let generation = candidateGeneration
         DispatchQueue.main.async { [weak self] in
             guard let self, self.candidateGeneration == generation else { return }
-            panel.show(candidates: pageCandidates, selectedIndex: pageSelectedIndex, cursorRect: rect)
+            panel.show(candidates: pageCandidates, selectedIndex: pageSelectedIndex,
+                       globalIndex: clampedIndex, totalCount: totalCount, cursorRect: rect)
         }
     }
 


### PR DESCRIPTION
## Summary

- 候補パネルの表示・選択変更時に VoiceOver で候補を読み上げる
- 形式: `"今日 1/5"` (候補テキスト + 位置/総数)
- VoiceOver 無効時は `isVoiceOverEnabled` ガードで即 return (パフォーマンス影響なし)

## Changes

- **`CandidatePanel.swift`**: `show()` に `globalIndex`/`totalCount` 追加、`announceCandidate()` で `NSAccessibility.post(.announcementRequested)` を発火
- **`LeximeInputController.swift`**: 2箇所の `panel.show()` 呼び出しに引数追加

## Test plan

- [x] `mise run build` + `mise run test-swift` パス
- [x] VoiceOver (Cmd+F5) 有効時に候補読み上げを確認
- [x] VoiceOver 無効時の通常動作に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)