### PR TITLE
feat: add GhostText conversion mode (Phase C)

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -6,6 +6,7 @@ class AppContext {
     let dict: OpaquePointer?
     let conn: OpaquePointer?
     let history: OpaquePointer?
+    let neural: OpaquePointer?  // LexNeuralScorer*
     let historyPath: String
     let candidatePanel = CandidatePanel()
 
@@ -57,6 +58,21 @@ class AppContext {
         } else {
             NSLog("Lexime: Failed to open user history at %@", self.historyPath)
             self.history = nil
+        }
+
+        // Load neural model (optional — GhostText mode requires this)
+        let modelPath = resourcePath + "/zenz-v3.1-Q5_K_M.gguf"
+        if FileManager.default.fileExists(atPath: modelPath) {
+            if let n = lex_neural_open(modelPath) {
+                NSLog("Lexime: Neural model loaded from %@", modelPath)
+                self.neural = n
+            } else {
+                NSLog("Lexime: Failed to load neural model at %@", modelPath)
+                self.neural = nil
+            }
+        } else {
+            NSLog("Lexime: Neural model not found at %@ (GhostText mode unavailable)", modelPath)
+            self.neural = nil
         }
     }
 }

--- a/Sources/MarkedTextManager.swift
+++ b/Sources/MarkedTextManager.swift
@@ -17,4 +17,22 @@ extension LeximeInputController {
                              selectionRange: NSRange(location: len, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: 0))
     }
