### PR TITLE
feat: inject history-learned surfaces into upper candidate positions

### DIFF
--- a/engine/crates/lex-core/src/candidates/standard.rs
+++ b/engine/crates/lex-core/src/candidates/standard.rs
@@ -41,6 +41,16 @@ pub(super) fn generate_normal_candidates(
         nbest_paths.push(path.clone());
     }
 
+    // 1.5. Inject history-learned surfaces not in N-best.
+    if let Some(h) = history {
+        let now = crate::user_history::now_epoch();
+        for (surface, _boost) in h.learned_surfaces(reading, now) {
+            if seen.insert(surface.clone()) {
+                surfaces.push(surface);
+            }
+        }
+    }
+
     // 2. Reading (kana) — position depends on history boost.
     //    If the user previously selected the hiragana form, promote it —
     //    but only above the N-best #1 when the #1 hasn't been explicitly

--- a/engine/crates/lex-core/src/user_history/mod.rs
+++ b/engine/crates/lex-core/src/user_history/mod.rs
@@ -211,6 +211,21 @@ impl UserHistory {
         results
     }
 
+    /// Return surfaces the user has previously confirmed for this reading,
+    /// sorted by boost descending. Only returns entries with positive boost.
+    pub fn learned_surfaces(&self, reading: &str, now: u64) -> Vec<(String, i64)> {
+        let Some(inner) = self.unigrams.get(reading) else {
+            return Vec::new();
+        };
+        let mut results: Vec<(String, i64)> = inner
+            .iter()
+            .map(|(surface, entry)| (surface.clone(), entry.boost(now)))
+            .filter(|(_, boost)| *boost > 0)
+            .collect();
+        results.sort_by(|a, b| b.1.cmp(&a.1));
+        results
+    }
+
     /// Reorder dictionary candidates so learned entries appear first.
     pub fn reorder_candidates(&self, reading: &str, entries: &[DictEntry]) -> Vec<DictEntry> {
         let now = now_epoch();

--- a/engine/crates/lex-core/src/user_history/tests.rs
+++ b/engine/crates/lex-core/src/user_history/tests.rs
@@ -222,6 +222,28 @@ fn test_reorder_candidates_no_boost_preserves_order() {
 }
 
 #[test]
+fn test_learned_surfaces() {
+    let mut h = UserHistory::new();
+    let now = 1_700_000_000;
+    h.record_at(&[("ゆうかい".into(), "夕会".into())], now);
+    h.record_at(&[("ゆうかい".into(), "夕会".into())], now + 1);
+    h.record_at(&[("ゆうかい".into(), "誘拐".into())], now + 2);
+
+    let surfaces = h.learned_surfaces("ゆうかい", now + 3);
+    assert_eq!(surfaces.len(), 2);
+    // "夕会" has frequency=2 → higher boost → first
+    assert_eq!(surfaces[0].0, "夕会");
+    assert_eq!(surfaces[1].0, "誘拐");
+    assert!(surfaces[0].1 > surfaces[1].1);
+}
+
+#[test]
+fn test_learned_surfaces_empty() {
+    let h = UserHistory::new();
+    assert!(h.learned_surfaces("ゆうかい", now_epoch()).is_empty());
+}
+
+#[test]
 fn test_bigram_successors() {
     let mut h = UserHistory::new();
     h.record(&[


### PR DESCRIPTION
## Summary

- Add `UserHistory::learned_surfaces()` method that returns previously confirmed surfaces for a reading, sorted by boost descending
- Inject learned surfaces right after N-best Viterbi results (step 1.5) in `generate_normal_candidates()`, so words the user has confirmed before appear near the top of candidates instead of only in the dictionary lookup section at the bottom
- Deduplication via `seen` HashSet ensures no duplicate entries

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean  
- [x] `cargo test --workspace --all-features` — 340 tests pass
- [x] Manual: confirm 「夕会」(ゆうかい), then re-type — appears in upper candidates
- [x] Manual: remove 「夕会」 from user dict, reload — still appears in upper candidates via history alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)