### PR TITLE
feat: CompositeDictionary + Arc<dyn Dictionary> unification

### DIFF
--- a/engine/crates/lex-core/benches/candidates.rs
+++ b/engine/crates/lex-core/benches/candidates.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use lex_core::candidates::{generate_candidates, generate_prediction_candidates};
-use lex_core::dict::{DictEntry, TrieDictionary};
+use lex_core::dict::{DictEntry, Dictionary, TrieDictionary};
 
-fn bench_dict() -> Arc<TrieDictionary> {
+fn bench_dict() -> Arc<dyn Dictionary> {
     let entries = vec![
         (
             "きょう".into(),

--- a/engine/crates/lex-core/src/dict/composite.rs
+++ b/engine/crates/lex-core/src/dict/composite.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::{DictEntry, Dictionary, SearchResult};
+
+/// A dictionary that merges results from multiple layers.
+///
+/// Layers are searched in order; later layers have higher priority.
+/// Duplicate entries (same reading + surface) are deduplicated, keeping
+/// the lowest cost across all layers.
+pub struct CompositeDictionary {
+    layers: Vec<Arc<dyn Dictionary>>,
+}
+
+impl CompositeDictionary {
+    pub fn new(layers: Vec<Arc<dyn Dictionary>>) -> Self {
+        Self { layers }
+    }
+}
+
+/// Deduplicate entries by surface, keeping the lowest cost for each.
+fn dedup_entries(entries: Vec<DictEntry>) -> Vec<DictEntry> {
+    let mut best: HashMap<String, DictEntry> = HashMap::new();
+    for e in entries {
+        best.entry(e.surface.clone())
+            .and_modify(|existing| {
+                if e.cost < existing.cost {
+                    *existing = e.clone();
+                }
+            })
+            .or_insert(e);
+    }
+    let mut result: Vec<DictEntry> = best.into_values().collect();
+    result.sort_by_key(|e| e.cost);
+    result
+}
+
+/// Merge search results by reading, deduplicating entries within each reading.
+fn merge_results(results: Vec<SearchResult>) -> Vec<SearchResult> {
+    let mut by_reading: HashMap<String, Vec<DictEntry>> = HashMap::new();
+    for sr in results {
+        by_reading.entry(sr.reading).or_default().extend(sr.entries);
+    }
+    let mut merged: Vec<SearchResult> = by_reading
+        .into_iter()
+        .map(|(reading, entries)| SearchResult {
+            reading,
+            entries: dedup_entries(entries),
+        })
+        .collect();
+    merged.sort_by(|a, b| a.reading.cmp(&b.reading));
+    merged
+}
+
+impl Dictionary for CompositeDictionary {
+    fn lookup(&self, reading: &str) -> Vec<DictEntry> {
+        let mut all = Vec::new();
+        for layer in &self.layers {
+            all.extend(layer.lookup(reading));
+        }
+        dedup_entries(all)
+    }
+
+    fn predict(&self, prefix: &str, max_results: usize) -> Vec<SearchResult> {
+        let mut all = Vec::new();
+        for layer in &self.layers {
+            all.extend(layer.predict(prefix, max_results));
+        }
+        let mut merged = merge_results(all);
+        merged.truncate(max_results);
+        merged
+    }
+
+    fn common_prefix_search(&self, query: &str) -> Vec<SearchResult> {
+        let mut all = Vec::new();
+        for layer in &self.layers {
+            all.extend(layer.common_prefix_search(query));
+        }
+        merge_results(all)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dict::TrieDictionary;
+
+    fn layer_a() -> Arc<dyn Dictionary> {
+        let entries = vec![
+            (
+                "きょう".to_string(),
+                vec![
+                    DictEntry {
+                        surface: "今日".to_string(),
+                        cost: 3000,
+                        left_id: 100,
+                        right_id: 100,
+                    },
+                    DictEntry {
+                        surface: "京".to_string(),
+                        cost: 5000,
+                        left_id: 101,
+                        right_id: 101,
+                    },
+                ],
+            ),
+            (
+                "は".to_string(),
+                vec![DictEntry {
+                    surface: "は".to_string(),
+                    cost: 2000,
+                    left_id: 200,
+                    right_id: 200,
+                }],
+            ),
+        ];
+        Arc::new(TrieDictionary::from_entries(entries))
+    }
+
+    fn layer_b() -> Arc<dyn Dictionary> {
+        let entries = vec![
+            (
+                "きょう".to_string(),
+                vec![
+                    DictEntry {
+                        surface: "今日".to_string(),
+                        cost: 2000, // lower cost override
+                        left_id: 100,
+                        right_id: 100,
+                    },
+                    DictEntry {
+                        surface: "教".to_string(),
+                        cost: 4000, // new entry
+                        left_id: 102,
+                        right_id: 102,
+                    },
+                ],
+            ),
+            (
+                "きょうと".to_string(),
+                vec![DictEntry {
+                    surface: "京都".to_string(),
+                    cost: 3500,
+                    left_id: 103,
+                    right_id: 103,
+                }],
+            ),
+        ];
+        Arc::new(TrieDictionary::from_entries(entries))
+    }
+
+    #[test]
+    fn test_lookup_merges_and_deduplicates() {
+        let dict = CompositeDictionary::new(vec![layer_a(), layer_b()]);
+        let results = dict.lookup("きょう");
+        let surfaces: Vec<&str> = results.iter().map(|e| e.surface.as_str()).collect();
+        // Should contain all unique surfaces
+        assert!(surfaces.contains(&"今日"));
+        assert!(surfaces.contains(&"京"));
+        assert!(surfaces.contains(&"教"));
+        // "今日" should have the lower cost (2000 from layer_b)
+        let kyou = results.iter().find(|e| e.surface == "今日").unwrap();
+        assert_eq!(kyou.cost, 2000);
+        // No duplicates
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_lookup_empty_layers() {
+        let dict = CompositeDictionary::new(vec![]);
+        assert!(dict.lookup("きょう").is_empty());
+    }
+
+    #[test]
+    fn test_lookup_single_layer() {
+        let dict = CompositeDictionary::new(vec![layer_a()]);
+        let results = dict.lookup("きょう");
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_lookup_not_found() {
+        let dict = CompositeDictionary::new(vec![layer_a(), layer_b()]);
+        assert!(dict.lookup("そんざい").is_empty());
+    }
+
+    #[test]
+    fn test_predict_merges() {
+        let dict = CompositeDictionary::new(vec![layer_a(), layer_b()]);
+        let results = dict.predict("きょう", 100);
+        let readings: Vec<&str> = results.iter().map(|r| r.reading.as_str()).collect();
+        // Should have both "きょう" (merged) and "きょうと" (from layer_b)
+        assert!(readings.contains(&"きょう"));
+        assert!(readings.contains(&"きょうと"));
+        // "きょう" entries should be merged and deduplicated
+        let kyou = results.iter().find(|r| r.reading == "きょう").unwrap();
+        assert_eq!(kyou.entries.len(), 3); // 今日, 京, 教
+    }
+
+    #[test]
+    fn test_common_prefix_search_merges() {
+        let dict = CompositeDictionary::new(vec![layer_a(), layer_b()]);
+        let results = dict.common_prefix_search("きょうは");
+        let readings: Vec<&str> = results.iter().map(|r| r.reading.as_str()).collect();
+        // Common prefix search on "きょうは" should find "きょう" (3-char prefix)
+        assert!(readings.contains(&"きょう"));
+        // Entries for "きょう" should be merged from both layers
+        let kyou = results.iter().find(|r| r.reading == "きょう").unwrap();
+        assert_eq!(kyou.entries.len(), 3); // 今日, 京, 教
+    }
+
+    #[test]
+    fn test_predict_max_results() {
+        let dict = CompositeDictionary::new(vec![layer_a(), layer_b()]);
+        let results = dict.predict("きょう", 1);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_dedup_keeps_lowest_cost() {
+        let entries = vec![
+            DictEntry {
+                surface: "今日".to_string(),
+                cost: 5000,
+                left_id: 0,
+                right_id: 0,
+            },
+            DictEntry {
+                surface: "今日".to_string(),
+                cost: 2000,
+                left_id: 1,
+                right_id: 1,
+            },
+            DictEntry {
+                surface: "今日".to_string(),
+                cost: 3000,
+                left_id: 2,
+                right_id: 2,
+            },
+        ];
+        let deduped = dedup_entries(entries);
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].cost, 2000);
+    }
+}

--- a/engine/crates/lex-core/src/dict/mod.rs
+++ b/engine/crates/lex-core/src/dict/mod.rs
@@ -3,6 +3,7 @@
 //! `TrieDictionary` stores reading → entries mappings in a serialized trie.
 //! `ConnectionMatrix` stores POS bigram transition costs for Viterbi scoring.
 
+mod composite;
 pub mod connection;
 mod connection_io;
 mod entry;
@@ -10,6 +11,7 @@ mod entry;
 mod tests;
 mod trie_dict;
 
+pub use composite::CompositeDictionary;
 pub use entry::DictEntry;
 pub use trie_dict::TrieDictionary;
 

--- a/engine/crates/lex-session/src/lib.rs
+++ b/engine/crates/lex-session/src/lib.rs
@@ -20,7 +20,7 @@ mod tests;
 use std::sync::{Arc, RwLock};
 
 use lex_core::dict::connection::ConnectionMatrix;
-use lex_core::dict::TrieDictionary;
+use lex_core::dict::Dictionary;
 use lex_core::user_history::UserHistory;
 
 pub use types::{
@@ -32,7 +32,7 @@ use types::{Composition, GhostState, SessionConfig, SessionState, Submode};
 
 /// Stateful IME session encapsulating all input processing logic.
 pub struct InputSession {
-    dict: Arc<TrieDictionary>,
+    dict: Arc<dyn Dictionary>,
     conn: Option<Arc<ConnectionMatrix>>,
     history: Option<Arc<RwLock<UserHistory>>>,
 
@@ -54,7 +54,7 @@ pub struct InputSession {
 
 impl InputSession {
     pub fn new(
-        dict: Arc<TrieDictionary>,
+        dict: Arc<dyn Dictionary>,
         conn: Option<Arc<ConnectionMatrix>>,
         history: Option<Arc<RwLock<UserHistory>>>,
     ) -> Self {

--- a/engine/crates/lex-session/src/tests/candidates.rs
+++ b/engine/crates/lex-session/src/tests/candidates.rs
@@ -139,7 +139,7 @@ fn test_deferred_auto_commit_shows_provisional_candidates() {
 
     // Helper: complete one async candidate cycle.
     // Returns the response from receive_candidates (None if stale).
-    fn complete_cycle(session: &mut InputSession, dict: &TrieDictionary) -> Option<KeyResponse> {
+    fn complete_cycle(session: &mut InputSession, dict: &dyn Dictionary) -> Option<KeyResponse> {
         let reading = session.comp().kana.clone();
         if reading.is_empty() {
             return None;
@@ -151,17 +151,17 @@ fn test_deferred_auto_commit_shows_provisional_candidates() {
     // Build up "きょうはいいてんき" with async cycles after each romaji group.
     // Each cycle increments the stability counter (first segment = "きょう").
     type_string(&mut session, "kyou"); // "きょう"
-    let r = complete_cycle(&mut session, &dict);
+    let r = complete_cycle(&mut session, &*dict);
     assert!(r.is_some());
     assert!(r.unwrap().commit.is_none(), "no auto-commit yet");
 
     type_string(&mut session, "ha"); // "きょうは"
-    let r = complete_cycle(&mut session, &dict);
+    let r = complete_cycle(&mut session, &*dict);
     assert!(r.is_some());
     assert!(r.unwrap().commit.is_none(), "no auto-commit yet");
 
     type_string(&mut session, "ii"); // "きょうはいい"
-    let r = complete_cycle(&mut session, &dict);
+    let r = complete_cycle(&mut session, &*dict);
     assert!(r.is_some());
     assert!(
         r.unwrap().commit.is_none(),
@@ -169,7 +169,7 @@ fn test_deferred_auto_commit_shows_provisional_candidates() {
     );
 
     type_string(&mut session, "tenki"); // "きょうはいいてんき"
-    let r = complete_cycle(&mut session, &dict);
+    let r = complete_cycle(&mut session, &*dict);
     let resp = r.expect("receive_candidates should return a response");
 
     // Auto-commit should fire: first segment committed, remaining shown
@@ -209,7 +209,7 @@ fn test_predictive_mode_no_auto_commit() {
     session.set_conversion_mode(ConversionMode::Predictive);
     session.set_defer_candidates(true);
 
-    fn complete_cycle(session: &mut InputSession, dict: &TrieDictionary) -> Option<KeyResponse> {
+    fn complete_cycle(session: &mut InputSession, dict: &dyn Dictionary) -> Option<KeyResponse> {
         let reading = session.comp().kana.clone();
         if reading.is_empty() {
             return None;
@@ -220,13 +220,13 @@ fn test_predictive_mode_no_auto_commit() {
 
     // Build up enough input that would trigger auto-commit in Standard mode
     type_string(&mut session, "kyou");
-    complete_cycle(&mut session, &dict);
+    complete_cycle(&mut session, &*dict);
     type_string(&mut session, "ha");
-    complete_cycle(&mut session, &dict);
+    complete_cycle(&mut session, &*dict);
     type_string(&mut session, "ii");
-    complete_cycle(&mut session, &dict);
+    complete_cycle(&mut session, &*dict);
     type_string(&mut session, "tenki");
-    let r = complete_cycle(&mut session, &dict);
+    let r = complete_cycle(&mut session, &*dict);
 
     // In Predictive mode, auto-commit should NOT fire
     if let Some(resp) = r {

--- a/engine/crates/lex-session/src/tests/mod.rs
+++ b/engine/crates/lex-session/src/tests/mod.rs
@@ -9,13 +9,13 @@ mod submode;
 
 use std::sync::Arc;
 
-use lex_core::dict::{DictEntry, TrieDictionary};
+use lex_core::dict::{DictEntry, Dictionary, TrieDictionary};
 
 use super::types::key;
 use super::InputSession;
 use super::KeyResponse;
 
-pub(super) fn make_test_dict() -> Arc<TrieDictionary> {
+pub(super) fn make_test_dict() -> Arc<dyn Dictionary> {
     let entries = vec![
         (
             "きょう".to_string(),

--- a/engine/crates/lex-session/src/tests/proptest_fsm.rs
+++ b/engine/crates/lex-session/src/tests/proptest_fsm.rs
@@ -5,6 +5,8 @@
 
 use proptest::prelude::*;
 
+use lex_core::dict::Dictionary;
+
 use super::make_test_dict;
 use crate::types::key;
 use crate::{CandidateAction, ConversionMode, InputSession};
@@ -83,7 +85,7 @@ fn arb_action() -> impl Strategy<Value = Action> {
 fn execute_action(
     session: &mut InputSession,
     action: &Action,
-    dict: &lex_core::dict::TrieDictionary,
+    dict: &dyn Dictionary,
 ) -> Option<crate::KeyResponse> {
     match action {
         Action::TypeRomaji(ch) => {
@@ -252,7 +254,7 @@ proptest! {
         let mut session = InputSession::new(dict.clone(), None, None);
         for action in &actions {
             let was_composing = session.is_composing();
-            if let Some(resp) = execute_action(&mut session, action, &dict) {
+            if let Some(resp) = execute_action(&mut session, action, &*dict) {
                 assert_invariants(&session, &resp, action, was_composing);
             }
         }
@@ -267,7 +269,7 @@ proptest! {
         session.set_defer_candidates(true);
         for action in &actions {
             let was_composing = session.is_composing();
-            if let Some(resp) = execute_action(&mut session, action, &dict) {
+            if let Some(resp) = execute_action(&mut session, action, &*dict) {
                 assert_invariants(&session, &resp, action, was_composing);
             }
         }

--- a/engine/crates/lex-session/src/tests/simulator.rs
+++ b/engine/crates/lex-session/src/tests/simulator.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use lex_core::candidates::CandidateResponse;
 use lex_core::dict::connection::ConnectionMatrix;
-use lex_core::dict::TrieDictionary;
+use lex_core::dict::Dictionary;
 
 use super::type_string;
 use crate::types::MAX_CANDIDATES;
@@ -14,12 +14,12 @@ use crate::InputSession;
 /// and provides helpers that drive the full type → generate → receive → commit cycle.
 pub(super) struct HeadlessIME {
     pub session: InputSession,
-    dict: Arc<TrieDictionary>,
+    dict: Arc<dyn Dictionary>,
     conn: Option<Arc<ConnectionMatrix>>,
 }
 
 impl HeadlessIME {
-    pub fn new(dict: Arc<TrieDictionary>, conn: Option<Arc<ConnectionMatrix>>) -> Self {
+    pub fn new(dict: Arc<dyn Dictionary>, conn: Option<Arc<ConnectionMatrix>>) -> Self {
         let mut session = InputSession::new(dict.clone(), conn.clone(), None);
         session.set_defer_candidates(true);
         Self {

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -9,7 +9,7 @@ use super::LexError;
 
 #[derive(uniffi::Object)]
 pub struct LexDictionary {
-    pub(crate) inner: Arc<TrieDictionary>,
+    pub(crate) inner: Arc<dyn Dictionary>,
 }
 
 #[uniffi::export]

--- a/engine/src/async_worker.rs
+++ b/engine/src/async_worker.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::candidates::CandidateResponse;
 use crate::dict::connection::ConnectionMatrix;
-use crate::dict::TrieDictionary;
+use crate::dict::Dictionary;
 use crate::user_history::UserHistory;
 
 // ---------------------------------------------------------------------------
@@ -52,7 +52,7 @@ pub(crate) struct AsyncWorker {
 
 impl AsyncWorker {
     pub fn new(
-        dict: Arc<TrieDictionary>,
+        dict: Arc<dyn Dictionary>,
         conn: Option<Arc<ConnectionMatrix>>,
         history: Option<Arc<RwLock<UserHistory>>>,
         #[cfg(feature = "neural")] neural: Option<Arc<Mutex<crate::neural::NeuralScorer>>>,
@@ -163,7 +163,7 @@ fn candidate_worker(
     rx: mpsc::Receiver<CandidateWork>,
     tx: mpsc::Sender<CandidateResult>,
     gen: Arc<AtomicU64>,
-    dict: Arc<TrieDictionary>,
+    dict: Arc<dyn Dictionary>,
     conn: Option<Arc<ConnectionMatrix>>,
     history: Option<Arc<RwLock<UserHistory>>>,
     #[cfg(feature = "neural")] neural: Option<Arc<Mutex<crate::neural::NeuralScorer>>>,


### PR DESCRIPTION
## Summary
- Add `CompositeDictionary` that merges results from multiple `Arc<dyn Dictionary>` layers
  - `lookup`: merge + dedup by surface (lowest cost wins)
  - `predict` / `common_prefix_search`: merge + dedup by reading (entries merged within each reading)
  - `predict_ranked`: default impl works automatically
- Unify `Arc<TrieDictionary>` → `Arc<dyn Dictionary>` across:
  - `lex-session::InputSession`
  - `async_worker::AsyncWorker` + `candidate_worker`
  - `api/resources::LexDictionary`
  - All test files (simulator, candidates, proptest_fsm)
  - Benchmark

`LexDictionary::open` still creates a `TrieDictionary` — composing multiple dictionaries will be wired in a future FFI API.

Replaces #130 (auto-closed by stacked branch deletion).

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — 289 tests pass (8 new CompositeDictionary tests)
- [x] CompositeDictionary tests: 2-layer merge, dedup (lowest cost), predict merge, common_prefix_search merge, empty/single layer edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)