### PR TITLE
fix: enable --all-features in lint and test tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -242,16 +242,16 @@ cd engine && cargo run --features neural --bin dictool -- neural-score \
 """
 
 [tasks.lint]
-description = "Run cargo fmt --check and clippy"
+description = "Run cargo fmt --check and clippy (all features)"
 run = [
   "cd engine && cargo fmt --check",
-  "cd engine && cargo clippy -- -D warnings",
+  "cd engine && cargo clippy --all-features -- -D warnings",
 ]
 
 [tasks.test]
-description = "Run lint + engine tests"
+description = "Run lint + engine tests (all features)"
 depends = ["lint"]
-run = "cd engine && cargo test"
+run = "cd engine && cargo test --all-features"
 
 [tasks.clean]
 description = "Remove build artifacts"


### PR DESCRIPTION
## Summary
- Changed `mise.toml` lint task to use `cargo clippy --all-features` instead of bare `cargo clippy`
- Changed test task to use `cargo test --all-features`
- Ensures the `neural` and `trace` feature code paths are linted and tested both locally and in CI

Fixes review issues: Infra-1 (High), Infra-2 (High), Infra-9 (Low)

## Test plan
- [x] `mise run test` passes with `--all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)