### PR TITLE
feat: zero-copy trie via mmap (LXDX v3)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "lexime-trie"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e45689eeee370d0325077fd078c2a254e340953c808e8e5d9167167383e5c"
+checksum = "e5708e6e116e0cb4c679c3718d548a99ee4b09e4aa48fe0df8c3a31862775829"
 
 [[package]]
 name = "libc"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -13,7 +13,7 @@ neural = ["candle-core", "candle-nn", "dep:anyhow"]
 
 [dependencies]
 tracing = { workspace = true }
-lexime-trie = "0.1"
+lexime-trie = "0.2"
 serde = { workspace = true }
 bincode = "1"
 thiserror = { workspace = true }

--- a/engine/crates/lex-core/src/dict/mod.rs
+++ b/engine/crates/lex-core/src/dict/mod.rs
@@ -52,6 +52,7 @@ impl From<lexime_trie::TrieError> for DictError {
             lexime_trie::TrieError::InvalidMagic => DictError::InvalidMagic,
             lexime_trie::TrieError::InvalidVersion => DictError::UnsupportedVersion(0),
             lexime_trie::TrieError::TruncatedData => DictError::InvalidHeader,
+            lexime_trie::TrieError::MisalignedData => DictError::Parse("misaligned data".into()),
         }
     }
 }

--- a/engine/crates/lex-core/src/dict/tests/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/tests/trie_dict.rs
@@ -227,6 +227,28 @@ fn test_predict_ranked_no_match() {
     assert!(results.is_empty());
 }
 
+#[test]
+fn test_open_mmap() {
+    let dict = sample_dict();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.dict");
+    dict.save(&path).unwrap();
+
+    let dict2 = TrieDictionary::open(&path).unwrap();
+    let r1 = dict.lookup("かんじ");
+    let r2 = dict2.lookup("かんじ");
+    assert_eq!(r1.len(), r2.len());
+    for (a, b) in r1.iter().zip(r2.iter()) {
+        assert_eq!(a.surface, b.surface);
+        assert_eq!(a.cost, b.cost);
+    }
+
+    // Verify predictive search also works with mmap-backed trie
+    let p1 = dict.predict("かん", 100);
+    let p2 = dict2.predict("かん", 100);
+    assert_eq!(p1.len(), p2.len());
+}
+
 // --- Integration tests (require compiled Mozc dictionary) ---
 
 #[test]

--- a/engine/crates/lex-core/src/dict/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict.rs
@@ -1,17 +1,54 @@
 use std::fs::{self, File};
 use std::path::Path;
 
-use lexime_trie::DoubleArray;
+use lexime_trie::{DoubleArray, DoubleArrayRef, PrefixMatch, SearchMatch};
 use memmap2::Mmap;
 
 use super::{DictEntry, DictError, Dictionary, SearchResult};
 
 const MAGIC: &[u8; 4] = b"LXDX";
-const VERSION: u8 = 2;
-const HEADER_SIZE: usize = 4 + 1 + 4 + 4; // magic + version + trie_len + values_len = 13
+const VERSION: u8 = 3;
+const HEADER_SIZE: usize = 4 + 1 + 3 + 4 + 4; // magic + version + reserved(3) + trie_len + values_len = 16
+
+enum TrieStore {
+    Owned(DoubleArray<u8>),
+    MmapRef {
+        _mmap: Mmap,
+        trie: DoubleArrayRef<'static, u8>,
+    },
+}
+
+impl TrieStore {
+    fn exact_match(&self, key: &[u8]) -> Option<u32> {
+        match self {
+            Self::Owned(da) => da.exact_match(key),
+            Self::MmapRef { trie, .. } => trie.exact_match(key),
+        }
+    }
+
+    fn common_prefix_search<'a>(
+        &'a self,
+        query: &'a [u8],
+    ) -> Box<dyn Iterator<Item = PrefixMatch> + 'a> {
+        match self {
+            Self::Owned(da) => Box::new(da.common_prefix_search(query)),
+            Self::MmapRef { trie, .. } => Box::new(trie.common_prefix_search(query)),
+        }
+    }
+
+    fn predictive_search<'a>(
+        &'a self,
+        prefix: &'a [u8],
+    ) -> Box<dyn Iterator<Item = SearchMatch<u8>> + 'a> {
+        match self {
+            Self::Owned(da) => Box::new(da.predictive_search(prefix)),
+            Self::MmapRef { trie, .. } => Box::new(trie.predictive_search(prefix)),
+        }
+    }
+}
 
 pub struct TrieDictionary {
-    trie: DoubleArray<u8>,
+    trie: TrieStore,
     values: Vec<Vec<DictEntry>>,
 }
 
