### PR TITLE
fix: harden Swift frontend (overflow, clamp, ghost attrs)

### DIFF
--- a/Sources/MarkedTextManager.swift
+++ b/Sources/MarkedTextManager.swift
@@ -22,6 +22,7 @@ extension LeximeInputController {
     func showGhostText(_ text: String, client: IMKTextInput) {
         let attrs: [NSAttributedString.Key: Any] = [
             .foregroundColor: NSColor.placeholderTextColor,
+            .markedClauseSegment: 0,
         ]
         let attrStr = NSAttributedString(string: text, attributes: attrs)
         client.setMarkedText(attrStr,


### PR DESCRIPTION
## Summary
- Use `&+=` for `candidateGeneration` to prevent overflow trap (3.1)
- Clamp `conversionMode` to `UInt8` range before cast to prevent runtime trap from malformed UserDefaults (3.5)
- Add `.markedClauseSegment: 0` to ghost text attributes for consistency with `updateMarkedText` (3.6)
- Document `setValue(_:forTag:client:)` design decision — blocking IMKit mode changes during composition (4.1)

## Test plan
- [ ] Verify `candidateGeneration` increments work normally (no functional change)
- [ ] Verify ghost text still renders with placeholder color
- [ ] Verify mode switching still blocked during composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)