### PR TITLE
refactor: session field grouping + Composition methods

### DIFF
--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -5,7 +5,7 @@ use super::InputSession;
 
 impl InputSession {
     pub(super) fn try_auto_commit(&mut self) -> Option<KeyResponse> {
-        if !self.conversion_mode.auto_commit_enabled() {
+        if !self.config.conversion_mode.auto_commit_enabled() {
             return None;
         }
         // Extract data from comp() in a block so the borrow is dropped before
@@ -94,7 +94,7 @@ impl InputSession {
                 text: String::new(),
                 dashed: false,
             });
-        } else if self.defer_candidates {
+        } else if self.config.defer_candidates {
             // Async mode: extract provisional candidates from remaining N-best
             // segments so the candidate panel stays visible (no flicker).
             let c = self.comp();
@@ -134,7 +134,7 @@ impl InputSession {
             });
             resp.async_request = Some(AsyncCandidateRequest {
                 reading: c.kana.clone(),
-                candidate_dispatch: self.conversion_mode.candidate_dispatch(),
+                candidate_dispatch: self.config.conversion_mode.candidate_dispatch(),
             });
             resp.candidates = CandidateAction::Show {
                 surfaces: provisional,

--- a/engine/crates/lex-session/src/candidate_gen.rs
+++ b/engine/crates/lex-session/src/candidate_gen.rs
@@ -15,7 +15,7 @@ impl InputSession {
             return;
         }
 
-        let mode = self.conversion_mode;
+        let mode = self.config.conversion_mode;
         let reading = self.comp().kana.clone();
         let CandidateResponse { surfaces, paths } = {
             let h_guard = self.history.as_ref().and_then(|h| h.read().ok());
@@ -62,7 +62,7 @@ impl InputSession {
         if !reading.is_empty() {
             resp.async_request = Some(AsyncCandidateRequest {
                 reading,
-                candidate_dispatch: self.conversion_mode.candidate_dispatch(),
+                candidate_dispatch: self.config.conversion_mode.candidate_dispatch(),
             });
         }
         resp

--- a/engine/crates/lex-session/src/composing.rs
+++ b/engine/crates/lex-session/src/composing.rs
@@ -68,7 +68,7 @@ impl InputSession {
 
         // Unrecognized non-romaji character — add to kana
         self.comp().kana.push_str(text);
-        if self.defer_candidates {
+        if self.config.defer_candidates {
             self.make_deferred_candidates_response()
         } else {
             self.update_candidates();
@@ -82,8 +82,8 @@ impl InputSession {
             let resp = self.commit_composed();
             self.state = SessionState::Composing(Composition::new(Submode::Japanese));
             self.comp().pending.push_str(input);
-            self.drain_pending(false);
-            let sub_resp = if self.defer_candidates {
+            self.comp().drain_pending(false);
+            let sub_resp = if self.config.defer_candidates {
                 self.make_deferred_candidates_response()
             } else {
                 if self.comp().pending.is_empty() {
@@ -96,9 +96,9 @@ impl InputSession {
 
         self.comp().prefix.has_boundary_space = false;
         self.comp().pending.push_str(input);
-        self.drain_pending(false);
+        self.comp().drain_pending(false);
 
-        if self.defer_candidates {
+        if self.config.defer_candidates {
             if self.comp().pending.is_empty() {
                 // Kana resolved — defer candidate generation to caller
                 self.make_deferred_candidates_response()
@@ -113,16 +113,5 @@ impl InputSession {
             }
             self.make_marked_text_and_candidates_response()
         }
-    }
-
-    pub(super) fn drain_pending(&mut self, force: bool) {
-        let c = self.comp();
-        let result = convert_romaji(&c.kana, &c.pending, force);
-        c.kana = result.composed_kana;
-        c.pending = result.pending_romaji;
-    }
-
-    pub(super) fn flush(&mut self) {
-        self.drain_pending(true);
     }
 }

--- a/engine/crates/lex-session/src/ghost.rs
+++ b/engine/crates/lex-session/src/ghost.rs
@@ -4,17 +4,17 @@ use super::InputSession;
 impl InputSession {
     /// Accept the current ghost text (Tab in idle with ghost visible).
     pub(super) fn accept_ghost_text(&mut self) -> KeyResponse {
-        let text = self.ghost_text.take().unwrap();
+        let text = self.ghost.text.take().unwrap();
         // Accumulate accepted ghost text into committed_context
         self.committed_context.push_str(&text);
         let mut resp = KeyResponse::consumed();
         resp.commit = Some(text);
         // After accepting ghost, request another generation with full context
-        if self.conversion_mode == ConversionMode::GhostText {
-            self.ghost_generation += 1;
+        if self.config.conversion_mode == ConversionMode::GhostText {
+            self.ghost.generation += 1;
             resp.ghost_request = Some(AsyncGhostRequest {
                 context: self.committed_context.clone(),
-                generation: self.ghost_generation,
+                generation: self.ghost.generation,
             });
         }
         resp
@@ -23,16 +23,16 @@ impl InputSession {
     /// Receive ghost text from async generation. Returns a response if valid.
     /// Returns `None` if the generation is stale or session is in wrong state.
     pub fn receive_ghost_text(&mut self, generation: u64, text: String) -> Option<KeyResponse> {
-        if generation != self.ghost_generation {
+        if generation != self.ghost.generation {
             return None;
         }
         if self.is_composing() {
             return None;
         }
-        if self.conversion_mode != ConversionMode::GhostText {
+        if self.config.conversion_mode != ConversionMode::GhostText {
             return None;
         }
-        self.ghost_text = Some(text.clone());
+        self.ghost.text = Some(text.clone());
         let mut resp = KeyResponse::consumed();
         resp.ghost_text = Some(text);
         Some(resp)
@@ -40,6 +40,6 @@ impl InputSession {
 
     /// Get current ghost generation counter (for staleness checks).
     pub fn ghost_generation(&self) -> u64 {
-        self.ghost_generation
+        self.ghost.generation
     }
 }

--- a/engine/crates/lex-session/src/response.rs
+++ b/engine/crates/lex-session/src/response.rs
@@ -32,7 +32,7 @@ impl InputSession {
         }
 
         // Try auto-commit (only in sync mode; async mode handles it in receive_candidates)
-        if !self.defer_candidates {
+        if !self.config.defer_candidates {
             if let Some(auto_resp) = self.try_auto_commit() {
                 resp = auto_resp;
             }

--- a/engine/crates/lex-session/src/submode.rs
+++ b/engine/crates/lex-session/src/submode.rs
@@ -12,7 +12,7 @@ impl InputSession {
         if self.is_composing() {
             // Flush pending romaji before switching
             if !self.comp().pending.is_empty() {
-                self.flush();
+                self.comp().flush();
             }
 
             // Undo boundary space if nothing was typed since the last toggle
@@ -46,7 +46,7 @@ impl InputSession {
 
             // Programmer mode: insert space at submode boundary
             c.prefix.has_boundary_space = false;
-            if self.programmer_mode && !self.comp().prefix.is_empty() {
+            if self.config.programmer_mode && !self.comp().prefix.is_empty() {
                 if let Some(last) = self.comp().prefix.text.chars().last() {
                     let last_is_ascii = last.is_ascii();
                     let should_insert = (current_submode == Submode::Japanese

--- a/engine/crates/lex-session/src/tests/auto_commit.rs
+++ b/engine/crates/lex-session/src/tests/auto_commit.rs
@@ -7,6 +7,6 @@ fn test_set_conversion_mode_ghosttext() {
     let mut session = InputSession::new(dict.clone(), None, None);
 
     session.set_conversion_mode(ConversionMode::GhostText);
-    assert_eq!(session.conversion_mode, ConversionMode::GhostText);
-    assert_eq!(session.conversion_mode.candidate_dispatch(), 2);
+    assert_eq!(session.config.conversion_mode, ConversionMode::GhostText);
+    assert_eq!(session.config.conversion_mode.candidate_dispatch(), 2);
 }

--- a/engine/crates/lex-session/src/tests/candidates.rs
+++ b/engine/crates/lex-session/src/tests/candidates.rs
@@ -105,11 +105,11 @@ fn test_conversion_mode_switch() {
     let mut session = InputSession::new(dict.clone(), None, None);
 
     // Default is Standard
-    assert_eq!(session.conversion_mode, ConversionMode::Standard);
+    assert_eq!(session.config.conversion_mode, ConversionMode::Standard);
 
     // Switch to Predictive
     session.set_conversion_mode(ConversionMode::Predictive);
-    assert_eq!(session.conversion_mode, ConversionMode::Predictive);
+    assert_eq!(session.config.conversion_mode, ConversionMode::Predictive);
 
     type_string(&mut session, "kyou");
     // Tab should commit (Predictive behavior)
@@ -119,7 +119,7 @@ fn test_conversion_mode_switch() {
 
     // Switch back to Standard
     session.set_conversion_mode(ConversionMode::Standard);
-    assert_eq!(session.conversion_mode, ConversionMode::Standard);
+    assert_eq!(session.config.conversion_mode, ConversionMode::Standard);
 
     type_string(&mut session, "kyou");
     // Tab should toggle submode (Standard behavior)

--- a/engine/crates/lex-session/src/tests/ghost.rs
+++ b/engine/crates/lex-session/src/tests/ghost.rs
@@ -8,14 +8,14 @@ fn test_ghosttext_tab_accepts_ghost() {
     session.set_conversion_mode(ConversionMode::GhostText);
 
     // Simulate ghost text being received
-    session.ghost_text = Some("ですね".to_string());
-    session.ghost_generation = 1;
+    session.ghost.text = Some("ですね".to_string());
+    session.ghost.generation = 1;
 
     // Tab should accept ghost text
     let resp = session.handle_key(key::TAB, "", 0);
     assert!(resp.consumed);
     assert_eq!(resp.commit.as_deref(), Some("ですね"));
-    assert!(session.ghost_text.is_none());
+    assert!(session.ghost.text.is_none());
 }
 
 #[test]
@@ -41,12 +41,12 @@ fn test_ghosttext_input_clears_ghost() {
     session.set_conversion_mode(ConversionMode::GhostText);
 
     // Simulate ghost text
-    session.ghost_text = Some("ですね".to_string());
+    session.ghost.text = Some("ですね".to_string());
 
     // Type a character → should clear ghost
     let resp = session.handle_key(0, "k", 0);
     assert!(resp.consumed);
-    assert!(session.ghost_text.is_none());
+    assert!(session.ghost.text.is_none());
     // Ghost clear signaled in response
     assert_eq!(resp.ghost_text.as_deref(), Some(""));
 }
@@ -56,17 +56,17 @@ fn test_ghosttext_stale_generation_rejected() {
     let dict = make_test_dict();
     let mut session = InputSession::new(dict.clone(), None, None);
     session.set_conversion_mode(ConversionMode::GhostText);
-    session.ghost_generation = 5;
+    session.ghost.generation = 5;
 
     // Stale generation
     let result = session.receive_ghost_text(3, "stale text".to_string());
     assert!(result.is_none());
-    assert!(session.ghost_text.is_none());
+    assert!(session.ghost.text.is_none());
 
     // Correct generation
     let result = session.receive_ghost_text(5, "correct text".to_string());
     assert!(result.is_some());
-    assert_eq!(session.ghost_text.as_deref(), Some("correct text"));
+    assert_eq!(session.ghost.text.as_deref(), Some("correct text"));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_ghosttext_rejected_while_composing() {
     let dict = make_test_dict();
     let mut session = InputSession::new(dict.clone(), None, None);
     session.set_conversion_mode(ConversionMode::GhostText);
-    session.ghost_generation = 1;
+    session.ghost.generation = 1;
 
     type_string(&mut session, "kyou");
     assert!(session.is_composing());
@@ -89,7 +89,7 @@ fn test_standard_mode_no_ghost() {
     let dict = make_test_dict();
     let mut session = InputSession::new(dict.clone(), None, None);
     session.set_conversion_mode(ConversionMode::Standard);
-    session.ghost_generation = 1;
+    session.ghost.generation = 1;
 
     // Standard mode rejects ghost text
     let result = session.receive_ghost_text(1, "text".to_string());
@@ -119,8 +119,8 @@ fn test_ghosttext_accept_then_requests_more() {
     session.set_conversion_mode(ConversionMode::GhostText);
 
     // Simulate ghost text
-    session.ghost_text = Some("ですね".to_string());
-    session.ghost_generation = 1;
+    session.ghost.text = Some("ですね".to_string());
+    session.ghost.generation = 1;
 
     // Accept ghost
     let resp = session.handle_key(key::TAB, "", 0);

--- a/engine/crates/lex-session/src/tests/simulator.rs
+++ b/engine/crates/lex-session/src/tests/simulator.rs
@@ -88,7 +88,7 @@ impl HeadlessIME {
             return None;
         }
 
-        let mode = self.session.conversion_mode;
+        let mode = self.session.config.conversion_mode;
         let cand: CandidateResponse = mode.generate_candidates(
             &self.dict,
             self.conn.as_deref(),

--- a/engine/crates/lex-session/src/types.rs
+++ b/engine/crates/lex-session/src/types.rs
@@ -142,6 +142,31 @@ impl Composition {
     pub(super) fn display_kana(&self) -> String {
         format!("{}{}{}", self.prefix.text, self.kana, self.pending)
     }
+
+    /// Convert pending romaji to kana. If `force`, flush incomplete sequences.
+    pub(super) fn drain_pending(&mut self, force: bool) {
+        let result = lex_core::romaji::convert_romaji(&self.kana, &self.pending, force);
+        self.kana = result.composed_kana;
+        self.pending = result.pending_romaji;
+    }
+
+    /// Flush all pending romaji (force incomplete sequences).
+    pub(super) fn flush(&mut self) {
+        self.drain_pending(true);
+    }
+}
+
+// --- Session-level groupings ---
+
+pub(super) struct SessionConfig {
+    pub(super) programmer_mode: bool,
+    pub(super) defer_candidates: bool,
+    pub(super) conversion_mode: ConversionMode,
+}
+
+pub(super) struct GhostState {
+    pub(super) text: Option<String>,
+    pub(super) generation: u64,
 }
 
 // --- Sub-structures for grouping related state ---


### PR DESCRIPTION
## Summary
- Add `SessionConfig` and `GhostState` structs to group related `InputSession` fields
- Move `drain_pending`/`flush` from `InputSession` methods to `Composition` methods
- Refactor `commit_current_state` to use `let-else` pattern for explicit state matching
- Update ~60 field references across all session modules and tests

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (242 tests)
- [ ] `mise run build && mise run install && mise run reload` + manual IME test

🤖 Generated with [Claude Code](https://claude.com/claude-code)