### PR TITLE
chore: fix build sources, CI paths, and LSMinimumSystemVersion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           filters: |
             engine:
               - 'engine/**'
+              - 'mise.toml'
             swift:
               - 'Sources/**'
               - 'Tests/**'

--- a/Info.plist
+++ b/Info.plist
@@ -18,6 +18,8 @@
     <string>0.1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
     <key>LSBackgroundOnly</key>
     <true/>
     <key>InputMethodConnectionName</key>

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tasks.engine-lib]
 description = "Build universal static library (x86_64 + aarch64)"
-sources = ["engine/src/**/*.rs", "engine/Cargo.toml", "engine/include/engine.h"]
+sources = ["engine/src/**/*.rs", "engine/Cargo.toml", "engine/Cargo.lock", "engine/include/engine.h"]
 outputs = ["build/liblex_engine.a"]
 run = """
 #!/usr/bin/env bash
@@ -31,7 +31,7 @@ run = "cd engine && cargo run --bin dictool -- fetch --source mozc data/mozc-raw
 [tasks.dict-mozc]
 description = "Compile binary dictionary from Mozc"
 depends = ["fetch-dict-mozc"]
-sources = ["engine/data/mozc-raw/.stamp"]
+sources = ["engine/data/mozc-raw/.stamp", "engine/src/bin/dictool.rs", "engine/src/dict/source/mozc.rs"]
 outputs = ["engine/data/lexime-mozc.dict"]
 run = """
 #!/usr/bin/env bash
@@ -175,6 +175,8 @@ run = "bash scripts/icon.sh"
 [tasks.test-swift]
 description = "Run Swift unit tests (FFI round-trip)"
 depends = ["engine-lib"]
+# NOTE: Test files are listed explicitly because swiftc compiles all sources
+# into one binary. If you add a new test file under Tests/, add it here too.
 run = """
 #!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Add `Cargo.lock` to `engine-lib` task sources so dependency updates trigger rebuild (Infra-3)
- Add dictool source files to `dict-mozc` task sources so code changes trigger recompile (Infra-6)
- Add `mise.toml` to CI engine path filter so build config changes trigger CI (Infra-4)
- Add `LSMinimumSystemVersion: 13.0` to Info.plist to match build target (Infra-5)
- Document hardcoded test file list in `test-swift` task (Infra-7)

## Test plan
- [ ] `mise run build` succeeds
- [ ] CI triggers on engine/** or mise.toml changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)