@@ -27,11 +64,21 @@ impl TrieDictionary {
         let trie = DoubleArray::<u8>::build(&keys);
         let values: Vec<Vec<DictEntry>> = pairs.into_iter().map(|(_, v)| v).collect();
 
-        Self { trie, values }
+        Self {
+            trie: TrieStore::Owned(trie),
+            values,
+        }
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, DictError> {
-        let trie_data = self.trie.as_bytes();
+        let trie_data = match &self.trie {
+            TrieStore::Owned(da) => da.as_bytes(),
+            TrieStore::MmapRef { .. } => {
+                return Err(DictError::Parse(
+                    "cannot serialize mmap-backed dictionary".into(),
+                ));
+            }
+        };
         let values_data = bincode::serialize(&self.values).map_err(DictError::Serialize)?;
 
         let trie_len: u32 = trie_data
@@ -46,6 +93,7 @@ impl TrieDictionary {
         let mut buf = Vec::with_capacity(HEADER_SIZE + trie_data.len() + values_data.len());
         buf.extend_from_slice(MAGIC);
         buf.push(VERSION);
+        buf.extend_from_slice(&[0u8; 3]); // reserved padding
         buf.extend_from_slice(&trie_len.to_le_bytes());
         buf.extend_from_slice(&values_len.to_le_bytes());
         buf.extend_from_slice(&trie_data);
@@ -68,8 +116,8 @@ impl TrieDictionary {
             return Err(DictError::InvalidHeader);
         }
 
-        let trie_len = u32::from_le_bytes(data[5..9].try_into().unwrap()) as usize;
-        let values_len = u32::from_le_bytes(data[9..13].try_into().unwrap()) as usize;
+        let trie_len = u32::from_le_bytes(data[8..12].try_into().unwrap()) as usize;
+        let values_len = u32::from_le_bytes(data[12..16].try_into().unwrap()) as usize;
 
         let expected = HEADER_SIZE + trie_len + values_len;
         if data.len() < expected {
@@ -84,19 +132,67 @@ impl TrieDictionary {
             bincode::deserialize(&data[values_start..values_start + values_len])
                 .map_err(DictError::Deserialize)?;
 
-        Ok(Self { trie, values })
+        Ok(Self {
+            trie: TrieStore::Owned(trie),
+            values,
+        })
     }
 
-    /// Open a dictionary file, using mmap to avoid doubling peak memory.
+    /// Open a dictionary file, using mmap for zero-copy trie access.
     ///
-    /// The trie is deserialized from the mapped region (avoiding a separate
-    /// heap allocation for the raw file bytes), then the mapping is dropped.
+    /// The trie data is referenced directly from the memory-mapped region
+    /// via `DoubleArrayRef`, eliminating ~70MB of heap allocation for the
+    /// trie nodes/siblings arrays. The values (strings) are still
+    /// deserialized onto the heap.
     pub fn open(path: &Path) -> Result<Self, DictError> {
         let file = File::open(path)?;
         // SAFETY: The file is opened read-only and the mapping is immutable.
-        // The Mmap is dropped after deserialization completes below.
         let mmap = unsafe { Mmap::map(&file)? };
-        Self::from_bytes(&mmap)
+
+        if mmap.len() < 5 {
+            return Err(DictError::InvalidHeader);
+        }
+        if &mmap[..4] != MAGIC {
+            return Err(DictError::InvalidMagic);
+        }
+        if mmap[4] != VERSION {
+            return Err(DictError::UnsupportedVersion(mmap[4]));
+        }
+        if mmap.len() < HEADER_SIZE {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_len = u32::from_le_bytes(mmap[8..12].try_into().unwrap()) as usize;
+        let values_len = u32::from_le_bytes(mmap[12..16].try_into().unwrap()) as usize;
+
+        let expected = HEADER_SIZE + trie_len + values_len;
+        if mmap.len() < expected {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_start = HEADER_SIZE;
+        let values_start = trie_start + trie_len;
+
+        // Zero-copy trie from mmap
+        let trie_ref =
+            DoubleArrayRef::<u8>::from_bytes_ref(&mmap[trie_start..trie_start + trie_len])?;
+        // SAFETY: The mmap is stored in TrieStore::MmapRef._mmap and will be dropped
+        // after the trie reference (Rust drops fields in declaration order).
+        let trie_ref = unsafe {
+            std::mem::transmute::<DoubleArrayRef<'_, u8>, DoubleArrayRef<'static, u8>>(trie_ref)
+        };
+
+        let values: Vec<Vec<DictEntry>> =
+            bincode::deserialize(&mmap[values_start..values_start + values_len])
+                .map_err(DictError::Deserialize)?;
+
+        Ok(Self {
+            trie: TrieStore::MmapRef {
+                _mmap: mmap,
+                trie: trie_ref,
+            },
+            values,
+        })
     }
 
     pub fn save(&self, path: &Path) -> Result<(), DictError> {


### PR DESCRIPTION
## Summary
- Upgrade lexime-trie 0.1 → 0.2 for `DoubleArrayRef` zero-copy support
- `TrieDictionary::open()` now holds the mmap and borrows trie nodes/siblings directly, eliminating ~70MB heap allocation
- LXDX v3 header (16B with 3B reserved padding) ensures 4-byte alignment for the LXTR section
- `TrieStore` enum dispatches between `Owned` (compile/test) and `MmapRef` (production) paths

## Test plan
- [x] All 313 existing tests pass (cargo test --workspace --all-features)
- [x] New `test_open_mmap` verifies save→open round-trip with mmap-backed trie
- [x] `mise run dict-clean && mise run dict` to rebuild dictionary in v3 format
- [x] `mise run build && mise run install && mise run reload` for E2E verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)