### PR TITLE
test: add criterion benchmarks for converter and candidates

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +308,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -350,6 +389,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -733,16 +808,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -771,6 +876,7 @@ dependencies = [
  "bincode",
  "candle-core",
  "candle-nn",
+ "criterion",
  "lexime-trie",
  "memmap2",
  "serde",
@@ -940,6 +1046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1074,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1134,6 +1274,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1369,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -1528,6 +1686,16 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1861,6 +2029,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -22,3 +22,14 @@ unicode-width = "0.2"
 anyhow = { version = "1", optional = true }
 candle-core = { version = "0.9", optional = true }
 candle-nn = { version = "0.9", optional = true }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "converter"
+harness = false
+
+[[bench]]
+name = "candidates"
+harness = false

--- a/engine/crates/lex-core/benches/candidates.rs
+++ b/engine/crates/lex-core/benches/candidates.rs
@@ -1,0 +1,301 @@
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use lex_core::candidates::{generate_candidates, generate_prediction_candidates};
+use lex_core::dict::{DictEntry, TrieDictionary};
+
+fn bench_dict() -> Arc<TrieDictionary> {
+    let entries = vec![
+        (
+            "きょう".into(),
+            vec![
+                DictEntry {
+                    surface: "今日".into(),
+                    cost: 3000,
+                    left_id: 100,
+                    right_id: 100,
+                },
+                DictEntry {
+                    surface: "京".into(),
+                    cost: 5000,
+                    left_id: 101,
+                    right_id: 101,
+                },
+            ],
+        ),
+        (
+            "は".into(),
+            vec![DictEntry {
+                surface: "は".into(),
+                cost: 2000,
+                left_id: 200,
+                right_id: 200,
+            }],
+        ),
+        (
+            "いい".into(),
+            vec![
+                DictEntry {
+                    surface: "良い".into(),
+                    cost: 3500,
+                    left_id: 300,
+                    right_id: 300,
+                },
+                DictEntry {
+                    surface: "いい".into(),
+                    cost: 4000,
+                    left_id: 301,
+                    right_id: 301,
+                },
+            ],
+        ),
+        (
+            "てんき".into(),
+            vec![DictEntry {
+                surface: "天気".into(),
+                cost: 4000,
+                left_id: 400,
+                right_id: 400,
+            }],
+        ),
+        (
+            "です".into(),
+            vec![DictEntry {
+                surface: "です".into(),
+                cost: 2500,
+                left_id: 800,
+                right_id: 800,
+            }],
+        ),
+        (
+            "ね".into(),
+            vec![DictEntry {
+                surface: "ね".into(),
+                cost: 2000,
+                left_id: 900,
+                right_id: 900,
+            }],
+        ),
+        (
+            "わたし".into(),
+            vec![DictEntry {
+                surface: "私".into(),
+                cost: 3000,
+                left_id: 1000,
+                right_id: 1000,
+            }],
+        ),
+        (
+            "だ".into(),
+            vec![DictEntry {
+                surface: "だ".into(),
+                cost: 2500,
+                left_id: 810,
+                right_id: 810,
+            }],
+        ),
+        (
+            "と".into(),
+            vec![DictEntry {
+                surface: "と".into(),
+                cost: 2000,
+                left_id: 820,
+                right_id: 820,
+            }],
+        ),
+        (
+            "おもい".into(),
+            vec![DictEntry {
+                surface: "思い".into(),
+                cost: 3500,
+                left_id: 830,
+                right_id: 830,
+            }],
+        ),
+        (
+            "おもいます".into(),
+            vec![DictEntry {
+                surface: "思います".into(),
+                cost: 3200,
+                left_id: 831,
+                right_id: 831,
+            }],
+        ),
+        (
+            "ます".into(),
+            vec![DictEntry {
+                surface: "ます".into(),
+                cost: 2500,
+                left_id: 840,
+                right_id: 840,
+            }],
+        ),
+        (
+            "い".into(),
+            vec![DictEntry {
+                surface: "胃".into(),
+                cost: 6000,
+                left_id: 600,
+                right_id: 600,
+            }],
+        ),
+        (
+            "き".into(),
+            vec![DictEntry {
+                surface: "木".into(),
+                cost: 4500,
+                left_id: 500,
+                right_id: 500,
+            }],
+        ),
+        (
+            "てん".into(),
+            vec![DictEntry {
+                surface: "天".into(),
+                cost: 5000,
+                left_id: 700,
+                right_id: 700,
+            }],
+        ),
+        (
+            "がくせい".into(),
+            vec![DictEntry {
+                surface: "学生".into(),
+                cost: 4000,
+                left_id: 1100,
+                right_id: 1100,
+            }],
+        ),
+        (
+            "しゅくだい".into(),
+            vec![DictEntry {
+                surface: "宿題".into(),
+                cost: 4000,
+                left_id: 1200,
+                right_id: 1200,
+            }],
+        ),
+        (
+            "を".into(),
+            vec![DictEntry {
+                surface: "を".into(),
+                cost: 2000,
+                left_id: 210,
+                right_id: 210,
+            }],
+        ),
+        (
+            "やる".into(),
+            vec![DictEntry {
+                surface: "やる".into(),
+                cost: 3500,
+                left_id: 850,
+                right_id: 850,
+            }],
+        ),
+        (
+            "の".into(),
+            vec![DictEntry {
+                surface: "の".into(),
+                cost: 2000,
+                left_id: 220,
+                right_id: 220,
+            }],
+        ),
+        (
+            "が".into(),
+            vec![DictEntry {
+                surface: "が".into(),
+                cost: 2000,
+                left_id: 230,
+                right_id: 230,
+            }],
+        ),
+        (
+            "めんどう".into(),
+            vec![DictEntry {
+                surface: "面倒".into(),
+                cost: 4500,
+                left_id: 860,
+                right_id: 860,
+            }],
+        ),
+        (
+            "くさい".into(),
+            vec![DictEntry {
+                surface: "臭い".into(),
+                cost: 5000,
+                left_id: 870,
+                right_id: 870,
+            }],
+        ),
+        (
+            "めんどうくさい".into(),
+            vec![DictEntry {
+                surface: "面倒くさい".into(),
+                cost: 3800,
+                left_id: 861,
+                right_id: 861,
+            }],
+        ),
+        (
+            "けど".into(),
+            vec![DictEntry {
+                surface: "けど".into(),
+                cost: 2500,
+                left_id: 880,
+                right_id: 880,
+            }],
+        ),
+        (
+            "がんばり".into(),
+            vec![DictEntry {
+                surface: "頑張り".into(),
+                cost: 4000,
+                left_id: 890,
+                right_id: 890,
+            }],
+        ),
+        (
+            "がんばります".into(),
+            vec![DictEntry {
+                surface: "頑張ります".into(),
+                cost: 3500,
+                left_id: 891,
+                right_id: 891,
+            }],
+        ),
+    ];
+    Arc::new(TrieDictionary::from_entries(entries))
+}
+
+static INPUTS: &[(&str, &str)] = &[
+    ("short", "きょう"),
+    ("medium", "きょうはいいてんきですね"),
+    ("long", "わたしはきょうはいいてんきだとおもいます"),
+];
+
+fn bench_standard(c: &mut Criterion) {
+    let dict = bench_dict();
+    let mut group = c.benchmark_group("candidates/standard");
+    for &(label, kana) in INPUTS {
+        group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
+            b.iter(|| generate_candidates(&dict, None, None, kana, 20));
+        });
+    }
+    group.finish();
+}
+
+fn bench_predictive(c: &mut Criterion) {
+    let dict = bench_dict();
+    let mut group = c.benchmark_group("candidates/predictive");
+    for &(label, kana) in INPUTS {
+        group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
+            b.iter(|| generate_prediction_candidates(&dict, None, None, kana, 20));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_standard, bench_predictive);
+criterion_main!(benches);

--- a/engine/crates/lex-core/benches/converter.rs
+++ b/engine/crates/lex-core/benches/converter.rs
@@ -1,0 +1,319 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use lex_core::converter::{build_lattice, convert, convert_nbest};
+use lex_core::dict::{DictEntry, TrieDictionary};
+
+fn bench_dict() -> TrieDictionary {
+    let entries = vec![
+        (
+            "きょう".into(),
+            vec![
+                DictEntry {
+                    surface: "今日".into(),
+                    cost: 3000,
+                    left_id: 100,
+                    right_id: 100,
+                },
+                DictEntry {
+                    surface: "京".into(),
+                    cost: 5000,
+                    left_id: 101,
+                    right_id: 101,
+                },
+            ],
+        ),
+        (
+            "は".into(),
+            vec![DictEntry {
+                surface: "は".into(),
+                cost: 2000,
+                left_id: 200,
+                right_id: 200,
+            }],
+        ),
+        (
+            "いい".into(),
+            vec![
+                DictEntry {
+                    surface: "良い".into(),
+                    cost: 3500,
+                    left_id: 300,
+                    right_id: 300,
+                },
+                DictEntry {
+                    surface: "いい".into(),
+                    cost: 4000,
+                    left_id: 301,
+                    right_id: 301,
+                },
+            ],
+        ),
+        (
+            "てんき".into(),
+            vec![DictEntry {
+                surface: "天気".into(),
+                cost: 4000,
+                left_id: 400,
+                right_id: 400,
+            }],
+        ),
+        (
+            "です".into(),
+            vec![DictEntry {
+                surface: "です".into(),
+                cost: 2500,
+                left_id: 800,
+                right_id: 800,
+            }],
+        ),
+        (
+            "ね".into(),
+            vec![DictEntry {
+                surface: "ね".into(),
+                cost: 2000,
+                left_id: 900,
+                right_id: 900,
+            }],
+        ),
+        (
+            "わたし".into(),
+            vec![DictEntry {
+                surface: "私".into(),
+                cost: 3000,
+                left_id: 1000,
+                right_id: 1000,
+            }],
+        ),
+        (
+            "だ".into(),
+            vec![DictEntry {
+                surface: "だ".into(),
+                cost: 2500,
+                left_id: 810,
+                right_id: 810,
+            }],
+        ),
+        (
+            "と".into(),
+            vec![DictEntry {
+                surface: "と".into(),
+                cost: 2000,
+                left_id: 820,
+                right_id: 820,
+            }],
+        ),
+        (
+            "おもい".into(),
+            vec![DictEntry {
+                surface: "思い".into(),
+                cost: 3500,
+                left_id: 830,
+                right_id: 830,
+            }],
+        ),
+        (
+            "おもいます".into(),
+            vec![DictEntry {
+                surface: "思います".into(),
+                cost: 3200,
+                left_id: 831,
+                right_id: 831,
+            }],
+        ),
+        (
+            "ます".into(),
+            vec![DictEntry {
+                surface: "ます".into(),
+                cost: 2500,
+                left_id: 840,
+                right_id: 840,
+            }],
+        ),
+        (
+            "い".into(),
+            vec![DictEntry {
+                surface: "胃".into(),
+                cost: 6000,
+                left_id: 600,
+                right_id: 600,
+            }],
+        ),
+        (
+            "き".into(),
+            vec![DictEntry {
+                surface: "木".into(),
+                cost: 4500,
+                left_id: 500,
+                right_id: 500,
+            }],
+        ),
+        (
+            "てん".into(),
+            vec![DictEntry {
+                surface: "天".into(),
+                cost: 5000,
+                left_id: 700,
+                right_id: 700,
+            }],
+        ),
+        (
+            "がくせい".into(),
+            vec![DictEntry {
+                surface: "学生".into(),
+                cost: 4000,
+                left_id: 1100,
+                right_id: 1100,
+            }],
+        ),
+        (
+            "しゅくだい".into(),
+            vec![DictEntry {
+                surface: "宿題".into(),
+                cost: 4000,
+                left_id: 1200,
+                right_id: 1200,
+            }],
+        ),
+        (
+            "を".into(),
+            vec![DictEntry {
+                surface: "を".into(),
+                cost: 2000,
+                left_id: 210,
+                right_id: 210,
+            }],
+        ),
+        (
+            "やる".into(),
+            vec![DictEntry {
+                surface: "やる".into(),
+                cost: 3500,
+                left_id: 850,
+                right_id: 850,
+            }],
+        ),
+        (
+            "の".into(),
+            vec![DictEntry {
+                surface: "の".into(),
+                cost: 2000,
+                left_id: 220,
+                right_id: 220,
+            }],
+        ),
+        (
+            "が".into(),
+            vec![DictEntry {
+                surface: "が".into(),
+                cost: 2000,
+                left_id: 230,
+                right_id: 230,
+            }],
+        ),
+        (
+            "めんどう".into(),
+            vec![DictEntry {
+                surface: "面倒".into(),
+                cost: 4500,
+                left_id: 860,
+                right_id: 860,
+            }],
+        ),
+        (
+            "くさい".into(),
+            vec![DictEntry {
+                surface: "臭い".into(),
+                cost: 5000,
+                left_id: 870,
+                right_id: 870,
+            }],
+        ),
+        (
+            "めんどうくさい".into(),
+            vec![DictEntry {
+                surface: "面倒くさい".into(),
+                cost: 3800,
+                left_id: 861,
+                right_id: 861,
+            }],
+        ),
+        (
+            "けど".into(),
+            vec![DictEntry {
+                surface: "けど".into(),
+                cost: 2500,
+                left_id: 880,
+                right_id: 880,
+            }],
+        ),
+        (
+            "がんばり".into(),
+            vec![DictEntry {
+                surface: "頑張り".into(),
+                cost: 4000,
+                left_id: 890,
+                right_id: 890,
+            }],
+        ),
+        (
+            "がんばります".into(),
+            vec![DictEntry {
+                surface: "頑張ります".into(),
+                cost: 3500,
+                left_id: 891,
+                right_id: 891,
+            }],
+        ),
+    ];
+    TrieDictionary::from_entries(entries)
+}
+
+static INPUTS: &[(&str, &str)] = &[
+    ("short", "きょう"),
+    ("medium", "きょうはいいてんきですね"),
+    ("long", "わたしはきょうはいいてんきだとおもいます"),
+    (
+        "very_long",
+        "わたしはきょうしゅくだいをやるのがめんどうくさいけどがんばります",
+    ),
+];
+
+fn bench_build_lattice(c: &mut Criterion) {
+    let dict = bench_dict();
+    let mut group = c.benchmark_group("converter/build_lattice");
+    for &(label, kana) in INPUTS {
+        group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
+            b.iter(|| build_lattice(&dict, kana));
+        });
+    }
+    group.finish();
+}
+
+fn bench_convert_1best(c: &mut Criterion) {
+    let dict = bench_dict();
+    let mut group = c.benchmark_group("converter/convert_1best");
+    for &(label, kana) in INPUTS {
+        group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
+            b.iter(|| convert(&dict, None, kana));
+        });
+    }
+    group.finish();
+}
+
+fn bench_convert_10best(c: &mut Criterion) {
+    let dict = bench_dict();
+    let mut group = c.benchmark_group("converter/convert_10best");
+    for &(label, kana) in INPUTS {
+        group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
+            b.iter(|| convert_nbest(&dict, None, kana, 10));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_build_lattice,
+    bench_convert_1best,
+    bench_convert_10best
+);
+criterion_main!(benches);

--- a/mise.toml
+++ b/mise.toml
@@ -265,6 +265,10 @@ cd engine && cargo run -p lex-cli --features neural --bin dictool -- neural-scor
   "$@"
 """
 
+[tasks.bench]
+description = "Run criterion benchmarks"
+run = "cd engine && cargo bench -p lex-core"
+
 [tasks.lint]
 description = "Run cargo fmt --check and clippy"
 run = [


### PR DESCRIPTION
## Summary
- criterion 0.5 を導入し、converter (build_lattice / 1-best / 10-best) と candidates (standard / predictive) のベンチマークを追加
- 入力サイズ (short〜very_long) ごとに計測し、統計的に有意な比較が可能に
- `mise run bench` で実行可能
- 既存の `bench_convert_latency` (#[ignore] test) はそのまま残置

## Test plan
- [x] `cargo fmt --all --check` pass
- [x] `cargo clippy --workspace --all-features -- -D warnings` pass
- [x] `cargo test --workspace --all-features` — 全テスト pass
- [x] `cargo bench -p lex-core --bench converter` 実行確認
- [x] `cargo bench -p lex-core --bench candidates` 実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)