### PR TITLE
feat: flat binary values format for zero-copy mmap (LXDX v4)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "lexime-trie"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5708e6e116e0cb4c679c3718d548a99ee4b09e4aa48fe0df8c3a31862775829"
+checksum = "0aca197ce858a2d5ef89e8a8da9f41ab61df8301616d7f96ca1ae99d35250b96"
 
 [[package]]
 name = "libc"

--- a/engine/crates/lex-core/src/dict/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::Path;
 
@@ -7,15 +8,15 @@ use memmap2::Mmap;
 use super::{DictEntry, DictError, Dictionary, SearchResult};
 
 const MAGIC: &[u8; 4] = b"LXDX";
-const VERSION: u8 = 3;
-const HEADER_SIZE: usize = 4 + 1 + 3 + 4 + 4; // magic + version + reserved(3) + trie_len + values_len = 16
+const VERSION: u8 = 4;
+// magic(4) + version(1) + reserved(3) + trie_len(4) + pool_len(4) + entries_len(4) + reading_count(4) = 24
+const HEADER_SIZE: usize = 24;
+const ENTRY_SIZE: usize = 12; // str_offset(4) + str_len(2) + cost(2) + left_id(2) + right_id(2)
+const SLOT_SIZE: usize = 6; // entry_offset(4) + count(2)
 
 enum TrieStore {
     Owned(DoubleArray<u8>),
-    MmapRef {
-        _mmap: Mmap,
-        trie: DoubleArrayRef<'static, u8>,
-    },
+    MmapRef(DoubleArrayRef<'static, u8>),
 }
 
 /// Dispatch a method call on the inner trie, avoiding `Box<dyn Iterator>`.
@@ -27,14 +28,99 @@ macro_rules! with_trie {
     ($self:expr, |$t:ident| $body:expr) => {
         match &$self.trie {
             TrieStore::Owned($t) => $body,
-            TrieStore::MmapRef { trie: $t, .. } => $body,
+            TrieStore::MmapRef($t) => $body,
         }
     };
 }
 
+enum ValuesStore {
+    Owned {
+        string_pool: Vec<u8>,
+        entries_data: Vec<u8>,
+        reading_index: Vec<u8>,
+    },
+    MmapRef {
+        string_pool: &'static [u8],
+        entries_data: &'static [u8],
+        reading_index: &'static [u8],
+    },
+}
+
+impl ValuesStore {
+    fn string_pool(&self) -> &[u8] {
+        match self {
+            ValuesStore::Owned { string_pool, .. } => string_pool,
+            ValuesStore::MmapRef { string_pool, .. } => string_pool,
+        }
+    }
+
+    fn entries_data(&self) -> &[u8] {
+        match self {
+            ValuesStore::Owned { entries_data, .. } => entries_data,
+            ValuesStore::MmapRef { entries_data, .. } => entries_data,
+        }
+    }
+
+    fn reading_index(&self) -> &[u8] {
+        match self {
+            ValuesStore::Owned { reading_index, .. } => reading_index,
+            ValuesStore::MmapRef { reading_index, .. } => reading_index,
+        }
+    }
+
+    fn reading_count(&self) -> usize {
+        self.reading_index().len() / SLOT_SIZE
+    }
+
+    fn get_entries(&self, value_id: usize) -> Vec<DictEntry> {
+        let idx = self.reading_index();
+        let slot_start = value_id * SLOT_SIZE;
+        if slot_start + SLOT_SIZE > idx.len() {
+            return Vec::new();
+        }
+
+        let entry_offset =
+            u32::from_le_bytes(idx[slot_start..slot_start + 4].try_into().unwrap()) as usize;
+        let count =
+            u16::from_le_bytes(idx[slot_start + 4..slot_start + 6].try_into().unwrap()) as usize;
+
+        let data = self.entries_data();
+        let pool = self.string_pool();
+        let mut entries = Vec::with_capacity(count);
+
+        for i in 0..count {
+            let off = (entry_offset + i) * ENTRY_SIZE;
+            if off + ENTRY_SIZE > data.len() {
+                break;
+            }
+            let str_offset = u32::from_le_bytes(data[off..off + 4].try_into().unwrap()) as usize;
+            let str_len = u16::from_le_bytes(data[off + 4..off + 6].try_into().unwrap()) as usize;
+            let cost = i16::from_le_bytes(data[off + 6..off + 8].try_into().unwrap());
+            let left_id = u16::from_le_bytes(data[off + 8..off + 10].try_into().unwrap());
+            let right_id = u16::from_le_bytes(data[off + 10..off + 12].try_into().unwrap());
+
+            let surface = if str_offset + str_len <= pool.len() {
+                String::from_utf8_lossy(&pool[str_offset..str_offset + str_len]).into_owned()
+            } else {
+                String::new()
+            };
+
+            entries.push(DictEntry {
+                surface,
+                cost,
+                left_id,
+                right_id,
+            });
+        }
+
+        entries
+    }
+}
+
 pub struct TrieDictionary {
     trie: TrieStore,
-    values: Vec<Vec<DictEntry>>,
+    values: ValuesStore,
+    _mmap: Option<Mmap>,
 }
 
 impl TrieDictionary {
@@ -47,42 +133,90 @@ impl TrieDictionary {
 
         let keys: Vec<&[u8]> = pairs.iter().map(|(r, _)| r.as_bytes()).collect();
         let trie = DoubleArray::<u8>::build(&keys);
-        let values: Vec<Vec<DictEntry>> = pairs.into_iter().map(|(_, v)| v).collect();
+
+        // Build string pool with global deduplication
+        let mut pool = Vec::new();
+        let mut pool_map: HashMap<String, u32> = HashMap::new();
+
+        // Build entry records and reading index
+        let mut entries_data = Vec::new();
+        let mut reading_index = Vec::with_capacity(pairs.len() * SLOT_SIZE);
+
+        for (_, candidates) in &pairs {
+            let entry_offset = (entries_data.len() / ENTRY_SIZE) as u32;
+            let count = candidates.len() as u16;
+
+            for e in candidates {
+                let str_offset = *pool_map.entry(e.surface.clone()).or_insert_with(|| {
+                    let offset = pool.len() as u32;
+                    pool.extend_from_slice(e.surface.as_bytes());
+                    offset
+                });
+                let str_len = e.surface.len() as u16;
+
+                entries_data.extend_from_slice(&str_offset.to_le_bytes());
+                entries_data.extend_from_slice(&str_len.to_le_bytes());
+                entries_data.extend_from_slice(&e.cost.to_le_bytes());
+                entries_data.extend_from_slice(&e.left_id.to_le_bytes());
+                entries_data.extend_from_slice(&e.right_id.to_le_bytes());
+            }
+
+            reading_index.extend_from_slice(&entry_offset.to_le_bytes());
+            reading_index.extend_from_slice(&count.to_le_bytes());
+        }
 
         Self {
             trie: TrieStore::Owned(trie),
-            values,
+            values: ValuesStore::Owned {
+                string_pool: pool,
+                entries_data,
+                reading_index,
+            },
+            _mmap: None,
         }
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, DictError> {
         let trie_data = match &self.trie {
             TrieStore::Owned(da) => da.as_bytes(),
-            TrieStore::MmapRef { .. } => {
+            TrieStore::MmapRef(_) => {
                 return Err(DictError::Parse(
                     "cannot serialize mmap-backed dictionary".into(),
                 ));
             }
         };
-        let values_data = bincode::serialize(&self.values).map_err(DictError::Serialize)?;
+
+        let pool = self.values.string_pool();
+        let entries = self.values.entries_data();
+        let index = self.values.reading_index();
 
         let trie_len: u32 = trie_data
             .len()
             .try_into()
             .map_err(|_| DictError::Parse("trie data exceeds u32::MAX".to_string()))?;
-        let values_len: u32 = values_data
+        let pool_len: u32 = pool
             .len()
             .try_into()
-            .map_err(|_| DictError::Parse("values data exceeds u32::MAX".to_string()))?;
+            .map_err(|_| DictError::Parse("string pool exceeds u32::MAX".to_string()))?;
+        let entries_len: u32 = entries
+            .len()
+            .try_into()
+            .map_err(|_| DictError::Parse("entries data exceeds u32::MAX".to_string()))?;
+        let reading_count: u32 = (index.len() / SLOT_SIZE) as u32;
 
-        let mut buf = Vec::with_capacity(HEADER_SIZE + trie_data.len() + values_data.len());
+        let total = HEADER_SIZE + trie_data.len() + pool.len() + entries.len() + index.len();
+        let mut buf = Vec::with_capacity(total);
         buf.extend_from_slice(MAGIC);
         buf.push(VERSION);
-        buf.extend_from_slice(&[0u8; 3]); // reserved padding
+        buf.extend_from_slice(&[0u8; 3]); // reserved
         buf.extend_from_slice(&trie_len.to_le_bytes());
-        buf.extend_from_slice(&values_len.to_le_bytes());
+        buf.extend_from_slice(&pool_len.to_le_bytes());
+        buf.extend_from_slice(&entries_len.to_le_bytes());
+        buf.extend_from_slice(&reading_count.to_le_bytes());
         buf.extend_from_slice(&trie_data);
-        buf.extend_from_slice(&values_data);
+        buf.extend_from_slice(pool);
+        buf.extend_from_slice(entries);
+        buf.extend_from_slice(index);
 
         Ok(buf)
     }
@@ -102,33 +236,38 @@ impl TrieDictionary {
         }
 
         let trie_len = u32::from_le_bytes(data[8..12].try_into().unwrap()) as usize;
-        let values_len = u32::from_le_bytes(data[12..16].try_into().unwrap()) as usize;
+        let pool_len = u32::from_le_bytes(data[12..16].try_into().unwrap()) as usize;
+        let entries_len = u32::from_le_bytes(data[16..20].try_into().unwrap()) as usize;
+        let reading_count = u32::from_le_bytes(data[20..24].try_into().unwrap()) as usize;
+        let index_len = reading_count * SLOT_SIZE;
 
-        let expected = HEADER_SIZE + trie_len + values_len;
+        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
         if data.len() < expected {
             return Err(DictError::InvalidHeader);
         }
 
         let trie_start = HEADER_SIZE;
-        let values_start = trie_start + trie_len;
+        let pool_start = trie_start + trie_len;
+        let entries_start = pool_start + pool_len;
+        let index_start = entries_start + entries_len;
 
         let trie = DoubleArray::<u8>::from_bytes(&data[trie_start..trie_start + trie_len])?;
-        let values: Vec<Vec<DictEntry>> =
-            bincode::deserialize(&data[values_start..values_start + values_len])
-                .map_err(DictError::Deserialize)?;
 
         Ok(Self {
             trie: TrieStore::Owned(trie),
-            values,
+            values: ValuesStore::Owned {
+                string_pool: data[pool_start..pool_start + pool_len].to_vec(),
+                entries_data: data[entries_start..entries_start + entries_len].to_vec(),
+                reading_index: data[index_start..index_start + index_len].to_vec(),
+            },
+            _mmap: None,
         })
     }
 
-    /// Open a dictionary file, using mmap for zero-copy trie access.
+    /// Open a dictionary file, using mmap for zero-copy access.
     ///
-    /// The trie data is referenced directly from the memory-mapped region
-    /// via `DoubleArrayRef`, eliminating ~70MB of heap allocation for the
-    /// trie nodes/siblings arrays. The values (strings) are still
-    /// deserialized onto the heap.
+    /// Both the trie and values data are referenced directly from the
+    /// memory-mapped region, eliminating ~60-80MB of heap allocation.
     pub fn open(path: &Path) -> Result<Self, DictError> {
         let file = File::open(path)?;
         // SAFETY: The file is opened read-only and the mapping is immutable.
@@ -148,35 +287,52 @@ impl TrieDictionary {
         }
 
         let trie_len = u32::from_le_bytes(mmap[8..12].try_into().unwrap()) as usize;
-        let values_len = u32::from_le_bytes(mmap[12..16].try_into().unwrap()) as usize;
+        let pool_len = u32::from_le_bytes(mmap[12..16].try_into().unwrap()) as usize;
+        let entries_len = u32::from_le_bytes(mmap[16..20].try_into().unwrap()) as usize;
+        let reading_count = u32::from_le_bytes(mmap[20..24].try_into().unwrap()) as usize;
+        let index_len = reading_count * SLOT_SIZE;
 
-        let expected = HEADER_SIZE + trie_len + values_len;
+        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
         if mmap.len() < expected {
             return Err(DictError::InvalidHeader);
         }
 
         let trie_start = HEADER_SIZE;
-        let values_start = trie_start + trie_len;
+        let pool_start = trie_start + trie_len;
+        let entries_start = pool_start + pool_len;
+        let index_start = entries_start + entries_len;
 
         // Zero-copy trie from mmap
         let trie_ref =
             DoubleArrayRef::<u8>::from_bytes_ref(&mmap[trie_start..trie_start + trie_len])?;
-        // SAFETY: The mmap is stored in TrieStore::MmapRef._mmap and will be dropped
-        // after the trie reference (Rust drops fields in declaration order).
+        // SAFETY: The mmap is stored in self._mmap and will be dropped after trie and values
+        // (Rust drops fields in declaration order: trie, values, _mmap).
         let trie_ref = unsafe {
             std::mem::transmute::<DoubleArrayRef<'_, u8>, DoubleArrayRef<'static, u8>>(trie_ref)
         };
 
-        let values: Vec<Vec<DictEntry>> =
-            bincode::deserialize(&mmap[values_start..values_start + values_len])
-                .map_err(DictError::Deserialize)?;
+        // SAFETY: The slices reference mmap data. The mmap is stored in self._mmap
+        // and will outlive these references (dropped last due to field order).
+        let string_pool = unsafe {
+            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[pool_start..pool_start + pool_len])
+        };
+        let entries_data = unsafe {
+            std::mem::transmute::<&[u8], &'static [u8]>(
+                &mmap[entries_start..entries_start + entries_len],
+            )
+        };
+        let reading_index = unsafe {
+            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[index_start..index_start + index_len])
+        };
 
         Ok(Self {
-            trie: TrieStore::MmapRef {
-                _mmap: mmap,
-                trie: trie_ref,
+            trie: TrieStore::MmapRef(trie_ref),
+            values: ValuesStore::MmapRef {
+                string_pool,
+                entries_data,
+                reading_index,
             },
-            values,
+            _mmap: Some(mmap),
         })
     }
 
@@ -185,8 +341,7 @@ impl TrieDictionary {
     }
 
     /// Iterate over all `(reading, entries)` pairs in the trie.
-    pub fn iter(&self) -> impl Iterator<Item = (String, &Vec<DictEntry>)> {
-        // Collect into Vec so the return type is concrete regardless of TrieStore variant.
+    pub fn iter(&self) -> impl Iterator<Item = (String, Vec<DictEntry>)> + '_ {
         let pairs: Vec<_> = with_trie!(self, |t| {
             t.predictive_search(b"")
                 .map(|m| {
@@ -199,13 +354,13 @@ impl TrieDictionary {
         });
         pairs
             .into_iter()
-            .map(move |(reading, idx)| (reading, &self.values[idx]))
+            .map(move |(reading, idx)| (reading, self.values.get_entries(idx)))
     }
 
     /// Returns (reading_count, entry_count).
     pub fn stats(&self) -> (usize, usize) {
-        let readings = self.values.len();
-        let entries: usize = self.values.iter().map(|v| v.len()).sum();
+        let readings = self.values.reading_count();
+        let entries = self.values.entries_data().len() / ENTRY_SIZE;
         (readings, entries)
     }
 }
@@ -214,7 +369,7 @@ impl Dictionary for TrieDictionary {
     fn lookup(&self, reading: &str) -> Vec<DictEntry> {
         with_trie!(self, |t| {
             t.exact_match(reading.as_bytes())
-                .map(|id| self.values[id as usize].to_vec())
+                .map(|id| self.values.get_entries(id as usize))
                 .unwrap_or_default()
         })
     }
@@ -226,7 +381,7 @@ impl Dictionary for TrieDictionary {
                 .map(|m| SearchResult {
                     reading: String::from_utf8(m.key)
                         .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned()),
-                    entries: self.values[m.value_id as usize].to_vec(),
+                    entries: self.values.get_entries(m.value_id as usize),
                 })
                 .collect()
         })
@@ -243,10 +398,10 @@ impl Dictionary for TrieDictionary {
             for m in t.predictive_search(prefix.as_bytes()).take(scan_limit) {
                 let reading = String::from_utf8(m.key)
                     .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
-                let entries = &self.values[m.value_id as usize];
+                let entries = self.values.get_entries(m.value_id as usize);
                 flat.reserve(entries.len());
                 for e in entries {
-                    flat.push((reading.clone(), e.clone()));
+                    flat.push((reading.clone(), e));
                 }
             }
         });
@@ -268,7 +423,7 @@ impl Dictionary for TrieDictionary {
                     let reading = std::str::from_utf8(&query_bytes[..m.len]).ok()?;
                     Some(SearchResult {
                         reading: reading.to_string(),
-                        entries: self.values[m.value_id as usize].to_vec(),
+                        entries: self.values.get_entries(m.value_id as usize),
                     })
                 })
                 .collect()


