### PR TITLE
refactor: remove V1/V2 connection format, add module docs

### DIFF
--- a/engine/src/candidates/mod.rs
+++ b/engine/src/candidates/mod.rs
@@ -1,3 +1,8 @@
+//! Candidate generation for IME input.
+//!
+//! Provides pluggable strategies (standard, predictive, neural) for
+//! generating conversion candidates from a kana reading.
+
 use std::collections::HashSet;
 
 use crate::converter::ConvertedSegment;

--- a/engine/src/converter/mod.rs
+++ b/engine/src/converter/mod.rs
@@ -1,3 +1,9 @@
+//! Kana-to-kanji conversion via lattice construction and Viterbi search.
+//!
+//! Builds a character-level lattice from dictionary lookups, then runs
+//! N-best Viterbi with connection costs and post-processing (reranking,
+//! segment grouping, history boosting).
+
 #[cfg(feature = "neural")]
 pub(crate) mod constrained;
 pub(crate) mod cost;

--- a/engine/src/dict/mod.rs
+++ b/engine/src/dict/mod.rs
@@ -1,3 +1,8 @@
+//! Dictionary and connection-matrix storage.
+//!
+//! `TrieDictionary` stores reading → entries mappings in a serialized trie.
+//! `ConnectionMatrix` stores POS bigram transition costs for Viterbi scoring.
+
 pub mod connection;
 mod connection_io;
 mod entry;

