### PR TITLE
feat: externalize conversion constants to TOML settings

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -54,6 +54,20 @@ class AppContext {
             atPath: logDir, withIntermediateDirectories: true)
         traceInit(logDir: logDir)
 
+        // Load custom settings if present
+        let settingsPath = appSupport
+            .appendingPathComponent("Lexime/settings.toml").path
+        if FileManager.default.fileExists(atPath: settingsPath) {
+            do {
+                try settingsLoadConfig(path: settingsPath)
+                NSLog("Lexime: Custom settings loaded from %@", settingsPath)
+            } catch {
+                NSLog("Lexime: settings config error at %@: %@",
+                      settingsPath, "\(error)")
+                // Embedded defaults will be used
+            }
+        }
+
         // Load custom romaji config if present
         let romajiPath = appSupport
             .appendingPathComponent("Lexime/romaji.toml").path

--- a/engine/crates/lex-cli/src/bin/dictool.rs
+++ b/engine/crates/lex-cli/src/bin/dictool.rs
@@ -144,6 +144,13 @@ enum Command {
         /// Path to the TOML file
         file: String,
     },
+    /// Export default settings as TOML
+    SettingsExport,
+    /// Validate a custom settings TOML file
+    SettingsValidate {
+        /// Path to the TOML file
+        file: String,
+    },
     /// Manage user dictionary
     UserDict {
         /// User dictionary file (default: ~/Library/Application Support/Lexime/user_dict.lxuw)
@@ -307,6 +314,10 @@ fn main() {
             print!("{}", lex_core::romaji::default_toml());
         }
         Command::RomajiValidate { file } => romaji_validate(&file),
+        Command::SettingsExport => {
+            print!("{}", lex_core::settings::default_toml());
+        }
+        Command::SettingsValidate { file } => settings_validate(&file),
         #[cfg(feature = "neural")]
         Command::NeuralScore {
             dict_file,
@@ -881,6 +892,18 @@ fn romaji_validate(file: &str) {
     let content = die!(fs::read_to_string(file), "Error reading {file}: {}");
     let map = die!(lex_core::romaji::parse_romaji_toml(&content), "Error: {}");
     println!("OK: {} mappings", map.len());
+}
+
+fn settings_validate(file: &str) {
+    let content = die!(fs::read_to_string(file), "Error reading {file}: {}");
+    let s = die!(
+        lex_core::settings::parse_settings_toml(&content),
+        "Error: {}"
+    );
+    println!(
+        "OK: cost.segment_penalty={}, candidates.nbest={}, candidates.max_results={}",
+        s.cost.segment_penalty, s.candidates.nbest, s.candidates.max_results
+    );
 }
 
 #[cfg(feature = "neural")]

--- a/engine/crates/lex-core/src/candidates/standard.rs
+++ b/engine/crates/lex-core/src/candidates/standard.rs
@@ -5,6 +5,7 @@ use tracing::{debug, debug_span};
 use crate::converter::{convert_nbest, convert_nbest_with_history};
 use crate::dict::connection::ConnectionMatrix;
 use crate::dict::Dictionary;
+use crate::settings::settings;
 use crate::user_history::UserHistory;
 
 use super::{generate_punctuation_candidates, punctuation_alternatives, CandidateResponse};
@@ -24,7 +25,7 @@ pub(super) fn generate_normal_candidates(
     //    history_rerank is applied post-Viterbi on N-best paths (not during
     //    lattice search), so it cannot cause fragmentation. Time-decayed
     //    boosts (half-life 168h) prevent stale history from dominating.
-    let nbest = 5usize;
+    let nbest = settings().candidates.nbest;
     let paths = if let Some(h) = history {
         convert_nbest_with_history(dict, conn, h, reading, nbest)
     } else {

--- a/engine/crates/lex-core/src/converter/explain.rs
+++ b/engine/crates/lex-core/src/converter/explain.rs
@@ -4,7 +4,9 @@ use crate::dict::connection::ConnectionMatrix;
 use crate::dict::Dictionary;
 use crate::user_history::UserHistory;
 
-use super::cost::{conn_cost, script_cost, DefaultCostFunction, SEGMENT_PENALTY};
+use crate::settings::settings;
+
+use super::cost::{conn_cost, script_cost, DefaultCostFunction};
 use super::lattice::{build_lattice, LatticeNode};
 use super::reranker;
 use super::viterbi::{viterbi_nbest, ScoredPath};
@@ -105,7 +107,7 @@ fn explain_segments(scored: &ScoredPath, conn: Option<&ConnectionMatrix>) -> Vec
                 reading: seg.reading.clone(),
                 surface: seg.surface.clone(),
                 word_cost: seg.word_cost as i64,
-                segment_penalty: SEGMENT_PENALTY,
+                segment_penalty: settings().cost.segment_penalty,
                 script_cost: script_cost(&seg.surface),
                 connection_cost: connection,
                 left_id: seg.left_id,
@@ -350,7 +352,7 @@ mod tests {
 
         for path in &result.paths {
             for seg in &path.segments {
-                assert_eq!(seg.segment_penalty, SEGMENT_PENALTY);
+                assert_eq!(seg.segment_penalty, settings().cost.segment_penalty);
             }
         }
     }

--- a/engine/crates/lex-core/src/converter/lattice.rs
+++ b/engine/crates/lex-core/src/converter/lattice.rs
@@ -1,6 +1,7 @@
 use tracing::{debug, debug_span};
 
 use crate::dict::Dictionary;
+use crate::settings::settings;
 
 /// A node in the conversion lattice.
 ///
@@ -39,8 +40,6 @@ pub struct Lattice {
     /// Number of characters in input
     pub char_count: usize,
 }
-
-const UNKNOWN_WORD_COST: i16 = 10000;
 
 /// Build a lattice from a kana string using dictionary lookups.
 ///
@@ -99,7 +98,7 @@ pub fn build_lattice(dict: &dyn Dictionary, kana: &str) -> Lattice {
                 end: start + 1,
                 reading: ch.clone(),
                 surface: ch,
-                cost: UNKNOWN_WORD_COST,
+                cost: settings().cost.unknown_word_cost,
                 left_id: 0,
                 right_id: 0,
             });

--- a/engine/crates/lex-core/src/default_settings.toml
+++ b/engine/crates/lex-core/src/default_settings.toml
@@ -1,0 +1,22 @@
+[cost]
+segment_penalty = 5000
+mixed_script_bonus = 3000
+katakana_penalty = 5000
+pure_kanji_bonus = 1000
+latin_penalty = 20000
+unknown_word_cost = 10000
+
+[reranker]
+length_variance_weight = 2000
+structure_cost_filter = 4000
+
+[history]
+boost_per_use = 3000
+max_boost = 15000
+half_life_hours = 168.0
+max_unigrams = 10000
+max_bigrams = 10000
+
+[candidates]
+nbest = 5
+max_results = 20

--- a/engine/crates/lex-core/src/lib.rs
+++ b/engine/crates/lex-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod dict;
 #[cfg(feature = "neural")]
 pub mod neural;
 pub mod romaji;
+pub mod settings;
 pub mod unicode;
 pub mod user_dict;
 pub mod user_history;

--- a/engine/crates/lex-core/src/settings.rs
+++ b/engine/crates/lex-core/src/settings.rs
@@ -1,0 +1,312 @@
+//! Global settings loaded from TOML, following the same OnceLock pattern as romaji config.
+//!
+//! - `init_custom(toml_content)` sets a custom TOML before first `settings()` call
+//! - `settings()` returns `&'static Settings` (lazy-init singleton)
+//! - Default values are embedded via `include_str!("default_settings.toml")`
+
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+pub const DEFAULT_SETTINGS_TOML: &str = include_str!("default_settings.toml");
+
+static CUSTOM_TOML: OnceLock<String> = OnceLock::new();
+
+/// Set custom TOML before first `settings()` call.
+pub fn init_custom(toml_content: String) -> Result<(), SettingsError> {
+    parse_settings_toml(&toml_content)?;
+    CUSTOM_TOML
+        .set(toml_content)
+        .map_err(|_| SettingsError::AlreadyInitialized)
+}
+
+/// Get or initialize the global settings singleton.
+pub fn settings() -> &'static Settings {
+    static INSTANCE: OnceLock<Settings> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let toml_str = CUSTOM_TOML
+            .get()
+            .map(|s| s.as_str())
+            .unwrap_or(DEFAULT_SETTINGS_TOML);
+        parse_settings_toml(toml_str).expect("settings TOML must be valid")
+    })
+}
+
+/// Returns the embedded default settings TOML content.
+pub fn default_toml() -> &'static str {
+    DEFAULT_SETTINGS_TOML
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SettingsError {
+    #[error("TOML parse error: {0}")]
+    Parse(String),
+    #[error("invalid value for {field}: {reason}")]
+    InvalidValue { field: String, reason: String },
+    #[error("settings already initialized")]
+    AlreadyInitialized,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Settings {
+    pub cost: CostSettings,
+    pub reranker: RerankerSettings,
+    pub history: HistorySettings,
+    pub candidates: CandidateSettings,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CostSettings {
+    pub segment_penalty: i64,
+    pub mixed_script_bonus: i64,
+    pub katakana_penalty: i64,
+    pub pure_kanji_bonus: i64,
+    pub latin_penalty: i64,
+    pub unknown_word_cost: i16,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RerankerSettings {
+    pub length_variance_weight: i64,
+    pub structure_cost_filter: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HistorySettings {
+    pub boost_per_use: i64,
+    pub max_boost: i64,
+    pub half_life_hours: f64,
+    pub max_unigrams: usize,
+    pub max_bigrams: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CandidateSettings {
+    pub nbest: usize,
+    pub max_results: usize,
+}
+
+pub fn parse_settings_toml(toml_str: &str) -> Result<Settings, SettingsError> {
+    let s: Settings = toml::from_str(toml_str).map_err(|e| SettingsError::Parse(e.to_string()))?;
+    validate(&s)?;
+    Ok(s)
+}
+
+fn validate(s: &Settings) -> Result<(), SettingsError> {
+    macro_rules! check_non_negative {
+        ($section:ident . $field:ident) => {
+            if s.$section.$field < 0 {
+                return Err(SettingsError::InvalidValue {
+                    field: concat!(stringify!($section), ".", stringify!($field)).to_string(),
+                    reason: "must be non-negative".to_string(),
+                });
+            }
+        };
+    }
+    macro_rules! check_positive_usize {
+        ($section:ident . $field:ident) => {
+            if s.$section.$field == 0 {
+                return Err(SettingsError::InvalidValue {
+                    field: concat!(stringify!($section), ".", stringify!($field)).to_string(),
+                    reason: "must be positive".to_string(),
+                });
+            }
+        };
+    }
+
+    check_non_negative!(cost.segment_penalty);
+    check_non_negative!(cost.mixed_script_bonus);
+    check_non_negative!(cost.katakana_penalty);
+    check_non_negative!(cost.pure_kanji_bonus);
+    check_non_negative!(cost.latin_penalty);
+    check_non_negative!(cost.unknown_word_cost);
+
+    check_non_negative!(reranker.length_variance_weight);
+    check_non_negative!(reranker.structure_cost_filter);
+
+    check_non_negative!(history.boost_per_use);
+    check_non_negative!(history.max_boost);
+    check_positive_usize!(history.max_unigrams);
+    check_positive_usize!(history.max_bigrams);
+    if s.history.half_life_hours <= 0.0 {
+        return Err(SettingsError::InvalidValue {
+            field: "history.half_life_hours".to_string(),
+            reason: "must be positive".to_string(),
+        });
+    }
+
+    check_positive_usize!(candidates.nbest);
+    check_positive_usize!(candidates.max_results);
+
+    // i16 range check for unknown_word_cost is enforced by the type itself
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_toml() {
+        let s = parse_settings_toml(DEFAULT_SETTINGS_TOML).unwrap();
+        assert_eq!(s.cost.segment_penalty, 5000);
+        assert_eq!(s.cost.mixed_script_bonus, 3000);
+        assert_eq!(s.cost.katakana_penalty, 5000);
+        assert_eq!(s.cost.pure_kanji_bonus, 1000);
+        assert_eq!(s.cost.latin_penalty, 20000);
+        assert_eq!(s.cost.unknown_word_cost, 10000);
+        assert_eq!(s.reranker.length_variance_weight, 2000);
+        assert_eq!(s.reranker.structure_cost_filter, 4000);
+        assert_eq!(s.history.boost_per_use, 3000);
+        assert_eq!(s.history.max_boost, 15000);
+        assert!((s.history.half_life_hours - 168.0).abs() < f64::EPSILON);
+        assert_eq!(s.history.max_unigrams, 10000);
+        assert_eq!(s.history.max_bigrams, 10000);
+        assert_eq!(s.candidates.nbest, 5);
+        assert_eq!(s.candidates.max_results, 20);
+    }
+
+    #[test]
+    fn parse_valid_custom_toml() {
+        let toml = r#"
+[cost]
+segment_penalty = 1000
+mixed_script_bonus = 500
+katakana_penalty = 2000
+pure_kanji_bonus = 200
+latin_penalty = 10000
+unknown_word_cost = 5000
+
+[reranker]
+length_variance_weight = 1000
+structure_cost_filter = 2000
+
+[history]
+boost_per_use = 1500
+max_boost = 8000
+half_life_hours = 72.0
+max_unigrams = 5000
+max_bigrams = 5000
+
+[candidates]
+nbest = 10
+max_results = 30
+"#;
+        let s = parse_settings_toml(toml).unwrap();
+        assert_eq!(s.cost.segment_penalty, 1000);
+        assert_eq!(s.candidates.nbest, 10);
+    }
+
+    #[test]
+    fn error_negative_penalty() {
+        let toml = r#"
+[cost]
+segment_penalty = -1
+mixed_script_bonus = 3000
+katakana_penalty = 5000
+pure_kanji_bonus = 1000
+latin_penalty = 20000
+unknown_word_cost = 10000
+
+[reranker]
+length_variance_weight = 2000
+structure_cost_filter = 4000
+
+[history]
+boost_per_use = 3000
+max_boost = 15000
+half_life_hours = 168.0
+max_unigrams = 10000
+max_bigrams = 10000
+
+[candidates]
+nbest = 5
+max_results = 20
+"#;
+        let err = parse_settings_toml(toml).unwrap_err();
+        assert!(matches!(err, SettingsError::InvalidValue { .. }));
+        assert!(err.to_string().contains("cost.segment_penalty"));
+    }
+
+    #[test]
+    fn error_zero_half_life() {
+        let toml = r#"
+[cost]
+segment_penalty = 5000
+mixed_script_bonus = 3000
+katakana_penalty = 5000
+pure_kanji_bonus = 1000
+latin_penalty = 20000
+unknown_word_cost = 10000
+
+[reranker]
+length_variance_weight = 2000
+structure_cost_filter = 4000
+
+[history]
+boost_per_use = 3000
+max_boost = 15000
+half_life_hours = 0.0
+max_unigrams = 10000
+max_bigrams = 10000
+
+[candidates]
+nbest = 5
+max_results = 20
+"#;
+        let err = parse_settings_toml(toml).unwrap_err();
+        assert!(err.to_string().contains("half_life_hours"));
+    }
+
+    #[test]
+    fn error_zero_nbest() {
+        let toml = r#"
+[cost]
+segment_penalty = 5000
+mixed_script_bonus = 3000
+katakana_penalty = 5000
+pure_kanji_bonus = 1000
+latin_penalty = 20000
+unknown_word_cost = 10000
+
+[reranker]
+length_variance_weight = 2000
+structure_cost_filter = 4000
+
+[history]
+boost_per_use = 3000
+max_boost = 15000
+half_life_hours = 168.0
+max_unigrams = 10000
+max_bigrams = 10000
+
+[candidates]
+nbest = 0
+max_results = 20
+"#;
+        let err = parse_settings_toml(toml).unwrap_err();
+        assert!(err.to_string().contains("candidates.nbest"));
+    }
+
+    #[test]
+    fn error_invalid_toml() {
+        let err = parse_settings_toml("not valid toml {{{").unwrap_err();
+        assert!(matches!(err, SettingsError::Parse(_)));
+    }
+
+    #[test]
+    fn error_missing_section() {
+        let toml = r#"
+[cost]
+segment_penalty = 5000
+mixed_script_bonus = 3000
+katakana_penalty = 5000
+pure_kanji_bonus = 1000
+latin_penalty = 20000
+unknown_word_cost = 10000
+"#;
+        let err = parse_settings_toml(toml).unwrap_err();
+        assert!(matches!(err, SettingsError::Parse(_)));
+    }
+}

--- a/engine/crates/lex-core/src/user_history/tests.rs
+++ b/engine/crates/lex-core/src/user_history/tests.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::Path;
 
+use crate::settings::settings;
+
 use super::*;
 
 #[test]
@@ -61,13 +63,14 @@ fn test_open_nonexistent() {
 
 #[test]
 fn test_evict() {
+    let max_unigrams = settings().history.max_unigrams;
     let mut h = UserHistory::new();
-    // Insert MAX_UNIGRAMS + 1 entries
-    for i in 0..=MAX_UNIGRAMS {
+    // Insert max_unigrams + 1 entries
+    for i in 0..=max_unigrams {
         h.record(&[(format!("r{i}"), format!("s{i}"))]);
     }
     let count: usize = h.unigrams.values().map(|inner| inner.len()).sum();
-    assert!(count <= MAX_UNIGRAMS);
+    assert!(count <= max_unigrams);
 }
 
 #[test]

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -115,6 +115,16 @@ fn romaji_load_config(path: String) -> Result<(), LexError> {
 }
 
 #[uniffi::export]
+fn settings_load_config(path: String) -> Result<(), LexError> {
+    let content = std::fs::read_to_string(&path).map_err(|e| LexError::Io {
+        msg: format!("{path}: {e}"),
+    })?;
+    crate::settings::init_custom(content)
+        .map_err(|e| LexError::InvalidData { msg: e.to_string() })?;
+    Ok(())
+}
+
+#[uniffi::export]
 fn trace_init(log_dir: String) {
     crate::trace_init::init_tracing(Path::new(&log_dir));
 }

--- a/engine/src/async_worker.rs
+++ b/engine/src/async_worker.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use crate::candidates::CandidateResponse;
 use crate::dict::connection::ConnectionMatrix;
 use crate::dict::Dictionary;
+use crate::settings::settings;
 use crate::user_history::UserHistory;
 
 // ---------------------------------------------------------------------------
@@ -184,6 +185,7 @@ fn candidate_worker(
         let hist_ref = h_guard.as_deref();
         let conn_ref = conn.as_deref();
 
+        let max_results = settings().candidates.max_results;
         let response = match latest.dispatch {
             #[cfg(feature = "neural")]
             2 => {
@@ -196,7 +198,7 @@ fn candidate_worker(
                             hist_ref,
                             &latest.context,
                             &latest.reading,
-                            20,
+                            max_results,
                         )
                     } else {
                         crate::candidates::generate_candidates(
@@ -204,7 +206,7 @@ fn candidate_worker(
                             conn_ref,
                             hist_ref,
                             &latest.reading,
-                            20,
+                            max_results,
                         )
                     }
                 } else {
@@ -213,7 +215,7 @@ fn candidate_worker(
                         conn_ref,
                         hist_ref,
                         &latest.reading,
-                        20,
+                        max_results,
                     )
                 }
             }
@@ -223,21 +225,21 @@ fn candidate_worker(
                 conn_ref,
                 hist_ref,
                 &latest.reading,
-                20,
+                max_results,
             ),
             1 => crate::candidates::generate_prediction_candidates(
                 &*dict,
                 conn_ref,
                 hist_ref,
                 &latest.reading,
-                20,
+                max_results,
             ),
             _ => crate::candidates::generate_candidates(
                 &*dict,
                 conn_ref,
                 hist_ref,
                 &latest.reading,
-                20,
+                max_results,
             ),
         };
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -5,6 +5,7 @@ pub use lex_core::dict;
 #[cfg(feature = "neural")]
 pub use lex_core::neural;
 pub use lex_core::romaji;
+pub use lex_core::settings;
 pub use lex_core::unicode;
 pub use lex_core::user_dict;
 pub use lex_core::user_history;

--- a/mise.toml
+++ b/mise.toml
@@ -275,6 +275,10 @@ cd engine && cargo run -p lex-cli --features neural --bin dictool -- neural-scor
 description = "Export default romaji mappings to TOML"
 run = "cd engine && cargo run -p lex-cli --bin dictool -- romaji-export"
 
+[tasks.settings-export]
+description = "Export default settings to TOML"
+run = "cd engine && cargo run -p lex-cli --bin dictool -- settings-export"
+
 [tasks.bench]
 description = "Run criterion benchmarks"
 run = "cd engine && cargo bench -p lex-core"


### PR DESCRIPTION
## Summary
- ハードコードされた Viterbi コスト・リランカー・履歴・候補生成の定数を TOML 外部化（Proposal K）
- romaji TOML 外部化 (PR #125–#126) と同じ OnceLock パターンを踏襲
- `~/Library/Application Support/Lexime/settings.toml` を編集して `mise run reload` だけで反映可能

## Changes
- **`settings.rs`** (~150行): `Settings` struct + OnceLock singleton + parse/validate + 7 tests
- **`default_settings.toml`**: 4 セクション (`[cost]`, `[reranker]`, `[history]`, `[candidates]`)
- **定数差し替え**: `cost.rs`, `reranker.rs`, `lattice.rs`, `user_history/mod.rs`, `standard.rs`, `async_worker.rs`
- **FFI**: `settings_load_config` UniFFI export
- **Swift**: `AppContext.swift` で settings.toml → romaji.toml の順にロード
- **CLI**: `dictool settings-export` / `settings-validate` サブコマンド
- **mise**: `settings-export` タスク追加

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — 280 tests pass
- [x] `mise run build && mise run install && mise run reload` — 正常起動
- [x] `mise run settings-export` — デフォルト TOML 出力確認
- [x] `dictool settings-validate` — バリデーション動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)