### PR TITLE
fix: add accessibility labels to settings UI

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -54,6 +54,7 @@ struct DeveloperSettingsView: View {
                         .font(.system(.body, design: .monospaced))
                         .frame(height: editorHeight)
                         .border(Color(nsColor: .separatorColor))
+                        .accessibilityLabel("ローマ字設定エディタ")
                     tomlButtons(
                         onSave: { saveFile(name: "romaji.toml", content: romajiText) },
                         onReload: { loadRomaji() },
@@ -66,6 +67,7 @@ struct DeveloperSettingsView: View {
                         .font(.system(.body, design: .monospaced))
                         .frame(height: editorHeight)
                         .border(Color(nsColor: .separatorColor))
+                        .accessibilityLabel("設定エディタ")
                     tomlButtons(
                         onSave: { saveFile(name: "settings.toml", content: settingsText) },
                         onReload: { loadSettings() },

--- a/Sources/UserDictionaryView.swift
+++ b/Sources/UserDictionaryView.swift
@@ -23,6 +23,8 @@ struct UserDictionaryView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .tag(index)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(word.reading)、\(word.surface)")
                     }
                 }
             }
@@ -33,9 +35,11 @@ struct UserDictionaryView: View {
                 Button(action: { showingAddSheet = true }) {
                     Image(systemName: "plus")
                 }
+                .accessibilityLabel("単語を追加")
                 Button(action: removeSelected) {
                     Image(systemName: "minus")
                 }
+                .accessibilityLabel("選択した単語を削除")
                 .disabled(selectedIndex == nil)
                 Spacer()
                 Text("\(words.count) 語")


### PR DESCRIPTION
## Summary
- User dictionary list rows: combined accessibility label "読み、表層" for VoiceOver
- +/- buttons: explicit labels "単語を追加" / "選択した単語を削除"
- TOML text editors: "ローマ字設定エディタ" / "設定エディタ" to distinguish editors

## Test plan
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)