### PR TITLE
chore: fix mise sources, CI paths, and add Swift FFI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
             swift:
               - 'Sources/**'
               - 'Tests/**'
+              - 'Info.plist'
 
   engine:
     needs: changes

--- a/Tests/TestDictFFI.swift
+++ b/Tests/TestDictFFI.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+func testDictFFI() {
+    print("--- Dict FFI Tests ---")
+
+    // Open / close round-trip (nonexistent path returns nil)
+    do {
+        let dict = lex_dict_open("/nonexistent/path/dict.bin")
+        assertTrue(dict == nil, "open nonexistent returns nil")
+    }
+
+    // Lookup null dict returns empty
+    do {
+        let list = lex_dict_lookup(nil, "かんじ")
+        assertEqual(list.len, 0, "null dict lookup returns empty")
+        lex_candidates_free(list)
+    }
+
+    // Predict null dict returns empty
+    do {
+        let list = lex_dict_predict(nil, "かん", 10)
+        assertEqual(list.len, 0, "null dict predict returns empty")
+        lex_candidates_free(list)
+    }
+
+    // Close null is safe
+    do {
+        lex_dict_close(nil)
+        testsPassed += 1
+    }
+}

--- a/Tests/TestRunner.swift
+++ b/Tests/TestRunner.swift
@@ -31,6 +31,8 @@ func assertTrue(_ condition: Bool,
 struct TestMain {
     static func main() {
         testRomajiFFI()
+        testDictFFI()
+        testSessionFFI()
 
         print("\nResults: \(testsPassed) passed, \(testsFailed) failed")
         exit(testsFailed > 0 ? 1 : 0)

--- a/Tests/TestSessionFFI.swift
+++ b/Tests/TestSessionFFI.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+func testSessionFFI() {
+    print("--- Session FFI Tests ---")
+
+    // Null dict → null session
+    do {
+        let session = lex_session_new(nil, nil, nil)
+        assertTrue(session == nil, "null dict → null session")
+    }
+
+    // Null session operations are safe
+    do {
+        let resp = lex_session_handle_key(nil, 0, "", 0)
+        assertEqual(resp.consumed, 0, "null session handle_key consumed=0")
+        lex_key_response_free(resp)
+
+        let resp2 = lex_session_commit(nil)
+        assertEqual(resp2.consumed, 0, "null session commit consumed=0")
+        lex_key_response_free(resp2)
+
+        assertEqual(lex_session_is_composing(nil), 0, "null session is_composing=0")
+
+        lex_session_free(nil)
+        testsPassed += 1
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tasks.engine-lib]
 description = "Build universal static library (x86_64 + aarch64)"
-sources = ["engine/src/**/*.rs", "engine/Cargo.toml"]
+sources = ["engine/src/**/*.rs", "engine/Cargo.toml", "engine/include/engine.h"]
 outputs = ["build/liblex_engine.a"]
 run = """
 #!/usr/bin/env bash
@@ -102,6 +102,7 @@ description = "Build Lexime.app (universal binary)"
 depends = ["engine-lib", "dict", "conn"]
 sources = [
   "Sources/*.swift",
+  "Sources/Bridging-Header.h",
   "build/liblex_engine.a",
   "engine/data/lexime.dict",
   "engine/data/lexime.conn",
@@ -180,7 +181,7 @@ set -euo pipefail
 mkdir -p build
 swiftc -import-objc-header Sources/Bridging-Header.h -Xcc -I. \
   -Lbuild -llex_engine \
-  Tests/TestRunner.swift Tests/TestRomajiFFI.swift \
+  Tests/TestRunner.swift Tests/TestRomajiFFI.swift Tests/TestDictFFI.swift Tests/TestSessionFFI.swift \
   -o build/test-runner && build/test-runner
 """
 


### PR DESCRIPTION
## Summary
- Add missing `engine/include/engine.h` to `engine-lib` task sources and `Sources/Bridging-Header.h` to `build` task sources so header changes trigger rebuilds
- Add `Info.plist` to CI swift paths filter
- Add `TestDictFFI.swift` and `TestSessionFFI.swift` — dict and session null-safety round-trip tests (20 total assertions, up from 13)

## Test plan
- [x] `mise run test-swift` — 20 passed, 0 failed
- [x] CI paths correctly include new filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)