+
+    /// Display ghost text (grayed-out, no underline) as marked text.
+    func showGhostText(_ text: String, client: IMKTextInput) {
+        let attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.placeholderTextColor,
+        ]
+        let attrStr = NSAttributedString(string: text, attributes: attrs)
+        client.setMarkedText(attrStr,
+                             selectionRange: NSRange(location: 0, length: 0),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    /// Clear ghost text by removing marked text.
+    func clearGhostText(client: IMKTextInput) {
+        client.setMarkedText("",
+                             selectionRange: NSRange(location: 0, length: 0),
+                             replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
 }

--- a/engine/src/candidates.rs
+++ b/engine/src/candidates.rs
@@ -346,6 +346,84 @@ pub fn generate_prediction_candidates(
     }
 }
 
+/// Generate candidates using neural speculative decoding (GhostText mode).
+///
+/// Uses speculative decode (Viterbi draft + GPT-2 verify) as the #1 candidate,
+/// followed by standard Viterbi N-best candidates. Falls back to standard
+/// candidate generation on neural failure.
+#[cfg(feature = "neural")]
+pub fn generate_neural_candidates(
+    scorer: &mut crate::neural::NeuralScorer,
+    dict: &TrieDictionary,
+    conn: Option<&ConnectionMatrix>,
+    history: Option<&UserHistory>,
+    context: &str,
+    reading: &str,
+    max_results: usize,
+) -> CandidateResponse {
+    let _span = debug_span!("generate_neural_candidates", reading, max_results).entered();
+
+    if reading.is_empty() {
+        return CandidateResponse {
+            surfaces: Vec::new(),
+            paths: Vec::new(),
+        };
+    }
+
+    // Punctuation → standard punctuation candidates
+    if punctuation_alternatives(reading).is_some() {
+        return generate_punctuation_candidates(dict, history, reading, max_results);
+    }
+
+    // Try speculative decoding
+    use crate::neural::speculative::{speculative_decode, SpeculativeConfig};
+
+    let config = SpeculativeConfig::default();
+    match speculative_decode(scorer, dict, conn, context, reading, &config) {
+        Ok(result) => {
+            let spec_surface: String = result.segments.iter().map(|s| s.surface.as_str()).collect();
+            let spec_segments = result.segments;
+
+            // Get standard candidates as the base
+            let base = generate_normal_candidates(dict, conn, history, reading, max_results);
+
+            let mut surfaces = Vec::new();
+            let mut seen = HashSet::new();
+            let mut paths = Vec::new();
+
+            // Speculative result as #1
+            if !spec_surface.is_empty() && seen.insert(spec_surface.clone()) {
+                surfaces.push(spec_surface);
+                paths.push(spec_segments);
+            }
+
+            // Then add base candidates
+            for (i, s) in base.surfaces.iter().enumerate() {
+                if seen.insert(s.clone()) {
+                    surfaces.push(s.clone());
+                }
+                // Include base paths
+                if i < base.paths.len() {
+                    paths.push(base.paths[i].clone());
+                }
+            }
+
+            surfaces.truncate(max_results);
+
+            debug!(
+                surface_count = surfaces.len(),
+                path_count = paths.len(),
+                "neural candidates"
+            );
+            CandidateResponse { surfaces, paths }
+        }
+        Err(e) => {
+            debug!("speculative decode failed, falling back to standard: {e}");
+            generate_normal_candidates(dict, conn, history, reading, max_results)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/src/neural/mod.rs
+++ b/engine/src/neural/mod.rs
@@ -10,12 +10,29 @@ mod tokenizer;
 
 use std::path::Path;
 
-use candle_core::{Device, IndexOp, Tensor};
+use candle_core::{DType, Device, IndexOp, Tensor};
 
 use crate::converter::ConvertedSegment;
 
 pub use gpt2::QuantizedGpt2;
 pub use tokenizer::{hiragana_to_katakana, BpeTokenizer, CHAR_CONTEXT, CHAR_INPUT, CHAR_OUTPUT};
+
+/// Configuration for autoregressive text generation.
+pub struct GenerateConfig {
+    /// Maximum number of tokens to generate.
+    pub max_tokens: usize,
+    /// Sampling temperature. 0.0 = greedy (argmax).
+    pub temperature: f32,
+}
+
+impl Default for GenerateConfig {
+    fn default() -> Self {
+        Self {
+            max_tokens: 30,
+            temperature: 0.0,
+        }
+    }
+}
 
 pub struct NeuralScorer {
     model: QuantizedGpt2,
@@ -214,6 +231,109 @@ impl NeuralScorer {
         map_token_logprobs_to_segments(&self.tokenizer, output_tokens, &token_logprobs, segments)
     }
 
+    /// Generate text continuation given context.
+    ///
+    /// Uses plain GPT-2 text continuation (no Zenzai kana conversion markers).
+    /// Context is truncated to 40 characters to stay within model's n_positions limit.
+    pub fn generate_text(
+        &mut self,
+        context: &str,
+        config: &GenerateConfig,
+    ) -> anyhow::Result<String> {
+        // Truncate context to last 40 characters
+        let truncated_context: String = context
+            .chars()
+            .rev()
+            .take(40)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        let truncated_context = truncated_context.replace(' ', "\u{3000}");
+
+        // Use Zenzai output format: place context after output marker so the model
+        // treats it as continuation text and generates what comes next.
+        let prompt = format!("{CHAR_CONTEXT}{CHAR_INPUT}{CHAR_OUTPUT}{truncated_context}");
+        let tokens = self.tokenizer.encode(&prompt);
+
+        if tokens.is_empty() {
+            return Ok(String::new());
+        }
+
+        // Forward pass for the prompt (builds KV-cache)
+        self.model.reset_kv_cache();
+        let mut logits = Tensor::zeros(1, DType::F32, &self.device)
+            .map_err(|e| anyhow::anyhow!("tensor init failed: {e}"))?;
+        for (i, &token) in tokens.iter().enumerate() {
+            logits = self
+                .model
+                .forward(&[token], i)
+                .map_err(|e| anyhow::anyhow!("forward at position {i} failed: {e}"))?;
+        }
+
+        let eos_id = self.tokenizer.eos_token();
+        // Also stop at Zenzai special marker tokens
+        let stop_tokens: Vec<u32> = [CHAR_CONTEXT, CHAR_INPUT, CHAR_OUTPUT]
+            .iter()
+            .flat_map(|c| self.tokenizer.encode(&c.to_string()))
+            .collect();
+        let mut generated_tokens: Vec<u32> = Vec::new();
+        let repetition_penalty: f32 = 1.3;
+
+        for _ in 0..config.max_tokens {
+            // Apply repetition penalty to already-generated tokens
+            if !generated_tokens.is_empty() {
+                let logits_vec: Vec<f32> = logits
+                    .to_vec1()
+                    .map_err(|e| anyhow::anyhow!("to_vec1 failed: {e}"))?;
+                let mut penalized = logits_vec;
+                for &prev_token in &generated_tokens {
+                    let idx = prev_token as usize;
+                    if idx < penalized.len() {
+                        if penalized[idx] > 0.0 {
+                            penalized[idx] /= repetition_penalty;
+                        } else {
+                            penalized[idx] *= repetition_penalty;
+                        }
+                    }
+                }
+                logits = Tensor::from_vec(penalized, logits.shape(), &self.device)
+                    .map_err(|e| anyhow::anyhow!("tensor from penalized: {e}"))?;
+            }
+
+            let next_token = argmax(&logits)?;
+
+            if next_token == eos_id || stop_tokens.contains(&next_token) {
+                break;
+            }
+
+            // Stop on consecutive repetition (same token 3+ times)
+            let repeat_count = generated_tokens
+                .iter()
+                .rev()
+                .take_while(|&&t| t == next_token)
+                .count();
+            if repeat_count >= 2 {
+                break;
+            }
+
+            generated_tokens.push(next_token);
+
+            let pos = tokens.len() + generated_tokens.len() - 1;
+            logits = self
+                .model
+                .forward(&[next_token], pos)
+                .map_err(|e| anyhow::anyhow!("generate forward at position {pos} failed: {e}"))?;
+        }
+
+        let text = self.tokenizer.decode(&generated_tokens);
+        // Convert fullwidth spaces back to ASCII spaces and strip special markers
+        let text = text
+            .replace('\u{3000}', " ")
+            .replace([CHAR_CONTEXT, CHAR_INPUT, CHAR_OUTPUT], "");
+        Ok(text)
+    }
+
     /// Get model configuration summary.
     pub fn config_summary(&self) -> String {
         self.model.config_summary()
@@ -332,6 +452,19 @@ pub(crate) fn map_token_logprobs_to_segments(
         .collect();
 
     Ok(scores)
+}
+
+/// Return the index of the maximum value in a 1-D logits tensor.
+fn argmax(logits: &Tensor) -> anyhow::Result<u32> {
+    let logits_vec: Vec<f32> = logits
+        .to_vec1()
+        .map_err(|e| anyhow::anyhow!("argmax to_vec1 failed: {e}"))?;
+    let (max_idx, _) = logits_vec
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .ok_or_else(|| anyhow::anyhow!("empty logits tensor"))?;
+    Ok(max_idx as u32)
 }
 
 /// Compute log_softmax for a specific token at a given logits vector.
@@ -456,5 +589,46 @@ mod tests {
         assert_eq!(find_subsequence(&[1, 2, 3, 4, 5], &[3, 4]), Some(2));
         assert_eq!(find_subsequence(&[1, 2, 3], &[4, 5]), None);
         assert_eq!(find_subsequence(&[1, 2, 3], &[1]), Some(0));
+    }
+
+    #[test]
+    fn test_argmax() {
+        use candle_core::Device;
+        let device = Device::Cpu;
+        let data = vec![0.1f32, 0.5, 0.3, 0.9, 0.2];
+        let tensor = Tensor::from_vec(data, 5, &device).unwrap();
+        let idx = argmax(&tensor).unwrap();
+        assert_eq!(idx, 3);
+    }
+
+    #[test]
+    fn test_argmax_single() {
+        use candle_core::Device;
+        let device = Device::Cpu;
+        let data = vec![42.0f32];
+        let tensor = Tensor::from_vec(data, 1, &device).unwrap();
+        let idx = argmax(&tensor).unwrap();
+        assert_eq!(idx, 0);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_generate_text_basic() {
+        let model_path = std::path::Path::new("../data/zenz-v3.1-Q5_K_M.gguf");
+        if !model_path.exists() {
+            eprintln!("Model not found at {:?}, skipping", model_path);
+            return;
+        }
+        let mut scorer = NeuralScorer::open(model_path).expect("failed to open model");
+        let config = GenerateConfig {
+            max_tokens: 10,
+            ..GenerateConfig::default()
+        };
+        let text = scorer
+            .generate_text("今日はいい天気です", &config)
+            .expect("generate_text failed");
+        eprintln!("Generated: {text}");
+        // Should generate some non-empty text
+        assert!(!text.is_empty(), "generated text should not be empty");
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -6,8 +6,8 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 cd engine
-cargo build --release --features trace --target x86_64-apple-darwin
-cargo build --release --features trace --target aarch64-apple-darwin
+cargo build --release --features trace,neural --target x86_64-apple-darwin
+cargo build --release --features trace,neural --target aarch64-apple-darwin
 cd ..
 mkdir -p build
 lipo -create \
@@ -135,6 +135,9 @@ cp -R Resources/en.lproj "$RES/en.lproj"
 cp -R Resources/ja.lproj "$RES/ja.lproj"
 cp engine/data/lexime.dict "$RES/"
 cp engine/data/lexime.conn "$RES/"
+if [ -f data/zenz-v3.1-Q5_K_M.gguf ]; then
+  cp data/zenz-v3.1-Q5_K_M.gguf "$RES/"
+fi
 codesign -f -s - "$APP"
 echo "Build complete: $APP"
 """


### PR DESCRIPTION
## Summary
- Add third conversion mode (GhostText) with GPT-2 speculative decode for composing candidates and ghost text prediction after commit
- Option+Tab cycles through standard → predictive → ghost (3-way, limited to 2-way if neural model absent)
- Ghost text lifecycle: 150ms debounced generation → grayed placeholder display → Tab to accept / any key to clear
- Build with `--features trace,neural` and bundle GGUF model in Resources

## Known Limitations
- Zenzai model is fine-tuned for kana→kanji conversion, not general text continuation — ghost text quality is limited
- Phase D (planned): investigate general-purpose Japanese LLM for ghost text generation

## Test plan
- [x] All 283 engine tests pass
- [x] clippy clean with `--features neural`
- [x] Manual test: Option+Tab mode cycling, ghost display, Tab accept, key clear
- [ ] CI build verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)