### PR TITLE
refactor: extract find_matching_path method on Composition

### DIFF
--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -82,20 +82,8 @@ impl InputSession {
             .push(vec![(reading.clone(), surface.clone())]);
 
         // Sub-phrase learning: if a matching N-best path exists
-        if let Some(matching_path) = self
-            .comp()
-            .candidates
-            .paths
-            .iter()
-            .find(|path| path.iter().map(|s| s.surface.as_str()).collect::<String>() == surface)
-        {
-            if matching_path.len() > 1 {
-                let seg_pairs: Vec<(String, String)> = matching_path
-                    .iter()
-                    .map(|s| (s.reading.clone(), s.surface.clone()))
-                    .collect();
-                self.history_records.push(seg_pairs);
-            }
+        if let Some(seg_pairs) = self.comp().find_matching_path(&surface) {
+            self.history_records.push(seg_pairs);
         }
     }
 

--- a/engine/crates/lex-session/src/types.rs
+++ b/engine/crates/lex-session/src/types.rs
@@ -154,6 +154,23 @@ impl Composition {
     pub(super) fn flush(&mut self) {
         self.drain_pending(true);
     }
+
+    /// Find the N-best path whose concatenated surfaces match `surface`.
+    /// Returns segment pairs (reading, surface) for sub-phrase history recording.
+    pub(super) fn find_matching_path(&self, surface: &str) -> Option<Vec<(String, String)>> {
+        let path =
+            self.candidates.paths.iter().find(|path| {
+                path.iter().map(|s| s.surface.as_str()).collect::<String>() == surface
+            })?;
+        if path.len() <= 1 {
+            return None;
+        }
+        Some(
+            path.iter()
+                .map(|s| (s.reading.clone(), s.surface.clone()))
+                .collect(),
+        )
+    }
 }
 
 // --- Session-level groupings ---


### PR DESCRIPTION
## Summary
- Extract `find_matching_path` from `record_history` into a method on `Composition`
- Simplifies `commit.rs` by delegating N-best path lookup to the composition type
- Phase 6 of 提案 C (セッション責務分離)

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (243 tests)

Supersedes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)