### PR TITLE
refactor: response builders as free functions + auto-commit decoupling

### DIFF
--- a/engine/crates/lex-session/src/candidate_gen.rs
+++ b/engine/crates/lex-session/src/candidate_gen.rs
@@ -1,6 +1,7 @@
 use lex_core::candidates::CandidateResponse;
 use lex_core::converter::{convert, convert_with_history, ConvertedSegment};
 
+use super::response::{build_marked_text, build_marked_text_and_candidates};
 use super::types::{AsyncCandidateRequest, KeyResponse, SessionState, Submode, MAX_CANDIDATES};
 use super::InputSession;
 
@@ -58,7 +59,7 @@ impl InputSession {
         } else {
             self.comp().candidates.clear();
         }
-        let mut resp = self.make_marked_text_response();
+        let mut resp = build_marked_text(self.comp());
         if !reading.is_empty() {
             resp.async_request = Some(AsyncCandidateRequest {
                 reading,
@@ -94,6 +95,6 @@ impl InputSession {
         }
 
         // No auto-commit: update marked text to Viterbi #1 and show candidates
-        Some(self.make_marked_text_and_candidates_response())
+        Some(build_marked_text_and_candidates(self.comp()))
     }
 }

--- a/engine/crates/lex-session/src/response.rs
+++ b/engine/crates/lex-session/src/response.rs
@@ -1,58 +1,46 @@
-use super::types::{CandidateAction, KeyResponse, MarkedText, Submode};
-use super::InputSession;
+use super::types::{CandidateAction, Composition, KeyResponse, MarkedText, Submode};
 
-impl InputSession {
-    pub(super) fn make_marked_text_response(&mut self) -> KeyResponse {
-        let c = self.comp();
-        let display = c.display();
-        let mut resp = KeyResponse::consumed();
-        resp.marked = Some(MarkedText {
-            text: display,
-            dashed: c.submode == Submode::English,
-        });
-        resp
-    }
+/// Build a response showing only marked text (no candidates).
+pub(super) fn build_marked_text(comp: &Composition) -> KeyResponse {
+    let display = comp.display();
+    let mut resp = KeyResponse::consumed();
+    resp.marked = Some(MarkedText {
+        text: display,
+        dashed: comp.submode == Submode::English,
+    });
+    resp
+}
 
-    pub(super) fn make_marked_text_and_candidates_response(&mut self) -> KeyResponse {
-        let mut resp = KeyResponse::consumed();
+/// Build a response showing marked text and candidate panel.
+pub(super) fn build_marked_text_and_candidates(comp: &Composition) -> KeyResponse {
+    let mut resp = KeyResponse::consumed();
 
-        let c = self.comp();
-        let display = c.display();
-        resp.marked = Some(MarkedText {
-            text: display,
-            dashed: c.submode == Submode::English,
-        });
+    let display = comp.display();
+    resp.marked = Some(MarkedText {
+        text: display,
+        dashed: comp.submode == Submode::English,
+    });
 
-        // Candidates
-        if !c.candidates.is_empty() {
-            resp.candidates = CandidateAction::Show {
-                surfaces: c.candidates.surfaces.clone(),
-                selected: c.candidates.selected as u32,
-            };
-        }
-
-        // Try auto-commit (only in sync mode; async mode handles it in receive_candidates)
-        if !self.config.defer_candidates {
-            if let Some(auto_resp) = self.try_auto_commit() {
-                resp = auto_resp;
-            }
-        }
-
-        resp
-    }
-
-    pub(super) fn make_candidate_selection_response(&mut self) -> KeyResponse {
-        let mut resp = KeyResponse::consumed();
-
-        let c = self.comp();
-        resp.marked = Some(MarkedText {
-            text: c.display(),
-            dashed: false,
-        });
+    if !comp.candidates.is_empty() {
         resp.candidates = CandidateAction::Show {
-            surfaces: c.candidates.surfaces.clone(),
-            selected: c.candidates.selected as u32,
+            surfaces: comp.candidates.surfaces.clone(),
+            selected: comp.candidates.selected as u32,
         };
-        resp
     }
+
+    resp
+}
+
+/// Build a response for candidate selection (always solid underline).
+pub(super) fn build_candidate_selection(comp: &Composition) -> KeyResponse {
+    let mut resp = KeyResponse::consumed();
+    resp.marked = Some(MarkedText {
+        text: comp.display(),
+        dashed: false,
+    });
+    resp.candidates = CandidateAction::Show {
+        surfaces: comp.candidates.surfaces.clone(),
+        selected: comp.candidates.selected as u32,
+    };
+    resp
 }


### PR DESCRIPTION
## Summary
- Extract `make_marked_text_response`, `make_marked_text_and_candidates_response`, `make_candidate_selection_response` from `&mut self` methods to free functions taking `&Composition` (`build_marked_text`, `build_marked_text_and_candidates`, `build_candidate_selection`)
- Move auto-commit check out of `build_marked_text_and_candidates` to callers via `maybe_auto_commit` helper
- `response.rs` is now a pure display data builder with no `InputSession` dependency

Stacked on #118.

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (242 tests)
- [ ] `mise run build && mise run install && mise run reload` + manual IME test

🤖 Generated with [Claude Code](https://claude.com/claude-code)