### PR TITLE
refactor: introduce LexEngine to consolidate shared resources

### DIFF
--- a/engine/src/api/engine.rs
+++ b/engine/src/api/engine.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+
+use super::{LexConnection, LexDictionary, LexError, LexNeuralScorer, LexSession, LexUserHistory};
+
+#[derive(uniffi::Object)]
+pub struct LexEngine {
+    dict: Arc<LexDictionary>,
+    conn: Option<Arc<LexConnection>>,
+    history: Option<Arc<LexUserHistory>>,
+    neural: Option<Arc<LexNeuralScorer>>,
+}
+
+#[uniffi::export]
+impl LexEngine {
+    #[uniffi::constructor]
+    fn new(
+        dict: Arc<LexDictionary>,
+        conn: Option<Arc<LexConnection>>,
+        history: Option<Arc<LexUserHistory>>,
+        neural: Option<Arc<LexNeuralScorer>>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            dict,
+            conn,
+            history,
+            neural,
+        })
+    }
+
+    fn create_session(&self) -> Arc<LexSession> {
+        LexSession::new(
+            Arc::clone(&self.dict),
+            self.conn.as_ref().map(Arc::clone),
+            self.history.as_ref().map(Arc::clone),
+            self.neural.as_ref().map(Arc::clone),
+        )
+    }
+
+    fn save_history(&self, path: String) -> Result<(), LexError> {
+        match &self.history {
+            Some(h) => h.save(path),
+            None => Ok(()),
+        }
+    }
+
+    fn has_neural(&self) -> bool {
+        self.neural.is_some()
+    }
+}

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Each public type here maps to a generated Swift class, struct, or enum.
 
+mod engine;
+pub use engine::LexEngine;
+
 use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 


### PR DESCRIPTION
## Summary
- Add `LexEngine` UniFFI object (`engine/src/api/engine.rs`) that owns all shared resources (dict, conn, history, neural)
- Sessions are created via `engine.createSession()` instead of passing 4 individual arguments
- `AppContext` simplified from 4 resource fields to a single `engine: LexEngine?`
- `LeximeInputController` updated: session creation, history save, and neural check all go through engine

## Test plan
- [x] Rust: `cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace --all-features` — all 272 tests pass
- [x] Swift: `mise run test-swift` — all 11 tests pass
- [x] Full build: `mise run build` — success
- [ ] Manual: `mise run install && mise run reload` → verify input works

🤖 Generated with [Claude Code](https://claude.com/claude-code)