### PR DESCRIPTION
## Summary
- Replace bincode-serialized `Vec<Vec<DictEntry>>` with flat binary layout: string pool (globally deduplicated), 12-byte entry records, and 6-byte reading index slots
- Move `Mmap` from `TrieStore` to `TrieDictionary` level so both trie and values can reference the same mmap
- Add `ValuesStore` enum (Owned/MmapRef) for zero-copy values access, eliminating ~60-80MB heap allocation
- Change `iter()` return type from `(String, &Vec<DictEntry>)` to `(String, Vec<DictEntry>)` since entries are now constructed on-demand

## LXDX v4 layout
```
[Header: 24 bytes]
  "LXDX" (4B) | version=4 (1B) | reserved (3B) |
  trie_len (u32) | pool_len (u32) | entries_len (u32) | reading_count (u32)

[Trie: trie_len bytes]
[String Pool: pool_len bytes]
[Entry Records: entries_len bytes]  ← 12B × N fixed-size
[Reading Index: count × 6B]
```

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes  
- [x] `cargo test --workspace --all-features` — 281 tests pass (including serialize roundtrip and mmap tests)
- [ ] `mise run dict-clean && mise run dict` — recompile dictionary with new format
- [ ] `mise run build && mise run install && mise run reload` — verify IME works end-to-end

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)