### PR TITLE
fix: exempt 2-segment paths from length variance penalty

### DIFF
--- a/engine/crates/lex-core/src/converter/reranker.rs
+++ b/engine/crates/lex-core/src/converter/reranker.rs
@@ -62,11 +62,13 @@ pub fn rerank(paths: &mut Vec<ScoredPath>, conn: Option<&ConnectionMatrix>) {
         // fragmented paths without dominating the Viterbi cost.
         path.viterbi_cost += structure_cost / 4;
 
-        // Length variance penalty: for paths with 2+ segments, penalise
-        // uneven reading lengths. Computed as sum-of-squared-deviations
-        // from the mean, scaled by LENGTH_VARIANCE_WEIGHT / N.
+        // Length variance penalty: for paths with 3+ segments, penalise
+        // uneven reading lengths. 2-segment paths are exempt because
+        // "long content word + short particle" is natural Japanese.
+        // Computed as sum-of-squared-deviations from the mean, scaled
+        // by LENGTH_VARIANCE_WEIGHT / N.
         let n = path.segments.len();
-        if n >= 2 {
+        if n >= 3 {
             let lengths: Vec<i64> = path
                 .segments
                 .iter()


### PR DESCRIPTION
## Summary

- Raise length variance penalty threshold from `n >= 2` to `n >= 3` in reranker
- 2-segment paths ("long content word + short particle") are natural Japanese and should not be penalized for uneven segment lengths
- Fixes "大きな影響を" being pushed out of candidate range for "おおきなえいきょうを"

## Details

The length variance penalty was designed to penalize fragmented paths with uneven segment lengths. However, for 2-segment paths like `大きな影響|を`, the variance between a 9-char content word and 1-char particle is extreme, producing a +29317 penalty that dwarfs the Viterbi cost advantage (14790 best among N-best).

3+ segment paths still receive the variance penalty, which correctly penalizes truly fragmented splits like `亜|位|鵜|絵|お`.

Closes #145

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes (updated existing test assertions)
- [x] Manual test: type "おおきなえいきょうを" → 「大きな影響を」 appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)