### PR TITLE
feat: add neural scoring with Zenzai GPT-2 (Phase A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ engine/target/
 engine/data/*
 !engine/data/snapshot-readings.txt
 
+# Neural model files
+data/
+
 # macOS
 .DS_Store
 *.swp

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,16 +101,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "candle-core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+dependencies = [
+ "byteorder",
+ "float8",
+ "gemm",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 2.0.18",
+ "yoke",
+ "zip",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
+dependencies = [
+ "candle-core",
+ "half",
+ "libc",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cc"
@@ -175,10 +264,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "deranged"
@@ -187,6 +301,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -213,6 +361,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "float8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand",
+ "rand_distr",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,16 +509,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -283,13 +608,16 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 name = "lex_engine"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
+ "candle-core",
+ "candle-nn",
  "clap",
  "lexime-trie",
  "memmap2",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -309,6 +637,12 @@ name = "libc"
 version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
@@ -338,6 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -360,10 +695,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -376,6 +741,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -396,6 +767,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +785,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +815,86 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "regex-automata"
@@ -438,7 +921,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -478,6 +961,32 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -550,6 +1059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,12 +1088,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -650,7 +1210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -790,10 +1350,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -802,6 +1387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -891,6 +1485,76 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zeroize"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/bin/lextool.rs"
 [features]
 default = []
 trace = ["tracing/max_level_debug", "tracing-subscriber", "tracing-appender"]
+neural = ["candle-core", "candle-nn", "dep:anyhow"]
 
 [dependencies]
 tracing = { version = "0.1", features = ["max_level_off"] }
@@ -30,6 +31,15 @@ zip = { version = "7", default-features = false, features = ["deflate"] }
 memmap2 = "0.9"
 clap = { version = "4", features = ["derive"] }
 unicode-width = "0.2"
+anyhow = { version = "1", optional = true }
+
+[dependencies.candle-core]
+version = "0.9"
+optional = true
+
+[dependencies.candle-nn]
+version = "0.9"
+optional = true
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -5,6 +5,8 @@
 pub mod candidates;
 pub mod converter;
 pub mod dict;
+#[cfg(feature = "neural")]
+pub mod neural;
 pub mod romaji;
 pub mod session;
 pub mod trace_init;

--- a/engine/src/neural/gpt2.rs
+++ b/engine/src/neural/gpt2.rs
@@ -1,0 +1,493 @@
+//! Quantized GPT-2 model loaded from GGUF format.
+//!
+//! Architecture: GPT-2 with LayerNorm, learned position embeddings,
+//! weight tying (wte == lm_head^T), and gelu_new activation.
+//!
+//! GGUF tensor names follow the llama.cpp convention for GPT-2.
+
+use std::path::Path;
+
+use candle_core::quantized::gguf_file;
+use candle_core::quantized::QMatMul;
+use candle_core::{Device, IndexOp, Module, Result, Tensor};
+use candle_nn::{Embedding, LayerNorm};
+
+// ---- Configuration ----
+
+struct Gpt2Config {
+    n_embd: usize,
+    n_head: usize,
+    n_layer: usize,
+    n_positions: usize,
+    vocab_size: usize,
+}
+
+impl Gpt2Config {
+    fn from_gguf(content: &gguf_file::Content) -> Self {
+        let get_u32 = |key: &str, default: u32| -> usize {
+            content
+                .metadata
+                .get(key)
+                .and_then(|v| v.to_u32().ok())
+                .unwrap_or(default) as usize
+        };
+        Self {
+            n_embd: get_u32("gpt2.embedding_length", 768),
+            n_head: get_u32("gpt2.attention.head_count", 12),
+            n_layer: get_u32("gpt2.block_count", 12),
+            n_positions: get_u32("gpt2.context_length", 1024),
+            vocab_size: get_u32("gpt2.vocab_size", 6000),
+        }
+    }
+
+    fn head_dim(&self) -> usize {
+        self.n_embd / self.n_head
+    }
+}
+
+// ---- Attention ----
+
+struct Attention {
+    qkv: QMatMul,
+    qkv_bias: Tensor,
+    out_proj: QMatMul,
+    out_bias: Tensor,
+    n_head: usize,
+    head_dim: usize,
+    kv_cache: Option<(Tensor, Tensor)>,
+}
+
+impl Attention {
+    fn forward(&mut self, x: &Tensor, pos: usize) -> Result<Tensor> {
+        let (batch, seq_len, n_embd) = x.dims3()?;
+        let head_dim = self.head_dim;
+        let n_head = self.n_head;
+
+        // QKV projection: [batch, seq, 3*n_embd]
+        let qkv = self.qkv.forward(x)?.broadcast_add(&self.qkv_bias)?;
+        let qkv = qkv.reshape((batch, seq_len, 3, n_head, head_dim))?;
+
+        // Split Q, K, V: each [batch, n_head, seq, head_dim]
+        let q = qkv.i((.., .., 0))?.transpose(1, 2)?.contiguous()?;
+        let k = qkv.i((.., .., 1))?.transpose(1, 2)?.contiguous()?;
+        let v = qkv.i((.., .., 2))?.transpose(1, 2)?.contiguous()?;
+
+        // KV-cache: concatenate along sequence dimension
+        let (k, v) = if let Some((prev_k, prev_v)) = &self.kv_cache {
+            let k = Tensor::cat(&[prev_k, &k], 2)?;
+            let v = Tensor::cat(&[prev_v, &v], 2)?;
+            (k, v)
+        } else {
+            (k, v)
+        };
+        self.kv_cache = Some((k.clone(), v.clone()));
+
+        let total_len = pos + seq_len;
+
+        // Scaled dot-product attention
+        let scale = (head_dim as f64).sqrt();
+        let attn_weights = q.matmul(&k.transpose(2, 3)?)? / scale;
+
+        // Causal mask: only attend to positions <= current
+        let mask = create_causal_mask(seq_len, total_len, x.device())?;
+        let attn_weights = attn_weights?.broadcast_add(&mask)?;
+
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        let attn_out = attn_weights.matmul(&v)?;
+
+        // Reshape back: [batch, seq, n_embd]
+        let attn_out = attn_out
+            .transpose(1, 2)?
+            .reshape((batch, seq_len, n_embd))?;
+
+        // Output projection
+        let out = self
+            .out_proj
+            .forward(&attn_out)?
+            .broadcast_add(&self.out_bias)?;
+        Ok(out)
+    }
+}
+
+fn create_causal_mask(seq_len: usize, total_len: usize, device: &Device) -> Result<Tensor> {
+    let offset = total_len - seq_len;
+    // For each query position i (0..seq_len), mask out key positions j where j > i + offset
+    let mask: Vec<f32> = (0..seq_len)
+        .flat_map(|i| {
+            (0..total_len).map(move |j| {
+                if j <= i + offset {
+                    0.0f32
+                } else {
+                    f32::NEG_INFINITY
+                }
+            })
+        })
+        .collect();
+    Tensor::from_vec(mask, (1, 1, seq_len, total_len), device)
+}
+
+// ---- MLP ----
+
+struct Mlp {
+    fc: QMatMul,
+    fc_bias: Tensor,
+    proj: QMatMul,
+    proj_bias: Tensor,
+}
+
+impl Mlp {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let h = self.fc.forward(x)?.broadcast_add(&self.fc_bias)?;
+        let h = gelu_new(&h)?;
+        self.proj.forward(&h)?.broadcast_add(&self.proj_bias)
+    }
+}
+
+/// GPT-2's gelu_new activation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+fn gelu_new(x: &Tensor) -> Result<Tensor> {
+    let x3 = x.powf(3.0)?;
+    let inner = ((x + (x3 * 0.044715)?)? * (2.0f64 / std::f64::consts::PI).sqrt())?;
+    let tanh_inner = inner.tanh()?;
+    (x * (tanh_inner + 1.0)?)? * 0.5
+}
+
+// ---- Transformer Block ----
+
+struct Block {
+    ln_1: LayerNorm,
+    attn: Attention,
+    ln_2: LayerNorm,
+    mlp: Mlp,
+}
+
+impl Block {
+    fn forward(&mut self, x: &Tensor, pos: usize) -> Result<Tensor> {
+        // Pre-norm attention
+        let residual = x;
+        let h = self.ln_1.forward(x)?;
+        let h = self.attn.forward(&h, pos)?;
+        let x = (residual + h)?;
+
+        // Pre-norm MLP
+        let residual = &x;
+        let h = self.ln_2.forward(&x)?;
+        let h = self.mlp.forward(&h)?;
+        residual + h
+    }
+}
+
+// ---- Full GPT-2 Model ----
+
+pub struct QuantizedGpt2 {
+    wte: Embedding,
+    wpe: Embedding,
+    blocks: Vec<Block>,
+    ln_f: LayerNorm,
+    lm_head: Option<QMatMul>,
+    config: Gpt2Config,
+}
+
+/// Load and dequantize a tensor from GGUF.
+fn load_tensor(
+    content: &gguf_file::Content,
+    file: &mut std::fs::File,
+    name: &str,
+    device: &Device,
+) -> anyhow::Result<Tensor> {
+    let qt = content
+        .tensor(file, name, device)
+        .map_err(|e| anyhow::anyhow!("failed to load tensor {name}: {e}"))?;
+    qt.dequantize(device)
+        .map_err(|e| anyhow::anyhow!("failed to dequantize {name}: {e}"))
+}
+
+/// Load a quantized tensor as QMatMul from GGUF.
+fn load_qmatmul(
+    content: &gguf_file::Content,
+    file: &mut std::fs::File,
+    name: &str,
+    device: &Device,
+) -> anyhow::Result<QMatMul> {
+    let qt = content
+        .tensor(file, name, device)
+        .map_err(|e| anyhow::anyhow!("failed to load tensor {name}: {e}"))?;
+    QMatMul::from_qtensor(qt)
+        .map_err(|e| anyhow::anyhow!("failed to create QMatMul for {name}: {e}"))
+}
+
+impl QuantizedGpt2 {
+    /// Load a quantized GPT-2 model from a GGUF file.
+    pub fn from_gguf(path: &Path, device: &Device) -> anyhow::Result<Self> {
+        let mut file = std::fs::File::open(path)?;
+        let content = gguf_file::Content::read(&mut file)
+            .map_err(|e| anyhow::anyhow!("failed to read GGUF: {e}"))?;
+
+        let config = Gpt2Config::from_gguf(&content);
+
+        // Embeddings (typically F16/F32 in GGUF, not quantized)
+        let wte_weight = load_tensor(&content, &mut file, "token_embd.weight", device)?;
+        let wte = Embedding::new(wte_weight, config.n_embd);
+
+        let wpe_weight = load_tensor(&content, &mut file, "position_embd.weight", device)?;
+        let wpe = Embedding::new(wpe_weight, config.n_embd);
+
+        // Transformer blocks
+        let mut blocks = Vec::with_capacity(config.n_layer);
+        for i in 0..config.n_layer {
+            let ln_1 = LayerNorm::new(
+                load_tensor(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.attn_norm.weight"),
+                    device,
+                )?,
+                load_tensor(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.attn_norm.bias"),
+                    device,
+                )?,
+                1e-5,
+            );
+
+            let attn = Attention {
+                qkv: load_qmatmul(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.attn_qkv.weight"),
+                    device,
+                )?,
+                qkv_bias: load_tensor(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.attn_qkv.bias"),
+                    device,
+                )?,
+                out_proj: load_qmatmul(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.attn_output.weight"),
+                    device,
+                )?,
+                out_bias: load_tensor(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.attn_output.bias"),
+                    device,
+                )?,
+                n_head: config.n_head,
+                head_dim: config.head_dim(),
+                kv_cache: None,
+            };
+
+            let ln_2 = LayerNorm::new(
+                load_tensor(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.ffn_norm.weight"),
+                    device,
+                )?,
+                load_tensor(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.ffn_norm.bias"),
+                    device,
+                )?,
+                1e-5,
+            );
+
+            let mlp = Mlp {
+                fc: load_qmatmul(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.ffn_up.weight"),
+                    device,
+                )?,
+                fc_bias: load_tensor(&content, &mut file, &format!("blk.{i}.ffn_up.bias"), device)?,
+                proj: load_qmatmul(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.ffn_down.weight"),
+                    device,
+                )?,
+                proj_bias: load_tensor(
+                    &content,
+                    &mut file,
+                    &format!("blk.{i}.ffn_down.bias"),
+                    device,
+                )?,
+            };
+
+            blocks.push(Block {
+                ln_1,
+                attn,
+                ln_2,
+                mlp,
+            });
+        }
+
+        // Final layer norm
+        let ln_f = LayerNorm::new(
+            load_tensor(&content, &mut file, "output_norm.weight", device)?,
+            load_tensor(&content, &mut file, "output_norm.bias", device)?,
+            1e-5,
+        );
+
+        // lm_head: may be absent if weight tying (use wte instead)
+        let lm_head = if content.tensor_infos.contains_key("output.weight") {
+            Some(load_qmatmul(&content, &mut file, "output.weight", device)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            wte,
+            wpe,
+            blocks,
+            ln_f,
+            lm_head,
+            config,
+        })
+    }
+
+    /// Run forward pass and return logits for the last token.
+    ///
+    /// `tokens`: input token IDs
+    /// `pos`: position offset (for KV-cache continuation)
+    ///
+    /// Returns logits tensor of shape `[vocab_size]`.
+    pub fn forward(&mut self, tokens: &[u32], pos: usize) -> Result<Tensor> {
+        let device = self.wte.embeddings().device().clone();
+        let seq_len = tokens.len();
+
+        // Token IDs → embedding
+        let token_ids = Tensor::new(tokens, &device)?;
+        let token_embd = self.wte.forward(&token_ids)?;
+
+        // Position IDs → embedding
+        let positions: Vec<u32> = (pos as u32..(pos + seq_len) as u32).collect();
+        let pos_ids = Tensor::new(positions.as_slice(), &device)?;
+        let pos_embd = self.wpe.forward(&pos_ids)?;
+
+        // Initial hidden state
+        let mut h = (token_embd + pos_embd)?;
+
+        // Add batch dimension: [1, seq_len, n_embd]
+        h = h.unsqueeze(0)?;
+
+        // Transformer blocks
+        for block in &mut self.blocks {
+            h = block.forward(&h, pos)?;
+        }
+
+        // Final layer norm
+        h = self.ln_f.forward(&h)?;
+
+        // Take last token: [1, n_embd]
+        let last = h.i((.., seq_len - 1, ..))?;
+
+        // Project to vocab: [1, vocab_size]
+        let logits = if let Some(ref lm_head) = self.lm_head {
+            lm_head.forward(&last)?
+        } else {
+            // Weight tying: logits = last @ wte.T
+            let wte_weight = self.wte.embeddings();
+            last.matmul(&wte_weight.t()?)?
+        };
+
+        // Remove batch dim → [vocab_size]
+        logits.squeeze(0)
+    }
+
+    /// Reset the KV cache (call between independent sequences).
+    pub fn reset_kv_cache(&mut self) {
+        for block in &mut self.blocks {
+            block.attn.kv_cache = None;
+        }
+    }
+
+    /// Save a snapshot of the current KV cache state.
+    ///
+    /// `Tensor::clone()` is O(1) (Arc-based reference counting),
+    /// so this is cheap even for large caches.
+    pub fn save_kv_cache(&self) -> Vec<Option<(Tensor, Tensor)>> {
+        self.blocks
+            .iter()
+            .map(|b| b.attn.kv_cache.clone())
+            .collect()
+    }
+
+    /// Restore KV cache from a previously saved snapshot.
+    pub fn restore_kv_cache(&mut self, snapshot: &[Option<(Tensor, Tensor)>]) {
+        for (block, cache) in self.blocks.iter_mut().zip(snapshot.iter()) {
+            block.attn.kv_cache = cache.clone();
+        }
+    }
+
+    /// Get model configuration summary.
+    pub fn config_summary(&self) -> String {
+        format!(
+            "GPT-2: {}L/{}H/{}E, vocab={}, ctx={}",
+            self.config.n_layer,
+            self.config.n_head,
+            self.config.n_embd,
+            self.config.vocab_size,
+            self.config.n_positions,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gelu_new_zero() {
+        let device = Device::Cpu;
+        let x = Tensor::new(&[0.0f32], &device).unwrap();
+        let y = gelu_new(&x).unwrap();
+        let val: Vec<f32> = y.to_vec1().unwrap();
+        assert!((val[0]).abs() < 1e-6, "gelu_new(0) should be ~0");
+    }
+
+    #[test]
+    fn test_gelu_new_positive() {
+        let device = Device::Cpu;
+        let x = Tensor::new(&[1.0f32], &device).unwrap();
+        let y = gelu_new(&x).unwrap();
+        let val: Vec<f32> = y.to_vec1().unwrap();
+        // gelu_new(1.0) ≈ 0.8412
+        assert!(
+            (val[0] - 0.8412).abs() < 0.01,
+            "gelu_new(1.0) ≈ 0.8412, got {}",
+            val[0]
+        );
+    }
+
+    #[test]
+    fn test_causal_mask() {
+        let mask = create_causal_mask(3, 3, &Device::Cpu).unwrap();
+        let vals: Vec<f32> = mask.flatten_all().unwrap().to_vec1().unwrap();
+        // Row 0: [0, -inf, -inf]
+        // Row 1: [0, 0, -inf]
+        // Row 2: [0, 0, 0]
+        assert_eq!(vals[0], 0.0); // (0,0)
+        assert!(vals[1].is_infinite()); // (0,1)
+        assert!(vals[2].is_infinite()); // (0,2)
+        assert_eq!(vals[3], 0.0); // (1,0)
+        assert_eq!(vals[4], 0.0); // (1,1)
+        assert!(vals[5].is_infinite()); // (1,2)
+        assert_eq!(vals[6], 0.0); // (2,0)
+        assert_eq!(vals[7], 0.0); // (2,1)
+        assert_eq!(vals[8], 0.0); // (2,2)
+    }
+
+    #[test]
+    fn test_causal_mask_with_offset() {
+        // Simulating KV-cache scenario: seq_len=1, total_len=4 (3 cached + 1 new)
+        let mask = create_causal_mask(1, 4, &Device::Cpu).unwrap();
+        let vals: Vec<f32> = mask.flatten_all().unwrap().to_vec1().unwrap();
+        // Single query at position 3 can attend to all 4 positions
+        assert_eq!(vals, vec![0.0, 0.0, 0.0, 0.0]);
+    }
+}

--- a/engine/src/neural/mod.rs
+++ b/engine/src/neural/mod.rs
@@ -1,0 +1,259 @@
+//! Neural scoring for IME conversion using Zenzai GPT-2.
+//!
+//! This module provides neural language model scoring for re-ranking
+//! Viterbi N-best candidates. It loads a GGUF quantized GPT-2 model
+//! and computes log-probabilities for candidate strings.
+
+mod gpt2;
+mod tokenizer;
+
+use std::path::Path;
+
+use candle_core::{Device, IndexOp, Tensor};
+
+use crate::converter::ConvertedSegment;
+
+pub use gpt2::QuantizedGpt2;
+pub use tokenizer::{hiragana_to_katakana, BpeTokenizer, CHAR_CONTEXT, CHAR_INPUT, CHAR_OUTPUT};
+
+pub struct NeuralScorer {
+    model: QuantizedGpt2,
+    tokenizer: BpeTokenizer,
+    device: Device,
+}
+
+impl NeuralScorer {
+    /// Load a neural scorer from a GGUF model file.
+    pub fn open(model_path: &Path) -> anyhow::Result<Self> {
+        let device = Device::Cpu;
+
+        // Read GGUF content for both model weights and tokenizer metadata
+        let mut file = std::fs::File::open(model_path)?;
+        let content = candle_core::quantized::gguf_file::Content::read(&mut file)
+            .map_err(|e| anyhow::anyhow!("failed to read GGUF: {e}"))?;
+
+        let tokenizer = BpeTokenizer::from_gguf(&content)?;
+        drop(file); // Close file before loading model (which reopens it)
+        let model = QuantizedGpt2::from_gguf(model_path, &device)?;
+
+        Ok(Self {
+            model,
+            tokenizer,
+            device,
+        })
+    }
+
+    /// Compute the log-probability of `output` given `context` and `kana`.
+    ///
+    /// Builds the Zenzai prompt:
+    ///   `\uEE02{context}\uEE00{katakana}\uEE01{output}</s>`
+    /// and sums the log-probabilities of the output tokens.
+    pub fn score_text(&mut self, context: &str, kana: &str, output: &str) -> anyhow::Result<f64> {
+        let prompt = build_prompt(context, kana, output);
+        let tokens = self.tokenizer.encode(&prompt);
+
+        if tokens.is_empty() {
+            return Ok(f64::NEG_INFINITY);
+        }
+
+        // Find the position of U+EE01 (output marker)
+        let output_marker_tokens = self.tokenizer.encode(&CHAR_OUTPUT.to_string());
+        let output_start = find_subsequence(&tokens, &output_marker_tokens)
+            .ok_or_else(|| anyhow::anyhow!("output marker not found in tokenized prompt"))?
+            + output_marker_tokens.len();
+
+        // Forward pass through entire sequence
+        self.model.reset_kv_cache();
+        let logits_all = self.forward_all(&tokens)?;
+
+        // Sum log-probabilities for output tokens (from output_start to end)
+        let mut log_prob = 0.0;
+        for i in output_start..tokens.len() {
+            // logits at position i-1 predict token at position i
+            let logits = &logits_all[i - 1];
+            let lp = log_softmax_at(logits, tokens[i], &self.device)?;
+            log_prob += lp;
+        }
+
+        Ok(log_prob)
+    }
+
+    /// Score multiple N-best paths and return them sorted by neural score (descending).
+    ///
+    /// Uses KV-cache prefix sharing: the common prefix (context + kana + output marker)
+    /// is processed once, then each candidate's output tokens are scored individually
+    /// by restoring the cached prefix state.
+    ///
+    /// Returns `Vec<(path_index, log_prob)>` sorted by `log_prob` descending.
+    pub fn score_paths(
+        &mut self,
+        context: &str,
+        kana: &str,
+        paths: &[Vec<ConvertedSegment>],
+    ) -> anyhow::Result<Vec<(usize, f64)>> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Build and process the shared prefix: \uEE02{context}\uEE00{katakana}\uEE01
+        let katakana = hiragana_to_katakana(kana);
+        let katakana = katakana.replace(' ', "\u{3000}");
+        let context = context.replace(' ', "\u{3000}");
+        let prefix = format!("{CHAR_CONTEXT}{context}{CHAR_INPUT}{katakana}{CHAR_OUTPUT}");
+        let prefix_tokens = self.tokenizer.encode(&prefix);
+
+        if prefix_tokens.is_empty() {
+            return Ok(paths
+                .iter()
+                .enumerate()
+                .map(|(i, _)| (i, f64::NEG_INFINITY))
+                .collect());
+        }
+
+        // Forward pass for the shared prefix (builds KV-cache)
+        self.model.reset_kv_cache();
+        let mut prefix_logits = None;
+        for (i, &token) in prefix_tokens.iter().enumerate() {
+            let logits = self
+                .model
+                .forward(&[token], i)
+                .map_err(|e| anyhow::anyhow!("prefix forward at position {i} failed: {e}"))?;
+            prefix_logits = Some(logits);
+        }
+        let prefix_logits =
+            prefix_logits.ok_or_else(|| anyhow::anyhow!("empty prefix after encoding"))?;
+
+        // Snapshot the KV-cache after processing the prefix
+        let kv_snapshot = self.model.save_kv_cache();
+        let prefix_len = prefix_tokens.len();
+
+        // Score each candidate by restoring the prefix cache
+        let mut scores: Vec<(usize, f64)> = Vec::with_capacity(paths.len());
+
+        for (i, path) in paths.iter().enumerate() {
+            let output: String = path.iter().map(|s| s.surface.as_str()).collect();
+            let output = output.replace(' ', "\u{3000}");
+            let output_with_eos = format!("{output}</s>");
+            let output_tokens = self.tokenizer.encode(&output_with_eos);
+
+            if output_tokens.is_empty() {
+                scores.push((i, f64::NEG_INFINITY));
+                continue;
+            }
+
+            // Restore KV-cache to the prefix state
+            self.model.restore_kv_cache(&kv_snapshot);
+
+            // First output token scored from prefix logits
+            let mut log_prob = log_softmax_at(&prefix_logits, output_tokens[0], &self.device)?;
+
+            // Forward remaining output tokens one by one
+            for j in 0..output_tokens.len() - 1 {
+                let logits = self
+                    .model
+                    .forward(&[output_tokens[j]], prefix_len + j)
+                    .map_err(|e| {
+                        anyhow::anyhow!("output forward at position {} failed: {e}", prefix_len + j)
+                    })?;
+                log_prob += log_softmax_at(&logits, output_tokens[j + 1], &self.device)?;
+            }
+
+            scores.push((i, log_prob));
+        }
+
+        // Sort by log_prob descending (higher = better)
+        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        Ok(scores)
+    }
+
+    /// Get model configuration summary.
+    pub fn config_summary(&self) -> String {
+        self.model.config_summary()
+    }
+
+    /// Run forward pass for all positions and collect per-position logits.
+    fn forward_all(&mut self, tokens: &[u32]) -> anyhow::Result<Vec<Tensor>> {
+        let mut logits_list = Vec::with_capacity(tokens.len());
+
+        // Process token-by-token with KV-cache for scoring.
+        // We need logits at every position to compute per-token log-probabilities.
+        self.model.reset_kv_cache();
+
+        for (i, &token) in tokens.iter().enumerate() {
+            let logits = self
+                .model
+                .forward(&[token], i)
+                .map_err(|e| anyhow::anyhow!("forward pass at position {i} failed: {e}"))?;
+            logits_list.push(logits);
+        }
+
+        Ok(logits_list)
+    }
+}
+
+/// Build the Zenzai v3 prompt format.
+///
+/// Format: `\uEE02{context}\uEE00{katakana}\uEE01{output}</s>`
+pub fn build_prompt(context: &str, kana: &str, output: &str) -> String {
+    let katakana = hiragana_to_katakana(kana);
+    // Replace ASCII spaces with fullwidth spaces (U+0020 → U+3000)
+    let katakana = katakana.replace(' ', "\u{3000}");
+    let output = output.replace(' ', "\u{3000}");
+    let context = context.replace(' ', "\u{3000}");
+
+    format!("{CHAR_CONTEXT}{context}{CHAR_INPUT}{katakana}{CHAR_OUTPUT}{output}</s>")
+}
+
+/// Find the starting index of `needle` in `haystack`.
+fn find_subsequence(haystack: &[u32], needle: &[u32]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Compute log_softmax for a specific token at a given logits vector.
+fn log_softmax_at(logits: &Tensor, token_id: u32, _device: &Device) -> anyhow::Result<f64> {
+    let log_probs = candle_nn::ops::log_softmax(logits, 0)
+        .map_err(|e| anyhow::anyhow!("log_softmax failed: {e}"))?;
+    let val = log_probs
+        .i(token_id as usize)
+        .map_err(|e| anyhow::anyhow!("index failed: {e}"))?
+        .to_scalar::<f32>()
+        .map_err(|e| anyhow::anyhow!("to_scalar failed: {e}"))?;
+    Ok(val as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_prompt() {
+        let prompt = build_prompt("", "きょうはいいてんきです", "今日はいい天気です");
+        assert_eq!(
+            prompt,
+            "\u{EE02}\u{EE00}キョウハイイテンキデス\u{EE01}今日はいい天気です</s>"
+        );
+    }
+
+    #[test]
+    fn test_build_prompt_with_context() {
+        let prompt = build_prompt("東京は", "きょうはいいてんきです", "今日はいい天気です");
+        assert_eq!(
+            prompt,
+            "\u{EE02}東京は\u{EE00}キョウハイイテンキデス\u{EE01}今日はいい天気です</s>"
+        );
+    }
+
+    #[test]
+    fn test_build_prompt_space_replacement() {
+        let prompt = build_prompt("a b", "a b", "a b");
+        assert!(prompt.contains('\u{3000}'));
+        assert!(!prompt.contains(' '));
+    }
+
+    #[test]
+    fn test_find_subsequence() {
+        assert_eq!(find_subsequence(&[1, 2, 3, 4, 5], &[3, 4]), Some(2));
+        assert_eq!(find_subsequence(&[1, 2, 3], &[4, 5]), None);
+        assert_eq!(find_subsequence(&[1, 2, 3], &[1]), Some(0));
+    }
+}

--- a/engine/src/neural/tokenizer.rs
+++ b/engine/src/neural/tokenizer.rs
@@ -1,0 +1,385 @@
+//! BPE tokenizer for Zenzai GPT-2, loaded from GGUF metadata.
+//!
+//! The GGUF file embeds `tokenizer.ggml.tokens` and `tokenizer.ggml.merges`
+//! which we parse to build a GPT-2-style **byte-level** BPE encoder.
+//!
+//! GPT-2 BPE encodes text as UTF-8 bytes, then maps each byte to a
+//! displayable Unicode character via a fixed table. BPE merges operate
+//! on these mapped characters.
+
+use std::collections::HashMap;
+
+use candle_core::quantized::gguf_file;
+
+/// Zenzai special characters.
+pub const CHAR_INPUT: char = '\u{EE00}';
+pub const CHAR_OUTPUT: char = '\u{EE01}';
+pub const CHAR_CONTEXT: char = '\u{EE02}';
+
+/// Special token IDs (Zenzai convention).
+const UNK_ID: u32 = 0;
+const EOS_ID: u32 = 3;
+
+/// Special token strings that should be matched atomically.
+const SPECIAL_TOKENS: &[&str] = &["[UNK]", "[PAD]", "<s>", "</s>"];
+
+pub struct BpeTokenizer {
+    /// token string → token ID
+    token_to_id: HashMap<String, u32>,
+    /// token ID → token string
+    id_to_token: Vec<String>,
+    /// Ordered merge rules: (left, right, merged)
+    merges: Vec<(String, String, String)>,
+    /// byte value → GPT-2 mapped character
+    byte_to_char: [char; 256],
+    /// GPT-2 mapped character → byte value
+    char_to_byte: HashMap<char, u8>,
+}
+
+impl BpeTokenizer {
+    /// Build the tokenizer from GGUF metadata.
+    pub fn from_gguf(content: &gguf_file::Content) -> anyhow::Result<Self> {
+        let tokens = get_string_array(&content.metadata, "tokenizer.ggml.tokens")?;
+        let merge_strs = get_string_array(&content.metadata, "tokenizer.ggml.merges")?;
+
+        let mut token_to_id = HashMap::with_capacity(tokens.len());
+        let mut id_to_token = Vec::with_capacity(tokens.len());
+        for (i, tok) in tokens.iter().enumerate() {
+            token_to_id.insert(tok.clone(), i as u32);
+            id_to_token.push(tok.clone());
+        }
+
+        let merges: Vec<(String, String, String)> = merge_strs
+            .iter()
+            .filter_map(|line| {
+                let mut parts = line.splitn(2, ' ');
+                let left = parts.next()?.to_string();
+                let right = parts.next()?.to_string();
+                let merged = format!("{left}{right}");
+                Some((left, right, merged))
+            })
+            .collect();
+
+        let (byte_to_char, char_to_byte) = build_byte_mapping();
+
+        Ok(Self {
+            token_to_id,
+            id_to_token,
+            merges,
+            byte_to_char,
+            char_to_byte,
+        })
+    }
+
+    /// Encode text into token IDs using GPT-2 byte-level BPE.
+    pub fn encode(&self, text: &str) -> Vec<u32> {
+        if text.is_empty() {
+            return Vec::new();
+        }
+
+        // 1. Extract special tokens first, splitting around them.
+        let segments = split_special_tokens(text);
+
+        let mut all_ids = Vec::new();
+        for segment in segments {
+            if let Some(&id) = self.token_to_id.get(segment.as_str()) {
+                // Atomic special token
+                all_ids.push(id);
+            } else {
+                // Byte-level BPE encode
+                let ids = self.bpe_encode_segment(&segment);
+                all_ids.extend(ids);
+            }
+        }
+
+        all_ids
+    }
+
+    /// Decode token IDs back to text.
+    ///
+    /// Reverses the byte-level mapping: concatenates token strings,
+    /// then converts the GPT-2 mapped characters back to UTF-8 bytes.
+    pub fn decode(&self, tokens: &[u32]) -> String {
+        let mapped: String = tokens
+            .iter()
+            .filter_map(|&id| self.id_to_token.get(id as usize))
+            .cloned()
+            .collect();
+
+        // Check if it looks like a special token (starts with [ or <)
+        // For tokens like </s>, [UNK], etc., return as-is
+        // For normal text, reverse the byte mapping
+        let bytes: Vec<u8> = mapped
+            .chars()
+            .map(|c| self.char_to_byte.get(&c).copied().unwrap_or(b'?'))
+            .collect();
+
+        String::from_utf8(bytes).unwrap_or(mapped)
+    }
+
+    /// Decode token IDs back to the raw GPT-2 token strings (no byte mapping reversal).
+    pub fn decode_raw(&self, tokens: &[u32]) -> String {
+        tokens
+            .iter()
+            .filter_map(|&id| self.id_to_token.get(id as usize))
+            .cloned()
+            .collect()
+    }
+
+    /// EOS token ID (</s> = 3).
+    pub fn eos_token(&self) -> u32 {
+        EOS_ID
+    }
+
+    /// Vocabulary size.
+    pub fn vocab_size(&self) -> usize {
+        self.id_to_token.len()
+    }
+
+    /// BPE encode a text segment (no special tokens).
+    fn bpe_encode_segment(&self, text: &str) -> Vec<u32> {
+        // Convert to byte-level symbols using GPT-2 mapping.
+        let mut symbols: Vec<String> = text
+            .as_bytes()
+            .iter()
+            .map(|&b| self.byte_to_char[b as usize].to_string())
+            .collect();
+
+        // Apply BPE merges greedily in priority order.
+        for (left, right, merged) in &self.merges {
+            let mut i = 0;
+            while i + 1 < symbols.len() {
+                if symbols[i] == *left && symbols[i + 1] == *right {
+                    symbols[i] = merged.clone();
+                    symbols.remove(i + 1);
+                    // Re-check from the previous position
+                    i = i.saturating_sub(1);
+                } else {
+                    i += 1;
+                }
+            }
+        }
+
+        // Map to IDs.
+        symbols
+            .iter()
+            .map(|s| self.token_to_id.get(s).copied().unwrap_or(UNK_ID))
+            .collect()
+    }
+}
+
+/// Build the GPT-2 byte-to-unicode mapping table.
+///
+/// GPT-2 maps bytes 0-255 to displayable Unicode characters:
+/// - Printable ASCII (33-126), Latin-1 supplement (161-172, 174-255)
+///   are mapped to themselves.
+/// - All other bytes (0-32, 127-160, 173) are mapped to U+0100..U+0143
+///   to avoid control characters in the token vocabulary.
+fn build_byte_mapping() -> ([char; 256], HashMap<char, u8>) {
+    let mut byte_to_char = ['\0'; 256];
+    let mut char_to_byte = HashMap::new();
+
+    // Directly mapped bytes: printable ranges
+    let mut direct: Vec<u8> = Vec::new();
+    direct.extend(33u8..=126); // ASCII printable (excluding space)
+    direct.extend(161u8..=172); // ¡ through ¬
+    direct.extend(174u8..=255); // ® through ÿ
+
+    for &b in &direct {
+        let c = b as char;
+        byte_to_char[b as usize] = c;
+        char_to_byte.insert(c, b);
+    }
+
+    // Remapped bytes: control chars and other non-printable
+    let mut remap_idx: u32 = 256; // Start at U+0100
+    for b in 0u16..=255 {
+        let b = b as u8;
+        if byte_to_char[b as usize] == '\0' {
+            let c = char::from_u32(remap_idx).unwrap();
+            byte_to_char[b as usize] = c;
+            char_to_byte.insert(c, b);
+            remap_idx += 1;
+        }
+    }
+
+    (byte_to_char, char_to_byte)
+}
+
+/// Split text into segments, isolating special tokens as separate items.
+fn split_special_tokens(text: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut remaining = text;
+
+    while !remaining.is_empty() {
+        // Try to find the earliest special token match
+        let mut earliest: Option<(usize, &str)> = None;
+        for &special in SPECIAL_TOKENS {
+            if let Some(pos) = remaining.find(special) {
+                if earliest.is_none() || pos < earliest.unwrap().0 {
+                    earliest = Some((pos, special));
+                }
+            }
+        }
+
+        match earliest {
+            Some((pos, special)) => {
+                if pos > 0 {
+                    segments.push(remaining[..pos].to_string());
+                }
+                segments.push(special.to_string());
+                remaining = &remaining[pos + special.len()..];
+            }
+            None => {
+                segments.push(remaining.to_string());
+                break;
+            }
+        }
+    }
+
+    segments
+}
+
+/// Extract a string array from GGUF metadata.
+fn get_string_array(
+    metadata: &HashMap<String, gguf_file::Value>,
+    key: &str,
+) -> anyhow::Result<Vec<String>> {
+    let value = metadata
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("missing GGUF metadata key: {key}"))?;
+    let arr = value
+        .to_vec()
+        .map_err(|e| anyhow::anyhow!("metadata key {key} is not an array: {e}"))?;
+    arr.iter()
+        .map(|v| {
+            v.to_string()
+                .cloned()
+                .map_err(|e| anyhow::anyhow!("non-string element in {key}: {e}"))
+        })
+        .collect()
+}
+
+/// Convert hiragana to katakana (for Zenzai input format).
+pub fn hiragana_to_katakana(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if ('\u{3040}'..='\u{309F}').contains(&c) {
+                char::from_u32(c as u32 + 0x60).unwrap_or(c)
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- byte mapping tests ---
+
+    #[test]
+    fn test_byte_mapping_roundtrip() {
+        let (byte_to_char, char_to_byte) = build_byte_mapping();
+        // Every byte should map to a unique char and back
+        for b in 0u16..=255 {
+            let b = b as u8;
+            let c = byte_to_char[b as usize];
+            assert_ne!(c, '\0', "byte {b} should be mapped");
+            assert_eq!(char_to_byte[&c], b, "char {c} should map back to byte {b}");
+        }
+        // All 256 chars should be unique
+        let mut chars: Vec<char> = byte_to_char.to_vec();
+        chars.sort();
+        chars.dedup();
+        assert_eq!(chars.len(), 256);
+    }
+
+    #[test]
+    fn test_byte_mapping_ascii() {
+        let (byte_to_char, _) = build_byte_mapping();
+        // Printable ASCII should map to themselves
+        assert_eq!(byte_to_char[b'A' as usize], 'A');
+        assert_eq!(byte_to_char[b'z' as usize], 'z');
+        assert_eq!(byte_to_char[b'!' as usize], '!');
+        // Space (32) is NOT directly mapped
+        assert_ne!(byte_to_char[b' ' as usize], ' ');
+    }
+
+    #[test]
+    fn test_split_special_tokens() {
+        let result = split_special_tokens("hello</s>");
+        assert_eq!(result, vec!["hello", "</s>"]);
+
+        let result = split_special_tokens("</s>");
+        assert_eq!(result, vec!["</s>"]);
+
+        let result = split_special_tokens("abc<s>def</s>");
+        assert_eq!(result, vec!["abc", "<s>", "def", "</s>"]);
+
+        let result = split_special_tokens("no specials here");
+        assert_eq!(result, vec!["no specials here"]);
+
+        let result = split_special_tokens("");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_hiragana_to_katakana() {
+        assert_eq!(hiragana_to_katakana("きょうは"), "キョウハ");
+        assert_eq!(hiragana_to_katakana("らーめん"), "ラーメン");
+        assert_eq!(hiragana_to_katakana("abc"), "abc");
+    }
+
+    // --- GGUF integration tests (require model file) ---
+
+    #[test]
+    #[ignore]
+    fn inspect_gguf_vocab() {
+        let model_path = std::path::Path::new(
+            "/Users/kazuaki.sakai/repos/send.sh/lexime/data/zenz-v3.1-Q5_K_M.gguf",
+        );
+        if !model_path.exists() {
+            println!("GGUF file not found, skipping");
+            return;
+        }
+
+        let mut file = std::fs::File::open(model_path).expect("failed to open GGUF");
+        let content = candle_core::quantized::gguf_file::Content::read(&mut file)
+            .expect("failed to read GGUF content");
+
+        let tok = BpeTokenizer::from_gguf(&content).expect("failed to build tokenizer");
+        println!("Vocab size: {}", tok.vocab_size());
+
+        // Test encoding of Japanese text
+        let text = "今日はいい天気です";
+        let ids = tok.encode(text);
+        println!("encode('{text}'): {ids:?}");
+        let decoded = tok.decode(&ids);
+        println!("decode back: '{decoded}'");
+        assert_eq!(decoded, text, "encode/decode roundtrip failed");
+
+        // Test full Zenzai prompt
+        let prompt = "\u{EE02}\u{EE00}キョウハイイテンキデス\u{EE01}今日はいい天気です</s>";
+        let ids = tok.encode(prompt);
+        println!("prompt IDs ({} tokens): {:?}", ids.len(), ids);
+        // Should not contain UNK (0) for known characters
+        let unk_count = ids.iter().filter(|&&id| id == 0).count();
+        println!("UNK count: {unk_count}");
+        assert_eq!(unk_count, 0, "prompt should not contain UNK tokens");
+
+        // Verify </s> is a single token at the end
+        assert_eq!(*ids.last().unwrap(), EOS_ID, "last token should be EOS");
+
+        // Test different outputs produce different encodings
+        let ids_a = tok.encode("今日はいい天気です");
+        let ids_b = tok.encode("教派いい天気です");
+        assert_ne!(
+            ids_a, ids_b,
+            "different text should produce different token IDs"
+        );
+        println!("'今日はいい天気です' => {} tokens", ids_a.len());
+        println!("'教派いい天気です'  => {} tokens", ids_b.len());
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -211,6 +211,32 @@ cd engine && cargo run --release --bin lextool -- diff-snapshot \
 description = "Stream trace JSONL output"
 run = "tail -f ~/Library/Logs/Lexime/lexime-trace.jsonl | python3 -m json.tool --no-ensure-ascii"
 
+[tasks.fetch-model]
+description = "Download Zenzai GGUF model"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p data
+if [ -f data/zenz-v3.1-Q5_K_M.gguf ]; then
+  echo "Model already exists at data/zenz-v3.1-Q5_K_M.gguf"
+  exit 0
+fi
+echo "Downloading zenz-v3.1-small-gguf (Q5_K_M, ~74MB)..."
+curl -L -o data/zenz-v3.1-Q5_K_M.gguf \
+  "https://huggingface.co/Miwa-Keita/zenz-v3.1-small-gguf/resolve/main/ggml-model-Q5_K_M.gguf"
+echo "Downloaded to data/zenz-v3.1-Q5_K_M.gguf"
+"""
+
+[tasks.neural-score]
+description = "Run neural scoring benchmark"
+depends = ["fetch-model", "dict", "conn"]
+run = """
+cd engine && cargo run --features neural --bin dictool -- neural-score \
+  data/lexime.dict data/lexime.conn \
+  --model ../data/zenz-v3.1-Q5_K_M.gguf \
+  "$@"
+"""
+
 [tasks.lint]
 description = "Run cargo fmt --check and clippy"
 run = [


### PR DESCRIPTION
## Summary

- Add GGUF quantized GPT-2 inference (`engine/src/neural/`) behind `neural` feature flag for re-ranking Viterbi N-best candidates
- Implement byte-level BPE tokenizer from GGUF metadata, GPT-2 forward pass with KV-cache, and NeuralScorer API
- Add `dictool neural-score` subcommand for benchmarking neural re-ranking
- KV-cache prefix sharing optimization: shared context+kana prefix processed once, each candidate scores only its output tokens (~65% latency reduction)

### Benchmark results

```
Input: きょうはいいてんきです (11 candidates)

Viterbi #1: 教派いい天気です  →  Neural #8 (log_prob: -14.09)
Viterbi #2: 今日はいい天気です  →  Neural #1 (log_prob: -0.22) ✓

Latency: 430ms (viterbi: 4ms, neural: 426ms, model_load: 41ms)
```

## Test plan

- [x] `cargo fmt --check && cargo clippy --features neural -- -D warnings`
- [x] `cargo test --features neural` — 281 passed, 0 failed
- [x] GGUF tokenizer integration test: encode/decode roundtrip, 0 UNK tokens
- [x] `dictool neural-score` benchmark with multiple inputs
- [x] KV-cache prefix sharing produces identical scores to naive approach
- [x] Default build (`cargo test`) unaffected — neural is opt-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)