--- a/engine/src/dict/tests/connection.rs
+++ b/engine/src/dict/tests/connection.rs
@@ -30,6 +30,8 @@ fn test_from_text() {
 fn test_serialize_roundtrip() {
     let m = sample_matrix();
     let bytes = m.to_bytes();
+    // Always V3
+    assert_eq!(bytes[4], 3);
     let m2 = ConnectionMatrix::from_bytes(&bytes).unwrap();
     assert_eq!(m2.num_ids(), m.num_ids());
     for left in 0..m.num_ids() {
@@ -57,7 +59,7 @@ fn test_file_roundtrip() {
 
 #[test]
 fn test_invalid_magic() {
-    let result = ConnectionMatrix::from_bytes(b"XXXX\x01\x03\x00");
+    let result = ConnectionMatrix::from_bytes(b"XXXX\x03\x03\x00\x00\x00\x00\x00");
     assert!(matches!(result, Err(DictError::InvalidMagic)));
 }
 
@@ -69,7 +71,7 @@ fn test_header_too_short() {
 
 #[test]
 fn test_unsupported_version() {
-    let result = ConnectionMatrix::from_bytes(b"LXCX\x99\x01\x00");
+    let result = ConnectionMatrix::from_bytes(b"LXCX\x99\x01\x00\x00\x00\x00\x00");
     assert!(matches!(result, Err(DictError::UnsupportedVersion(0x99))));
 }
 
@@ -92,28 +94,17 @@ fn test_wrong_count() {
 
 #[test]
 fn test_mecab_triplet_format() {
-    // MeCab matrix.def: "right_id left_id cost"
-    // Line "R L C" → cost(left=L, right=R) = C
-    // Use asymmetric values to catch transpose bugs
     let text = "2 2\n0 0 10\n0 1 20\n1 0 30\n1 1 40\n";
     let m = ConnectionMatrix::from_text(text).unwrap();
     assert_eq!(m.num_ids(), 2);
-    // "0 0 10" → cost(left=0, right=0) = 10
     assert_eq!(m.cost(0, 0), 10);
-    // "0 1 20" → cost(left=1, right=0) = 20
     assert_eq!(m.cost(1, 0), 20);
-    // "1 0 30" → cost(left=0, right=1) = 30
     assert_eq!(m.cost(0, 1), 30);
-    // "1 1 40" → cost(left=1, right=1) = 40
     assert_eq!(m.cost(1, 1), 40);
 }
 
 #[test]
 fn test_mecab_triplet_sparse() {
-    // Sparse: only specify some entries; rest default to 0
-    // Format: "right_id left_id cost"
-    // "0 1 100" → right=0, left=1 → cost(left=1, right=0) = 100
-    // "1 0 -200" → right=1, left=0 → cost(left=0, right=1) = -200
     let text = "2 2\n0 1 100\n1 0 -200\n";
     let m = ConnectionMatrix::from_text(text).unwrap();
     assert_eq!(m.cost(0, 0), 0);
@@ -137,7 +128,7 @@ fn test_mecab_triplet_roundtrip() {
 }
 
 #[test]
-fn test_v2_roundtrip_with_metadata() {
+fn test_metadata_roundtrip() {
     let text = "3 3\n0\n10\n20\n30\n40\n50\n60\n70\n80\n";
     let m = ConnectionMatrix::from_text_with_metadata(text, 29, 433).unwrap();
     assert!(m.is_function_word(29));
@@ -147,6 +138,7 @@ fn test_v2_roundtrip_with_metadata() {
     assert!(!m.is_function_word(434));
 
     let bytes = m.to_bytes();
+    assert_eq!(bytes[4], 3); // always V3
     let m2 = ConnectionMatrix::from_bytes(&bytes).unwrap();
     assert_eq!(m2.num_ids(), 3);
     assert!(m2.is_function_word(100));
@@ -161,16 +153,15 @@ fn test_v2_roundtrip_with_metadata() {
 #[test]
 fn test_is_function_word_no_range() {
     let m = sample_matrix();
-    // fw_min == 0 && fw_max == 0 → always false
     assert!(!m.is_function_word(0));
     assert!(!m.is_function_word(100));
 }
 
 #[test]
-fn test_v2_file_roundtrip() {
-    let dir = std::env::temp_dir().join("lexime_test_conn_v2");
+fn test_metadata_file_roundtrip() {
+    let dir = std::env::temp_dir().join("lexime_test_conn_meta");
     fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("test_v2.conn");
+    let path = dir.join("test_meta.conn");
 
     let text = "2 2\n10\n20\n30\n40\n";
     let m = ConnectionMatrix::from_text_with_metadata(text, 50, 300).unwrap();
@@ -182,58 +173,30 @@ fn test_v2_file_roundtrip() {
     assert!(!m2.is_function_word(49));
     assert_eq!(m2.cost(0, 0), 10);
     assert_eq!(m2.cost(1, 1), 40);
+    // roles default to 0
+    assert_eq!(m2.role(0), 0);
+    assert_eq!(m2.role(1), 0);
 
     fs::remove_dir_all(&dir).ok();
 }
 
 #[test]
-fn test_v1_backward_compat() {
-    // Construct a V1 binary manually
-    let magic = b"LXCX";
-    let mut v1_bytes = Vec::new();
-    v1_bytes.extend_from_slice(magic);
-    v1_bytes.push(1); // V1
-    v1_bytes.extend_from_slice(&2u16.to_le_bytes()); // num_ids = 2
-                                                     // 4 costs: 10, 20, 30, 40
-    for cost in [10i16, 20, 30, 40] {
-        v1_bytes.extend_from_slice(&cost.to_le_bytes());
-    }
-
-    let m = ConnectionMatrix::from_bytes(&v1_bytes).unwrap();
-    assert_eq!(m.num_ids(), 2);
-    assert_eq!(m.cost(0, 0), 10);
-    assert_eq!(m.cost(0, 1), 20);
-    assert_eq!(m.cost(1, 0), 30);
-    assert_eq!(m.cost(1, 1), 40);
-    // V1 has no function-word range or roles
-    assert!(!m.is_function_word(100));
-    assert_eq!(m.role(0), 0);
-    assert!(!m.is_suffix(0));
-    assert!(!m.is_prefix(0));
-}
-
-#[test]
-fn test_v3_roundtrip_with_roles() {
-    // 4 IDs: 0=content, 1=function, 2=suffix, 3=prefix
+fn test_roles_roundtrip() {
     let text = "4 4\n";
     let costs_text: String = (0..16).map(|i| format!("{}\n", i * 10)).collect::<String>();
     let full_text = format!("{text}{costs_text}");
     let roles = vec![0, 1, 2, 3];
-    let m = ConnectionMatrix::from_text_with_roles(&full_text, 1, 1, roles.clone()).unwrap();
+    let m = ConnectionMatrix::from_text_with_roles(&full_text, 1, 1, roles).unwrap();
 
     assert_eq!(m.role(0), 0);
     assert_eq!(m.role(1), 1);
     assert_eq!(m.role(2), 2);
     assert_eq!(m.role(3), 3);
-    assert!(!m.is_prefix(0));
-    assert!(!m.is_suffix(0));
     assert!(m.is_suffix(2));
     assert!(m.is_prefix(3));
     assert!(m.is_function_word(1));
 
-    // Serialize and deserialize
     let bytes = m.to_bytes();
-    // Check V3 marker
     assert_eq!(bytes[4], 3);
 
     let m2 = ConnectionMatrix::from_bytes(&bytes).unwrap();
@@ -252,10 +215,10 @@ fn test_v3_roundtrip_with_roles() {
 }
 
 #[test]
-fn test_v3_file_roundtrip() {
-    let dir = std::env::temp_dir().join("lexime_test_conn_v3");
+fn test_roles_file_roundtrip() {
+    let dir = std::env::temp_dir().join("lexime_test_conn_roles");
     fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("test_v3.conn");
+    let path = dir.join("test_roles.conn");
 
     let text = "3 3\n0\n10\n20\n30\n40\n50\n60\n70\n80\n";
     let roles = vec![0, 2, 3]; // content, suffix, prefix
@@ -273,20 +236,4 @@ fn test_v3_file_roundtrip() {
     assert_eq!(m2.cost(2, 2), 80);
 
     fs::remove_dir_all(&dir).ok();
-}
-
-#[test]
-fn test_v2_backward_compat_no_roles() {
-    // V2 binary should load with empty roles → role() always returns 0
-    let text = "2 2\n10\n20\n30\n40\n";
-    let m = ConnectionMatrix::from_text_with_metadata(text, 50, 300).unwrap();
-    let bytes = m.to_bytes();
-    // Should write V2 (no roles)
-    assert_eq!(bytes[4], 2);
-
-    let m2 = ConnectionMatrix::from_bytes(&bytes).unwrap();
-    assert_eq!(m2.role(0), 0);
-    assert_eq!(m2.role(1), 0);
-    assert!(!m2.is_suffix(0));
-    assert!(!m2.is_prefix(0));
 }

--- a/engine/src/romaji/mod.rs
+++ b/engine/src/romaji/mod.rs
@@ -1,3 +1,8 @@
+//! Romaji-to-kana conversion engine.
+//!
+//! Uses a trie-based lookup table to incrementally convert ASCII keystrokes
+//! into hiragana, handling sokuon (っ), hatsuon (ん), and yōon (きゃ).
+
 mod convert;
 mod table;
 mod trie;

--- a/engine/src/session/mod.rs
+++ b/engine/src/session/mod.rs
@@ -1,3 +1,8 @@
+//! Stateful IME session managing composition, candidate selection, and key handling.
+//!
+//! `InputSession` owns the current editing state and processes each keystroke,
+//! returning responses that the Swift frontend translates into IMKit calls.
+
 pub(crate) mod types;
 
 mod auto_commit;

--- a/engine/src/user_history/mod.rs
+++ b/engine/src/user_history/mod.rs
@@ -1,3 +1,8 @@
+//! User conversion history with time-decayed unigram/bigram boosting.
+//!
+//! Records confirmed conversions and uses frequency × recency scoring to
+//! promote learned candidates in subsequent sessions.
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
## Summary
- Remove V1/V2 backward compatibility from `ConnectionMatrix` binary format (V3-only)
- Simplify `validate_header` and `to_bytes` to single code path
- Remove `test_v1_backward_compat` and `test_v2_backward_compat_no_roles` tests
- Add `//!` module doc comments to `candidates`, `converter`, `dict`, `romaji`, `session`, `user_history`

Dict files are always rebuilt by the build system, so V1/V2 support was dead code.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 291 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)