### PR TITLE
refactor: replace history_records with typed LearningRecord enum

### DIFF
--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -1,6 +1,8 @@
 use lex_core::converter::ConvertedSegment;
 
-use super::types::{AsyncCandidateRequest, CandidateAction, KeyResponse, MarkedText, Submode};
+use super::types::{
+    AsyncCandidateRequest, CandidateAction, KeyResponse, LearningRecord, MarkedText, Submode,
+};
 use super::InputSession;
 
 impl InputSession {
@@ -65,11 +67,11 @@ impl InputSession {
 
         // Record to history (comp() borrow is dropped)
         if committed_surface != committed_reading {
-            let pairs = vec![(committed_reading.clone(), committed_surface.clone())];
-            self.history_records.push(pairs);
-        }
-        if let Some(seg_pairs) = seg_pairs {
-            self.history_records.push(seg_pairs);
+            self.history_records.push(LearningRecord::Committed {
+                reading: committed_reading.clone(),
+                surface: committed_surface.clone(),
+                segments: seg_pairs,
+            });
         }
 
         // Remove committed reading from kana.

--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -1,6 +1,6 @@
 use super::types::{
-    AsyncGhostRequest, CandidateAction, ConversionMode, KeyResponse, MarkedText, SessionState,
-    Submode,
+    AsyncGhostRequest, CandidateAction, ConversionMode, KeyResponse, LearningRecord, MarkedText,
+    SessionState, Submode,
 };
 use super::InputSession;
 
@@ -77,14 +77,12 @@ impl InputSession {
         if self.history.is_none() {
             return;
         }
-        // Record whole pair
-        self.history_records
-            .push(vec![(reading.clone(), surface.clone())]);
-
-        // Sub-phrase learning: if a matching N-best path exists
-        if let Some(seg_pairs) = self.comp().find_matching_path(&surface) {
-            self.history_records.push(seg_pairs);
-        }
+        let segments = self.comp().find_matching_path(&surface);
+        self.history_records.push(LearningRecord::Committed {
+            reading,
+            surface,
+            segments,
+        });
     }
 
     pub(super) fn reset_state(&mut self) {

--- a/engine/crates/lex-session/src/lib.rs
+++ b/engine/crates/lex-session/src/lib.rs
@@ -25,7 +25,7 @@ use lex_core::user_history::UserHistory;
 
 pub use types::{
     AsyncCandidateRequest, AsyncGhostRequest, CandidateAction, ConversionMode, KeyResponse,
-    MarkedText, SideEffects,
+    LearningRecord, MarkedText, SideEffects,
 };
 
 use types::{Composition, GhostState, SessionConfig, SessionState, Submode};
@@ -44,7 +44,7 @@ pub struct InputSession {
     config: SessionConfig,
 
     // History recording buffer
-    history_records: Vec<Vec<(String, String)>>,
+    history_records: Vec<LearningRecord>,
 
     ghost: GhostState,
 
@@ -124,7 +124,7 @@ impl InputSession {
 
     /// Take recorded history entries, clearing the internal buffer.
     /// The caller should feed these to `UserHistory::record()`.
-    pub fn take_history_records(&mut self) -> Vec<Vec<(String, String)>> {
+    pub fn take_history_records(&mut self) -> Vec<LearningRecord> {
         std::mem::take(&mut self.history_records)
     }
 

--- a/engine/crates/lex-session/src/tests/basic.rs
+++ b/engine/crates/lex-session/src/tests/basic.rs
@@ -1,7 +1,9 @@
 use std::sync::{Arc, RwLock};
 
 use super::*;
-use crate::types::{cyclic_index, is_romaji_input, CandidateAction, FLAG_HAS_MODIFIER};
+use crate::types::{
+    cyclic_index, is_romaji_input, CandidateAction, LearningRecord, FLAG_HAS_MODIFIER,
+};
 use lex_core::user_history::UserHistory;
 
 // --- Basic romaji input ---
@@ -349,8 +351,14 @@ fn test_history_recorded_on_escape() {
     let records = session.take_history_records();
     assert!(!records.is_empty());
     // Should record kana → kana
-    assert_eq!(records[0][0].0, "きょう");
-    assert_eq!(records[0][0].1, "きょう");
+    match &records[0] {
+        LearningRecord::Committed {
+            reading, surface, ..
+        } => {
+            assert_eq!(reading, "きょう");
+            assert_eq!(surface, "きょう");
+        }
+    }
 }
 
 // --- Cyclic index ---

--- a/engine/crates/lex-session/src/types.rs
+++ b/engine/crates/lex-session/src/types.rs
@@ -384,6 +384,20 @@ pub(super) fn is_romaji_input(text: &str) -> bool {
     }
 }
 
+/// A typed record of what the user confirmed, for history learning.
+#[derive(Debug, Clone)]
+pub enum LearningRecord {
+    /// User confirmed a whole reading→surface mapping.
+    /// Generates unigram entry + optional sub-phrase bigrams.
+    Committed {
+        reading: String,
+        surface: String,
+        /// Pre-segmented N-best path (if available and multi-segment).
+        /// Used for sub-phrase unigram + bigram learning.
+        segments: Option<Vec<(String, String)>>,
+    },
+}
+
 pub(super) fn cyclic_index(current: usize, delta: i32, count: usize) -> usize {
     if count == 0 {
         return 0;


### PR DESCRIPTION
## Summary

- `history_records: Vec<Vec<(String, String)>>` を typed enum `LearningRecord::Committed` に置換
- 2回 push パターン (whole-pair + sub-phrase) を `segments` フィールド内包の 1 レコードに統合
- FFI 層 (`api/mod.rs`) で enum を解釈し、`UserHistory::record()` へのシグネチャは不変

## Test plan

- [x] `cargo fmt --all --check` pass
- [x] `cargo clippy --workspace --all-features -- -D warnings` pass
- [x] `cargo test --workspace --all-features` — 全 282 テスト pass
- [x] `lex-core` への変更なし（`UserHistory::record` シグネチャ不変）

🤖 Generated with [Claude Code](https://claude.com/claude-code)