### PR TITLE
feat: Shift+letter uppercase passthrough in kana mode

### DIFF
--- a/engine/crates/lex-session/src/key_handlers.rs
+++ b/engine/crates/lex-session/src/key_handlers.rs
@@ -112,6 +112,23 @@ impl InputSession {
             return KeyResponse::not_consumed();
         }
 
+        // Uppercase letter: add to composition as-is (no romaji conversion)
+        if text
+            .chars()
+            .next()
+            .map_or(false, |c| c.is_ascii_uppercase())
+        {
+            self.state = SessionState::Composing(Composition::new());
+            self.comp().kana.push_str(text);
+            self.comp().stability.reset();
+            return if self.config.defer_candidates {
+                self.make_deferred_candidates_response()
+            } else {
+                self.update_candidates();
+                build_marked_text_and_candidates(self.comp())
+            };
+        }
+
         // Romaji input
         if is_romaji_input(text) {
             self.state = SessionState::Composing(Composition::new());


### PR DESCRIPTION
## Summary
- Shift+letter in kana mode adds the uppercase letter to the composition as-is (no romaji → kana conversion)
- Consecutive uppercase letters are grouped as one word (stability reset suppresses auto-commit)
- Pending romaji is flushed before adding uppercase (e.g. "kan" + Shift+A → "かんA")
- Follows standard IME behavior (Google IME, macOS built-in, etc.)

## Changes
- **key_handlers.rs**: Add uppercase check in `handle_idle` — start composing with uppercase text directly
- **composing.rs**: Add uppercase check in `handle_composing_text` — flush pending, add to kana, skip auto-commit
- **tests/basic.rs**: 3 new tests (idle, composing, with pending romaji)

## Test plan
- [x] `cargo test --workspace --all-features` — 340 tests pass
- [x] `mise run build` — successful
- [x] Manual: Shift+A in idle → composing with "A" (underlined)
- [x] Manual: Shift+B during composing → "かB" stays in composition
- [x] Manual: Consecutive uppercase (e.g. "ABC") stays grouped, no per-char auto-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)