### PR TITLE
fix: add debug_assert for connection matrix OOB and fix non-deterministic history boost

### DIFF
--- a/engine/src/converter/reranker.rs
+++ b/engine/src/converter/reranker.rs
@@ -113,13 +113,15 @@ pub fn history_rerank(paths: &mut [ScoredPath], history: &UserHistory) {
     if paths.is_empty() {
         return;
     }
+    let now = crate::user_history::now_epoch();
     for path in paths.iter_mut() {
         let mut boost: i64 = 0;
         for seg in &path.segments {
-            boost += history.unigram_boost(&seg.reading, &seg.surface);
+            boost += history.unigram_boost(&seg.reading, &seg.surface, now);
         }
         for pair in path.segments.windows(2) {
-            boost += history.bigram_boost(&pair[0].surface, &pair[1].reading, &pair[1].surface);
+            boost +=
+                history.bigram_boost(&pair[0].surface, &pair[1].reading, &pair[1].surface, now);
         }
         path.viterbi_cost -= boost;
     }

--- a/engine/src/ffi/dict.rs
+++ b/engine/src/ffi/dict.rs
@@ -176,9 +176,10 @@ pub extern "C" fn lex_dict_predict_ranked(
     if !history.is_null() {
         let wrapper = unsafe { &*history };
         if let Ok(h) = wrapper.inner.read() {
+            let now = crate::user_history::now_epoch();
             ranked.sort_by(|(r_a, e_a), (r_b, e_b)| {
-                let boost_a = h.unigram_boost(r_a, &e_a.surface);
-                let boost_b = h.unigram_boost(r_b, &e_b.surface);
+                let boost_a = h.unigram_boost(r_a, &e_a.surface, now);
+                let boost_b = h.unigram_boost(r_b, &e_b.surface, now);
                 boost_b.cmp(&boost_a).then(e_a.cost.cmp(&e_b.cost))
             });
         }


### PR DESCRIPTION
## Summary
- Added `debug_assert!` to `ConnectionMatrix::cost()` to catch out-of-bounds POS ID access in debug builds (release still returns 0 gracefully)
- Changed `unigram_boost`/`bigram_boost` to take an explicit `now: u64` parameter instead of calling `now_epoch()` internally. All callers compute `now_epoch()` once per batch operation, ensuring consistent timestamps within sort comparators and reranking loops
- Made `now_epoch()` public for caller access

Fixes review issues: Core-1 (High), Core-3 (High)

## Test plan
- [x] `cargo fmt --check && cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 302 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)