### PR TITLE
fix: address medium/low review issues in engine

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lex_engine"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.77"
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/engine/include/engine.h
+++ b/engine/include/engine.h
@@ -11,7 +11,7 @@ void lex_trace_init(const char * _Nonnull log_dir);
 
 /* Dictionary API */
 
-typedef struct LexDict LexDict;
+typedef struct LexDict LexDict;              /* Rust: TrieDictionary */
 
 typedef struct {
     const char * _Nonnull reading;
@@ -33,7 +33,7 @@ void lex_candidates_free(LexCandidateList list);
 
 /* Connection matrix API */
 
-typedef struct LexConnectionMatrix LexConnectionMatrix;
+typedef struct LexConnectionMatrix LexConnectionMatrix;  /* Rust: ConnectionMatrix */
 
 LexConnectionMatrix * _Nullable lex_conn_open(const char * _Nonnull path);
 void lex_conn_close(LexConnectionMatrix * _Nullable conn);
@@ -60,7 +60,7 @@ void lex_conversion_free(LexConversionResult result);
 
 /* User History API */
 
-typedef struct LexUserHistory LexUserHistory;
+typedef struct LexUserHistory LexUserHistory;  /* Rust: LexUserHistoryWrapper (RwLock<UserHistory>) */
 
 LexUserHistory * _Nullable lex_history_open(const char * _Nonnull path);
 void lex_history_close(LexUserHistory * _Nullable history);
@@ -166,7 +166,7 @@ void lex_candidate_response_free(LexCandidateResponse response);
 
 /* InputSession API */
 
-typedef struct LexSession LexSession;
+typedef struct LexSession LexSession;  /* Rust: LexSession (wraps InputSession) */
 
 typedef struct {
     uint8_t consumed;
@@ -203,14 +203,12 @@ void lex_session_set_conversion_mode(LexSession * _Nonnull session, uint8_t mode
 LexKeyResponse lex_session_handle_key(
     LexSession * _Nonnull session,
     uint16_t key_code,
-    const char * _Nonnull text,
+    const char * _Nullable text,
     uint8_t flags  /* bit0=shift, bit1=has_modifier(Cmd/Ctrl/Opt) */
 );
 
 LexKeyResponse lex_session_commit(LexSession * _Nonnull session);
 uint8_t lex_session_is_composing(const LexSession * _Nonnull session);
-
-const char * _Nonnull lex_session_composed_string(const LexSession * _Nonnull session);
 
 /* Get the committed context string for neural candidate generation.
  * Returns NULL if the context is empty.
@@ -226,7 +224,7 @@ uint32_t lex_key_response_history_count(const LexKeyResponse * _Nonnull response
  * Returns a LexKeyResponse with updated marked text and candidates. */
 LexKeyResponse lex_session_receive_candidates(
     LexSession * _Nonnull session,
-    const char * _Nonnull reading,
+    const char * _Nullable reading,
     const LexCandidateResponse * _Nonnull candidates
 );
 
@@ -247,7 +245,7 @@ uint64_t lex_session_ghost_generation(const LexSession * _Nonnull session);
 
 /* Neural scorer API */
 
-typedef struct LexNeuralScorer LexNeuralScorer;
+typedef struct LexNeuralScorer LexNeuralScorer;  /* Rust: LexNeuralScorer (Mutex<NeuralScorer>) */
 
 LexNeuralScorer * _Nullable lex_neural_open(const char * _Nonnull model_path);
 void lex_neural_close(LexNeuralScorer * _Nullable scorer);
@@ -259,7 +257,7 @@ typedef struct {
 
 LexGhostTextResult lex_neural_generate_ghost(
     LexNeuralScorer * _Nonnull scorer,
-    const char * _Nonnull context,
+    const char * _Nullable context,
     uint32_t max_tokens
 );
 void lex_ghost_text_free(LexGhostTextResult result);
@@ -269,8 +267,8 @@ LexCandidateResponse lex_generate_neural_candidates(
     const LexDict * _Nonnull dict,
     const LexConnectionMatrix * _Nullable conn,
     const LexUserHistory * _Nullable history,
-    const char * _Nonnull context,
-    const char * _Nonnull reading,
+    const char * _Nullable context,
+    const char * _Nullable reading,
     uint32_t max_results
 );
 

--- a/engine/src/candidates.rs
+++ b/engine/src/candidates.rs
@@ -156,7 +156,7 @@ fn generate_normal_candidates(
         }
     }
 
-    // 5. Dictionary lookup
+    // 4. Dictionary lookup
     let lookup_entries: Vec<&DictEntry> = if let Some(h) = history {
         if let Some(entries) = dict.lookup(reading) {
             let reordered = h.reorder_candidates(reading, entries);

--- a/engine/src/converter/mod.rs
+++ b/engine/src/converter/mod.rs
@@ -1,4 +1,4 @@
-#[allow(dead_code)]
+#[cfg(feature = "neural")]
 pub(crate) mod constrained;
 pub(crate) mod cost;
 pub mod explain;
@@ -38,6 +38,9 @@ fn postprocess(
     let katakana_rw = rewriter::KatakanaRewriter;
     let rewriters: Vec<&dyn rewriter::Rewriter> = vec![&katakana_rw];
     rewriter::run_rewriters(&rewriters, &mut top, kana);
+    // Rewriters may append extra candidates (e.g. katakana fallback);
+    // truncate back to the requested n to honour the caller's limit.
+    top.truncate(n);
     if let Some(c) = conn {
         for path in &mut top {
             group_segments(&mut path.segments, c);
@@ -115,7 +118,7 @@ fn group_segments(segments: &mut Vec<viterbi::RichSegment>, conn: &ConnectionMat
 ///
 /// Fixed segments in the prefix are enforced via a prohibitive cost for
 /// non-matching nodes. The suffix is explored freely.
-#[allow(dead_code)]
+#[cfg(feature = "neural")]
 pub(crate) fn convert_nbest_constrained(
     dict: &dyn Dictionary,
     conn: Option<&ConnectionMatrix>,

--- a/engine/src/dict/connection.rs
+++ b/engine/src/dict/connection.rs
@@ -223,6 +223,9 @@ impl ConnectionMatrix {
     }
 
     /// Build from a text file with function-word range and morpheme roles.
+    ///
+    /// `roles` must have length ≤ `num_ids`. IDs beyond the roles vector
+    /// length are treated as content words (role 0) by `role()`.
     pub fn from_text_with_roles(
         text: &str,
         fw_min: u16,
@@ -230,6 +233,9 @@ impl ConnectionMatrix {
         roles: Vec<u8>,
     ) -> Result<Self, DictError> {
         let mut m = Self::from_text(text)?;
+        if roles.len() > m.num_ids as usize {
+            return Err(DictError::InvalidHeader);
+        }
         m.fw_min = fw_min;
         m.fw_max = fw_max;
         m.roles = roles;

--- a/engine/src/ffi/dict.rs
+++ b/engine/src/ffi/dict.rs
@@ -35,6 +35,9 @@ impl LexCandidateList {
         let Ok(reading_cstr) = CString::new(reading) else {
             return Self::empty();
         };
+        // SAFETY: CString stores its data on the heap. Taking a pointer here and
+        // then moving the CString into `strings` is safe because Vec::push does
+        // not invalidate the CString's internal heap buffer.
         let reading_ptr = reading_cstr.as_ptr();
 
         let mut strings = Vec::with_capacity(entries.len() + 1);

--- a/engine/src/ffi/neural.rs
+++ b/engine/src/ffi/neural.rs
@@ -21,6 +21,7 @@ mod inner {
     }
 
     #[no_mangle]
+    #[must_use]
     pub extern "C" fn lex_neural_open(model_path: *const c_char) -> *mut LexNeuralScorer {
         ffi_guard!(ptr::null_mut() ; str: path_str = model_path ,);
         match crate::neural::NeuralScorer::open(std::path::Path::new(path_str)) {

--- a/engine/src/ffi/session.rs
+++ b/engine/src/ffi/session.rs
@@ -209,6 +209,7 @@ pub(crate) fn pack_key_response(
 /// The `history` pointer is only borrowed temporarily via `with_history()`;
 /// it does not need to outlive the session.
 #[no_mangle]
+#[must_use]
 pub extern "C" fn lex_session_new(
     dict: *const TrieDictionary,
     conn: *const ConnectionMatrix,
@@ -435,12 +436,6 @@ pub extern "C" fn lex_session_is_composing(session: *const LexSession) -> u8 {
     }
     let session = unsafe { &*session };
     session.inner.is_composing() as u8
-}
-
-/// Get the composed string for IMKit's composedString callback.
-#[no_mangle]
-pub extern "C" fn lex_session_composed_string(_session: *const LexSession) -> *const c_char {
-    c"".as_ptr()
 }
 
 /// Get the committed context string for neural candidate generation.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,10 +1,9 @@
-// FFI functions perform null checks before dereferencing raw pointers.
-// Clippy cannot verify this statically, so we allow it at crate level.
-#![allow(clippy::not_unsafe_ptr_arg_deref)]
-
 pub mod candidates;
 pub mod converter;
 pub mod dict;
+// FFI functions perform null checks before dereferencing raw pointers.
+// Clippy cannot verify this statically, so we scope the allow to the FFI module.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 mod ffi;
 #[cfg(feature = "neural")]
 pub mod neural;


### PR DESCRIPTION
## Summary
- **FFI-5**: Add Rust type comments to opaque C typedefs (LexDict→TrieDictionary etc.)
- **FFI-6..9**: Change `_Nonnull` to `_Nullable` for parameters where Rust defensively handles null (`text`, `reading`, `context`)
- **FFI-11**: Capture ptr/len before `Box::into_raw` in `OwnedVec::pack`, removing unnecessary unsafe derefs
- **FFI-13**: Add `#[must_use]` to resource-returning FFI functions (`ffi_open!`, `lex_session_new`, `lex_neural_open`)
- **FFI-15**: Scope `clippy::not_unsafe_ptr_arg_deref` allow from crate level to ffi module only
- **FFI-16**: Remove `lex_session_composed_string` stub (always returned empty, unused by Swift)
- **FFI-17**: Add safety comment explaining CString pointer stability in `LexCandidateList::from_entries`
- **Core-7**: Document `collapse_latin_kana` loop logic
- **Core-9**: Fix misnumbered comment (5→4) in candidates.rs
- **Core-11**: Use `select_nth_unstable_by` (O(n)) instead of full sort (O(n log n)) in `evict_map`
- **Core-14**: Eliminate double structure_cost computation in reranker by carrying over pre-computed costs
- **Core-17**: Truncate N-best after rewriters to honour the requested `n`
- **Core-19**: Validate `roles.len()` in `from_text_with_roles`
- **Core-22**: Replace `#[allow(dead_code)]` with `#[cfg(feature = "neural")]` on constrained module
- **Infra-12**: Add `rust-version = "1.77"` to Cargo.toml (c-string literals require 1.77+)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo clippy -- -D warnings` passes (no features)
- [x] `cargo test --all-features` — 302 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)