### PR TITLE
feat: add custom romaji config loading

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -52,6 +52,20 @@ class AppContext {
             atPath: logDir, withIntermediateDirectories: true)
         traceInit(logDir: logDir)
 
+        // Load custom romaji config if present
+        let romajiPath = appSupport
+            .appendingPathComponent("Lexime/romaji.toml").path
+        if FileManager.default.fileExists(atPath: romajiPath) {
+            do {
+                try romajiLoadConfig(path: romajiPath)
+                NSLog("Lexime: Custom romaji loaded from %@", romajiPath)
+            } catch {
+                NSLog("Lexime: romaji config error at %@: %@",
+                      romajiPath, "\(error)")
+                // Embedded default will be used
+            }
+        }
+
         let history: LexUserHistory?
         do {
             let h = try LexUserHistory.open(path: self.historyPath)

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -442,6 +442,15 @@ fn romaji_convert(kana: String, pending: String, force: bool) -> LexRomajiConver
 }
 
 #[uniffi::export]
+fn romaji_load_config(path: String) -> Result<(), LexError> {
+    let content = std::fs::read_to_string(&path).map_err(|e| LexError::Io {
+        msg: format!("{path}: {e}"),
+    })?;
+    RomajiTrie::init_custom(content).map_err(|e| LexError::InvalidData { msg: e.to_string() })?;
+    Ok(())
+}
+
+#[uniffi::export]
 fn trace_init(log_dir: String) {
     crate::trace_init::init_tracing(Path::new(&log_dir));
 }

--- a/mise.toml
+++ b/mise.toml
@@ -265,6 +265,10 @@ cd engine && cargo run -p lex-cli --features neural --bin dictool -- neural-scor
   "$@"
 """
 
+[tasks.romaji-export]
+description = "Export default romaji mappings to TOML"
+run = "cd engine && cargo run -p lex-cli --bin dictool -- romaji-export"
+
 [tasks.bench]
 description = "Run criterion benchmarks"
 run = "cd engine && cargo bench -p lex-core"


### PR DESCRIPTION
## Summary
- Add `romaji_load_config(path:)` UniFFI export for loading custom romaji TOML
- Load `~/Library/Application Support/Lexime/romaji.toml` at startup in AppContext (before engine init)
- Add `mise run romaji-export` task for exporting default mappings

## Details
This is PR 2 of 2 for 提案 H (ローマ字テーブル外部化).

Users can now customize their romaji layout (e.g. AZIK) by placing a `romaji.toml` at `~/Library/Application Support/Lexime/romaji.toml`. The file is a complete replacement (not a merge) — run `mise run romaji-export > romaji.toml` to get the default as a starting point.

**Changed files:**
- `engine/src/api/mod.rs` — `romaji_load_config` FFI function
- `Sources/AppContext.swift` — custom romaji loading at startup
- `mise.toml` — `romaji-export` task

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — all pass
- [ ] Manual: `mise run build && mise run install && mise run reload` — verify with/without custom romaji.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)