### PR TITLE
refactor: internalize async candidate/ghost generation

### DIFF
--- a/Sources/GhostTextManager.swift
+++ b/Sources/GhostTextManager.swift
@@ -5,9 +5,6 @@ class GhostTextManager {
 
     private(set) var text: String?
 
-    private let queue = DispatchQueue(label: "sh.send.lexime.ghost", qos: .utility)
-    private var debounceItem: DispatchWorkItem?
-
     // MARK: - Display
 
     func showDisplay(_ text: String, client: IMKTextInput) {
@@ -36,41 +33,12 @@ class GhostTextManager {
 
     func clear(client: IMKTextInput, updateDisplay: Bool) {
         text = nil
-        debounceItem?.cancel()
-        debounceItem = nil
         if updateDisplay {
             clearDisplay(client: client)
         }
     }
 
     func deactivate() {
-        debounceItem?.cancel()
-        debounceItem = nil
         text = nil
-    }
-
-    // MARK: - Async Neural Generation
-
-    func requestGeneration(
-        context: String,
-        generation: UInt64,
-        session: LexSession,
-        completion: @escaping (LexKeyResult) -> Void
-    ) {
-        debounceItem?.cancel()
-        let neural = AppContext.shared.neural
-        guard let neural else { return }
-        let item = DispatchWorkItem { [weak self] in
-            guard let text = neural.generateGhost(context: context, maxTokens: 30) else { return }
-            guard !text.isEmpty else { return }
-            DispatchQueue.main.async { [weak self] in
-                guard self != nil else { return }
-                guard let resp = session.receiveGhostText(generation: generation, text: text)
-                else { return }
-                completion(resp)
-            }
-        }
-        debounceItem = item
-        queue.asyncAfter(deadline: .now() + 0.15, execute: item)
     }
 }

--- a/engine/crates/lex-session/src/lib.rs
+++ b/engine/crates/lex-session/src/lib.rs
@@ -135,4 +135,9 @@ impl InputSession {
     pub fn committed_context(&self) -> String {
         self.committed_context.clone()
     }
+
+    /// Whether ghost text is currently being displayed.
+    pub fn has_ghost_text(&self) -> bool {
+        self.ghost_text.is_some()
+    }
 }

--- a/engine/src/async_worker.rs
+++ b/engine/src/async_worker.rs
@@ -1,0 +1,322 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, Mutex, RwLock};
+use std::thread;
+use std::time::Duration;
+
+use crate::candidates::CandidateResponse;
+use crate::dict::connection::ConnectionMatrix;
+use crate::dict::TrieDictionary;
+use crate::user_history::UserHistory;
+
+// ---------------------------------------------------------------------------
+// Work / Result types
+// ---------------------------------------------------------------------------
+
+pub(crate) struct CandidateWork {
+    pub reading: String,
+    pub dispatch: u8,
+    #[allow(dead_code)] // used only with neural feature
+    pub context: String,
+    pub generation: u64,
+}
+
+pub(crate) struct CandidateResult {
+    pub reading: String,
+    pub response: CandidateResponse,
+}
+
+pub(crate) struct GhostWork {
+    #[allow(dead_code)] // used only with neural feature
+    pub context: String,
+    pub generation: u64,
+}
+
+pub(crate) struct GhostResult {
+    pub generation: u64,
+    pub text: String,
+}
+
+// ---------------------------------------------------------------------------
+// AsyncWorker
+// ---------------------------------------------------------------------------
+
+pub(crate) struct AsyncWorker {
+    candidate_tx: mpsc::Sender<CandidateWork>,
+    candidate_rx: Mutex<mpsc::Receiver<CandidateResult>>,
+    candidate_gen: Arc<AtomicU64>,
+
+    ghost_tx: mpsc::Sender<GhostWork>,
+    ghost_rx: Mutex<mpsc::Receiver<GhostResult>>,
+    ghost_gen: Arc<AtomicU64>,
+}
+
+impl AsyncWorker {
+    pub fn new(
+        dict: Arc<TrieDictionary>,
+        conn: Option<Arc<ConnectionMatrix>>,
+        history: Option<Arc<RwLock<UserHistory>>>,
+        #[cfg(feature = "neural")] neural: Option<Arc<Mutex<crate::neural::NeuralScorer>>>,
+    ) -> Self {
+        let candidate_gen = Arc::new(AtomicU64::new(0));
+        let ghost_gen = Arc::new(AtomicU64::new(0));
+
+        // Candidate worker
+        let (work_tx, work_rx) = mpsc::channel::<CandidateWork>();
+        let (result_tx, result_rx) = mpsc::channel::<CandidateResult>();
+        {
+            let dict = Arc::clone(&dict);
+            let conn = conn.clone();
+            let history = history.clone();
+            let gen = Arc::clone(&candidate_gen);
+            #[cfg(feature = "neural")]
+            let neural = neural.clone();
+            thread::Builder::new()
+                .name("lexime-candidates".into())
+                .spawn(move || {
+                    candidate_worker(
+                        work_rx,
+                        result_tx,
+                        gen,
+                        dict,
+                        conn,
+                        history,
+                        #[cfg(feature = "neural")]
+                        neural,
+                    );
+                })
+                .expect("failed to spawn candidate worker");
+        }
+
+        // Ghost worker
+        let (ghost_work_tx, ghost_work_rx) = mpsc::channel::<GhostWork>();
+        let (ghost_result_tx, ghost_result_rx) = mpsc::channel::<GhostResult>();
+        {
+            let gen = Arc::clone(&ghost_gen);
+            #[cfg(feature = "neural")]
+            let neural = neural;
+            thread::Builder::new()
+                .name("lexime-ghost".into())
+                .spawn(move || {
+                    ghost_worker(
+                        ghost_work_rx,
+                        ghost_result_tx,
+                        gen,
+                        #[cfg(feature = "neural")]
+                        neural,
+                    );
+                })
+                .expect("failed to spawn ghost worker");
+        }
+
+        Self {
+            candidate_tx: work_tx,
+            candidate_rx: Mutex::new(result_rx),
+            candidate_gen,
+            ghost_tx: ghost_work_tx,
+            ghost_rx: Mutex::new(ghost_result_rx),
+            ghost_gen,
+        }
+    }
+
+    pub fn submit_candidates(&self, reading: String, dispatch: u8, context: String) {
+        let gen = self.candidate_gen.fetch_add(1, Ordering::SeqCst) + 1;
+        let _ = self.candidate_tx.send(CandidateWork {
+            reading,
+            dispatch,
+            context,
+            generation: gen,
+        });
+    }
+
+    pub fn submit_ghost(&self, context: String, generation: u64) {
+        self.ghost_gen.store(generation, Ordering::SeqCst);
+        let _ = self.ghost_tx.send(GhostWork {
+            context,
+            generation,
+        });
+    }
+
+    pub fn invalidate_candidates(&self) {
+        self.candidate_gen.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn invalidate_ghost(&self) {
+        self.ghost_gen.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn try_recv_candidate(&self) -> Option<CandidateResult> {
+        let rx = self.candidate_rx.lock().ok()?;
+        rx.try_recv().ok()
+    }
+
+    pub fn try_recv_ghost(&self) -> Option<GhostResult> {
+        let rx = self.ghost_rx.lock().ok()?;
+        rx.try_recv().ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker threads
+// ---------------------------------------------------------------------------
+
+fn candidate_worker(
+    rx: mpsc::Receiver<CandidateWork>,
+    tx: mpsc::Sender<CandidateResult>,
+    gen: Arc<AtomicU64>,
+    dict: Arc<TrieDictionary>,
+    conn: Option<Arc<ConnectionMatrix>>,
+    history: Option<Arc<RwLock<UserHistory>>>,
+    #[cfg(feature = "neural")] neural: Option<Arc<Mutex<crate::neural::NeuralScorer>>>,
+) {
+    while let Ok(work) = rx.recv() {
+        // Drain: if multiple work items queued, skip to latest
+        let mut latest = work;
+        while let Ok(newer) = rx.try_recv() {
+            latest = newer;
+        }
+
+        // Check staleness before doing work
+        if latest.generation != gen.load(Ordering::SeqCst) {
+            continue;
+        }
+
+        let h_guard = history.as_ref().and_then(|h| h.read().ok());
+        let hist_ref = h_guard.as_deref();
+        let conn_ref = conn.as_deref();
+
+        let response = match latest.dispatch {
+            #[cfg(feature = "neural")]
+            2 => {
+                if let Some(ref neural) = neural {
+                    if let Ok(mut scorer) = neural.lock() {
+                        crate::candidates::generate_neural_candidates(
+                            &mut scorer,
+                            &dict,
+                            conn_ref,
+                            hist_ref,
+                            &latest.context,
+                            &latest.reading,
+                            20,
+                        )
+                    } else {
+                        crate::candidates::generate_candidates(
+                            &dict,
+                            conn_ref,
+                            hist_ref,
+                            &latest.reading,
+                            20,
+                        )
+                    }
+                } else {
+                    crate::candidates::generate_candidates(
+                        &dict,
+                        conn_ref,
+                        hist_ref,
+                        &latest.reading,
+                        20,
+                    )
+                }
+            }
+            #[cfg(not(feature = "neural"))]
+            2 => crate::candidates::generate_candidates(
+                &dict,
+                conn_ref,
+                hist_ref,
+                &latest.reading,
+                20,
+            ),
+            1 => crate::candidates::generate_prediction_candidates(
+                &dict,
+                conn_ref,
+                hist_ref,
+                &latest.reading,
+                20,
+            ),
+            _ => crate::candidates::generate_candidates(
+                &dict,
+                conn_ref,
+                hist_ref,
+                &latest.reading,
+                20,
+            ),
+        };
+
+        // Check staleness after generation
+        if latest.generation != gen.load(Ordering::SeqCst) {
+            continue;
+        }
+
+        let _ = tx.send(CandidateResult {
+            reading: latest.reading,
+            response,
+        });
+    }
+}
+
+fn ghost_worker(
+    rx: mpsc::Receiver<GhostWork>,
+    #[allow(unused_variables)] tx: mpsc::Sender<GhostResult>,
+    gen: Arc<AtomicU64>,
+    #[cfg(feature = "neural")] neural: Option<Arc<Mutex<crate::neural::NeuralScorer>>>,
+) {
+    while let Ok(work) = rx.recv() {
+        // Drain to latest
+        let mut latest = work;
+        while let Ok(newer) = rx.try_recv() {
+            latest = newer;
+        }
+
+        // Debounce: wait 150ms, then check if still current
+        thread::sleep(Duration::from_millis(150));
+        if latest.generation != gen.load(Ordering::SeqCst) {
+            continue;
+        }
+
+        #[cfg(feature = "neural")]
+        {
+            let Some(ref neural) = neural else { continue };
+            let Ok(mut scorer) = neural.lock() else {
+                continue;
+            };
+            let config = crate::neural::GenerateConfig {
+                max_tokens: 30,
+                ..crate::neural::GenerateConfig::default()
+            };
+            let Ok(text) = scorer.generate_text(&latest.context, &config) else {
+                continue;
+            };
+            if text.is_empty() {
+                continue;
+            }
+            // Final staleness check after generation
+            if latest.generation != gen.load(Ordering::SeqCst) {
+                continue;
+            }
+            let _ = tx.send(GhostResult {
+                generation: latest.generation,
+                text,
+            });
+        }
+
+        #[cfg(not(feature = "neural"))]
+        {
+            let _ = &latest;
+            // No neural scorer available; nothing to generate
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generation_counter_invalidation() {
+        let gen = Arc::new(AtomicU64::new(0));
+        assert_eq!(gen.load(Ordering::SeqCst), 0);
+        gen.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(gen.load(Ordering::SeqCst), 1);
+        // Work with generation 0 is now stale
+        assert_ne!(0u64, gen.load(Ordering::SeqCst));
+    }
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -12,6 +12,7 @@ pub use lex_core::user_history;
 pub use lex_session as session;
 
 pub mod api;
+pub(crate) mod async_worker;
 pub mod trace_init;
 
 uniffi::setup_scaffolding!();


### PR DESCRIPTION
## Summary

- Move Swift DispatchQueue management, `[weak self]` capture chains, and generation counters into Rust worker threads
- Two dedicated worker threads (candidate + ghost) handle async generation internally with `mpsc` channels and `AtomicU64` staleness checks
- Swift now uses a simple 50ms poll timer via `session.poll()` instead of manual `dispatchAsync()`/`requestGeneration()`
- Remove `generateCandidates`, `generatePredictionCandidates`, `generateNeuralCandidates` free function exports from UniFFI
- Remove `receiveCandidates`, `receiveGhostText`, `ghostGeneration` from `LexSession` FFI surface
- `LexNeuralScorer` always defined (stub when neural feature disabled) to simplify `LexSession` constructor

## Data flow (before → after)

**Before:** Swift dispatches work to DispatchQueue, captures `[weak self]` + generation, calls back to Rust `receiveCandidates`/`receiveGhostText` on main thread.

**After:** `handle_key()` internally submits work to Rust worker threads. Swift calls `session.poll()` on a 50ms timer to collect results.

## Line changes

| File | Change |
|------|--------|
| `engine/src/async_worker.rs` | +322 (new) |
| `engine/src/api/mod.rs` | -55 |
| `engine/crates/lex-session/src/lib.rs` | +5 |
| `Sources/LeximeInputController.swift` | +24 |
| `Sources/CandidateManager.swift` | -49 |
| `Sources/GhostTextManager.swift` | -32 |

Net: Rust +272, Swift -57. Swift async complexity significantly reduced.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace --all-features` — 268 tests pass
- [x] `mise run build && mise run install` — builds and installs
- [x] `mise run test-swift` — 11 Swift tests pass
- [ ] Manual: TextEdit でひらがな・漢字変換 (1-best → full candidates 遷移)
- [ ] Manual: Space で候補切替、Enter で確定
- [ ] Manual: Tab でサブモード切替
- [ ] Manual: 長文入力で auto-commit (poll chain 動作)
- [ ] Manual: Ghost モードでゴーストテキスト表示 (debounce + poll timer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)