### PR TITLE
refactor: make Dictionary trait return owned types

### DIFF
--- a/engine/crates/lex-cli/src/bin/dictool.rs
+++ b/engine/crates/lex-cli/src/bin/dictool.rs
@@ -460,7 +460,8 @@ fn info_dict(dict_file: &str) {
     println!();
     println!("Sample lookups:");
     for key in &sample_keys {
-        if let Some(entries) = dict.lookup(key) {
+        let entries = dict.lookup(key);
+        if !entries.is_empty() {
             let surfaces: Vec<&str> = entries.iter().take(5).map(|e| e.surface.as_str()).collect();
             println!("  {key} → {}", surfaces.join(", "));
         } else {
@@ -729,12 +730,12 @@ fn lookup(dict_file: &str, reading: &str) {
         TrieDictionary::open(Path::new(dict_file)),
         "Error opening dictionary: {}"
     );
-    match dict.lookup(reading) {
-        Some(entries) => {
-            println!("{reading}: {} entries", entries.len());
-            print_entries(entries);
-        }
-        None => println!("{reading}: not found"),
+    let entries = dict.lookup(reading);
+    if entries.is_empty() {
+        println!("{reading}: not found");
+    } else {
+        println!("{reading}: {} entries", entries.len());
+        print_entries(&entries);
     }
 }
 
@@ -750,7 +751,7 @@ fn prefix(dict_file: &str, query: &str) {
     }
     for r in &results {
         println!("{} ({} entries):", r.reading, r.entries.len());
-        print_entries(r.entries);
+        print_entries(&r.entries);
     }
 }
 

--- a/engine/crates/lex-core/src/converter/lattice.rs
+++ b/engine/crates/lex-core/src/converter/lattice.rs
@@ -68,7 +68,7 @@ pub fn build_lattice(dict: &dyn Dictionary, kana: &str) -> Lattice {
         for result in &matches {
             let reading_char_count = result.reading.chars().count();
             let end = start + reading_char_count;
-            for entry in result.entries {
+            for entry in &result.entries {
                 let idx = nodes.len();
                 nodes.push(LatticeNode {
                     start,

--- a/engine/crates/lex-core/src/dict/mod.rs
+++ b/engine/crates/lex-core/src/dict/mod.rs
@@ -54,15 +54,15 @@ impl From<lexime_trie::TrieError> for DictError {
     }
 }
 
-pub struct SearchResult<'a> {
+pub struct SearchResult {
     pub reading: String,
-    pub entries: &'a [DictEntry],
+    pub entries: Vec<DictEntry>,
 }
 
 pub trait Dictionary: Send + Sync {
-    fn lookup(&self, reading: &str) -> Option<&[DictEntry]>;
-    fn predict(&self, prefix: &str, max_results: usize) -> Vec<SearchResult<'_>>;
-    fn common_prefix_search(&self, query: &str) -> Vec<SearchResult<'_>>;
+    fn lookup(&self, reading: &str) -> Vec<DictEntry>;
+    fn predict(&self, prefix: &str, max_results: usize) -> Vec<SearchResult>;
+    fn common_prefix_search(&self, query: &str) -> Vec<SearchResult>;
 
     /// Prediction candidates ranked by cost, deduplicated by surface.
     ///
@@ -79,7 +79,7 @@ pub trait Dictionary: Send + Sync {
         for sr in self.predict(prefix, scan_limit) {
             flat.reserve(sr.entries.len());
             for e in sr.entries {
-                flat.push((sr.reading.clone(), e.clone()));
+                flat.push((sr.reading.clone(), e));
             }
         }
 

--- a/engine/crates/lex-core/src/dict/tests/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/tests/trie_dict.rs
@@ -75,7 +75,7 @@ fn sample_dict() -> TrieDictionary {
 #[test]
 fn test_lookup_exact() {
     let dict = sample_dict();
-    let results = dict.lookup("かんじ").unwrap();
+    let results = dict.lookup("かんじ");
     assert_eq!(results.len(), 3);
     assert_eq!(results[0].surface, "漢字");
     assert_eq!(results[1].surface, "感じ");
@@ -85,7 +85,7 @@ fn test_lookup_exact() {
 #[test]
 fn test_lookup_not_found() {
     let dict = sample_dict();
-    assert!(dict.lookup("そんざい").is_none());
+    assert!(dict.lookup("そんざい").is_empty());
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn test_predict_no_match() {
 #[test]
 fn test_cost_ordering() {
     let dict = sample_dict();
-    let results = dict.lookup("かんじ").unwrap();
+    let results = dict.lookup("かんじ");
     for w in results.windows(2) {
         assert!(w[0].cost <= w[1].cost, "entries should be sorted by cost");
     }
@@ -135,8 +135,8 @@ fn test_serialize_roundtrip() {
     let bytes = dict.to_bytes().unwrap();
     let dict2 = TrieDictionary::from_bytes(&bytes).unwrap();
 
-    let r1 = dict.lookup("かんじ").unwrap();
-    let r2 = dict2.lookup("かんじ").unwrap();
+    let r1 = dict.lookup("かんじ");
+    let r2 = dict2.lookup("かんじ");
     assert_eq!(r1.len(), r2.len());
     for (a, b) in r1.iter().zip(r2.iter()) {
         assert_eq!(a.surface, b.surface);
@@ -239,7 +239,8 @@ fn test_mozc_dict_known_entries() {
         .expect("failed to open lexime-sudachi.dict — run `make dict` first");
 
     // かんじ should have 漢字
-    let results = dict.lookup("かんじ").expect("かんじ should exist");
+    let results = dict.lookup("かんじ");
+    assert!(!results.is_empty(), "かんじ should exist");
     let surfaces: Vec<&str> = results.iter().map(|e| e.surface.as_str()).collect();
     assert!(
         surfaces.contains(&"漢字"),
@@ -251,7 +252,8 @@ fn test_mozc_dict_known_entries() {
     );
 
     // にほん should have 日本
-    let results = dict.lookup("にほん").expect("にほん should exist");
+    let results = dict.lookup("にほん");
+    assert!(!results.is_empty(), "にほん should exist");
     let surfaces: Vec<&str> = results.iter().map(|e| e.surface.as_str()).collect();
     assert!(
         surfaces.contains(&"日本"),

--- a/engine/examples/debug_convert.rs
+++ b/engine/examples/debug_convert.rs
@@ -21,21 +21,21 @@ fn main() {
         "です",
         "たいです",
     ] {
-        match dict.lookup(key) {
-            Some(entries) => {
-                let surfaces: Vec<String> = entries
-                    .iter()
-                    .take(8)
-                    .map(|e| {
-                        format!(
-                            "{}(cost={},L={},R={})",
-                            e.surface, e.cost, e.left_id, e.right_id
-                        )
-                    })
-                    .collect();
-                println!("  {key} -> {}", surfaces.join(", "));
-            }
-            None => println!("  {key} -> NOT FOUND"),
+        let entries = dict.lookup(key);
+        if entries.is_empty() {
+            println!("  {key} -> NOT FOUND");
+        } else {
+            let surfaces: Vec<String> = entries
+                .iter()
+                .take(8)
+                .map(|e| {
+                    format!(
+                        "{}(cost={},L={},R={})",
+                        e.surface, e.cost, e.left_id, e.right_id
+                    )
+                })
+                .collect();
+            println!("  {key} -> {}", surfaces.join(", "));
         }
     }
 

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -24,10 +24,8 @@ impl LexDictionary {
     }
 
     fn lookup(&self, reading: String) -> Vec<super::LexDictEntry> {
-        let Some(entries) = self.inner.lookup(&reading) else {
-            return Vec::new();
-        };
-        entries
+        self.inner
+            .lookup(&reading)
             .iter()
             .map(|e| super::LexDictEntry {
                 reading: reading.clone(),


### PR DESCRIPTION
## Summary
- `SearchResult` → remove lifetime, `entries: Vec<DictEntry>` (was `&'a [DictEntry]`)
- `lookup` → `Vec<DictEntry>` (was `Option<&[DictEntry]>`, empty Vec = not found)
- `predict` / `common_prefix_search` → `Vec<SearchResult>` (was `Vec<SearchResult<'_>>`)
- TrieDictionary impl adds `.to_vec()` / `.unwrap_or_default()`
- All callers already cloned the data, so no performance impact

Enables CompositeDictionary (next PR) to merge results from multiple layers without lifetime issues.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — 281 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)