### PR TITLE
test: add HeadlessIME simulator and conversion quality corpus

### DIFF
--- a/engine/crates/lex-session/src/tests/corpus.rs
+++ b/engine/crates/lex-session/src/tests/corpus.rs
@@ -1,0 +1,89 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use lex_core::dict::connection::ConnectionMatrix;
+use lex_core::dict::TrieDictionary;
+
+use super::simulator::HeadlessIME;
+
+// ---------------------------------------------------------------------------
+// (a) Small-dict corpus — always runs with `cargo test`
+// ---------------------------------------------------------------------------
+
+/// Conversion test cases that match make_test_dict() entries.
+const SMALL_DICT_CORPUS: &[(&str, &str)] = &[
+    ("kyou", "今日"),
+    ("tenki", "天気"),
+    ("watashi", "私"),
+    ("desu", "です"),
+    ("ne", "ね"),
+    ("ii", "良い"),
+];
+
+#[test]
+fn test_small_dict_corpus() {
+    let dict = super::make_test_dict();
+    let mut ime = HeadlessIME::new(dict, None);
+
+    for &(romaji, expected) in SMALL_DICT_CORPUS {
+        let result = ime.convert(romaji);
+        assert_eq!(
+            result, expected,
+            "conversion mismatch: romaji={romaji:?}, expected={expected:?}, got={result:?}"
+        );
+        ime.reset();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (b) Real-dict corpus — #[ignore], opt-in via `cargo test -- --ignored`
+// ---------------------------------------------------------------------------
+
+/// Test cases for the full compiled dictionary + connection matrix.
+const REAL_DICT_CORPUS: &[(&str, &str)] = &[
+    ("toukyou", "東京"),
+    ("oosaka", "大阪"),
+    ("nihongo", "日本語"),
+    ("kyouhaiitenki", "今日はいい天気"),
+    ("watashihagakuseidesu", "私は学生です"),
+];
+
+fn real_dict_paths() -> Option<(PathBuf, PathBuf)> {
+    let dict_path = std::env::var("LEXIME_DICT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("data/lexime.dict"));
+    let conn_path = std::env::var("LEXIME_CONN")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("data/lexime.conn"));
+
+    if dict_path.exists() && conn_path.exists() {
+        Some((dict_path, conn_path))
+    } else {
+        None
+    }
+}
+
+#[test]
+#[ignore]
+fn test_real_dict_corpus() {
+    let (dict_path, conn_path) = match real_dict_paths() {
+        Some(paths) => paths,
+        None => {
+            eprintln!("skipping real-dict corpus: dictionary files not found");
+            return;
+        }
+    };
+
+    let dict = Arc::new(TrieDictionary::open(&dict_path).expect("failed to open dict"));
+    let conn = Arc::new(ConnectionMatrix::open(&conn_path).expect("failed to open conn"));
+    let mut ime = HeadlessIME::new(dict, Some(conn));
+
+    for &(romaji, expected) in REAL_DICT_CORPUS {
+        let result = ime.convert(romaji);
+        assert_eq!(
+            result, expected,
+            "conversion mismatch: romaji={romaji:?}, expected={expected:?}, got={result:?}"
+        );
+        ime.reset();
+    }
+}

--- a/engine/crates/lex-session/src/tests/mod.rs
+++ b/engine/crates/lex-session/src/tests/mod.rs
@@ -1,7 +1,9 @@
 mod auto_commit;
 mod basic;
 mod candidates;
+mod corpus;
 mod ghost;
+mod simulator;
 mod submode;
 
 use std::sync::Arc;

--- a/engine/crates/lex-session/src/tests/simulator.rs
+++ b/engine/crates/lex-session/src/tests/simulator.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use lex_core::candidates::CandidateResponse;
+use lex_core::dict::connection::ConnectionMatrix;
+use lex_core::dict::TrieDictionary;
+
+use super::type_string;
+use crate::types::MAX_CANDIDATES;
+use crate::InputSession;
+
+/// Headless IME simulator for integration tests.
+///
+/// Wraps `InputSession` with `defer_candidates = true` (matching the real async path)
+/// and provides helpers that drive the full type → generate → receive → commit cycle.
+pub(super) struct HeadlessIME {
+    pub session: InputSession,
+    dict: Arc<TrieDictionary>,
+    conn: Option<Arc<ConnectionMatrix>>,
+}
+
+impl HeadlessIME {
+    pub fn new(dict: Arc<TrieDictionary>, conn: Option<Arc<ConnectionMatrix>>) -> Self {
+        let mut session = InputSession::new(dict.clone(), conn.clone(), None);
+        session.set_defer_candidates(true);
+        Self {
+            session,
+            dict,
+            conn,
+        }
+    }
+
+    /// Type romaji, resolve async candidates, press Enter, return committed text.
+    pub fn convert(&mut self, romaji: &str) -> String {
+        let mut committed = String::new();
+
+        // 1. Type romaji one character at a time, collecting any auto-commits
+        for ch in romaji.chars() {
+            let resp = self.session.handle_key(0, &ch.to_string(), 0);
+            if let Some(ref text) = resp.commit {
+                committed.push_str(text);
+            }
+            // Resolve async request if present
+            if resp.async_request.is_some() {
+                if let Some(auto_text) = self.resolve_async() {
+                    committed.push_str(&auto_text);
+                }
+            }
+        }
+
+        // 2. Press Enter to commit remaining composition
+        if self.session.is_composing() {
+            let resp = self.session.handle_key(super::key::ENTER, "", 0);
+            if let Some(ref text) = resp.commit {
+                committed.push_str(text);
+            }
+        }
+
+        committed
+    }
+
+    /// Type romaji, resolve async candidates, return the composing display (no commit).
+    pub fn composing_display(&mut self, romaji: &str) -> String {
+        let responses = type_string(&mut self.session, romaji);
+        // Resolve the last async request
+        if let Some(resp) = responses.last() {
+            if resp.async_request.is_some() {
+                self.resolve_async();
+            }
+        }
+        self.session.composed_string()
+    }
+
+    /// Reset session to idle (simulates commitComposition).
+    pub fn reset(&mut self) {
+        if self.session.is_composing() {
+            self.session.commit();
+        }
+    }
+
+    /// Complete one async candidate cycle: generate candidates for current reading,
+    /// then feed them back. Returns committed text from auto-commit chain, if any.
+    fn resolve_async(&mut self) -> Option<String> {
+        if !self.session.is_composing() {
+            return None;
+        }
+        let reading = self.session.comp().kana.clone();
+        if reading.is_empty() {
+            return None;
+        }
+
+        let mode = self.session.conversion_mode;
+        let cand: CandidateResponse = mode.generate_candidates(
+            &self.dict,
+            self.conn.as_deref(),
+            None,
+            &reading,
+            MAX_CANDIDATES,
+        );
+        let resp = self
+            .session
+            .receive_candidates(&reading, cand.surfaces, cand.paths);
+
+        match resp {
+            Some(r) => {
+                let mut committed = String::new();
+                if let Some(ref text) = r.commit {
+                    committed.push_str(text);
+                }
+                // Auto-commit may leave a residual composition needing its own async resolve
+                if r.async_request.is_some() {
+                    if let Some(more) = self.resolve_async() {
+                        committed.push_str(&more);
+                    }
+                }
+                if committed.is_empty() {
+                    None
+                } else {
+                    Some(committed)
+                }
+            }
+            None => None,
+        }
+    }
+}
+
+#[test]
+fn test_headless_convert_single_word() {
+    let dict = super::make_test_dict();
+    let mut ime = HeadlessIME::new(dict, None);
+    let result = ime.convert("kyou");
+    assert_eq!(result, "今日");
+}
+
+#[test]
+fn test_headless_composing_display() {
+    let dict = super::make_test_dict();
+    let mut ime = HeadlessIME::new(dict, None);
+    let display = ime.composing_display("kyou");
+    assert_eq!(display, "今日");
+}
+
+#[test]
+fn test_headless_reset() {
+    let dict = super::make_test_dict();
+    let mut ime = HeadlessIME::new(dict, None);
+    ime.composing_display("kyou");
+    assert!(ime.session.is_composing());
+    ime.reset();
+    assert!(!ime.session.is_composing());
+}


### PR DESCRIPTION
## Summary
- **HeadlessIME** (`simulator.rs`): `InputSession` ラッパー。`defer_candidates=true` で実際の async パスを再現し、type → generate → receive → commit サイクルをプログラム的に駆動
- **変換品質コーパス** (`corpus.rs`): small-dict (6 cases, CI 常時実行) + real-dict (5 cases, `#[ignore]` opt-in)
- 不具合発見時にコーパスへテストケースを追加するだけで回帰検出可能

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — 58 session tests passed, 1 ignored
- [x] `cargo test -p lex-session -- --ignored` — real-dict corpus 5 cases all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)