### PR TITLE
fix: accumulate committed_context in all commit paths

### DIFF
--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -84,8 +84,13 @@ impl InputSession {
 
         // Include prefix in the committed text, then clear it
         let prefix_text = std::mem::take(&mut c.prefix.text);
+        let committed_text = format!("{}{}", prefix_text, committed_surface);
+
+        // Accumulate for neural context
+        self.committed_context.push_str(&committed_text);
+
         let mut resp = KeyResponse::consumed();
-        resp.commit = Some(format!("{}{}", prefix_text, committed_surface));
+        resp.commit = Some(committed_text);
 
         if self.comp().kana.is_empty() {
             self.comp().candidates.clear();

--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -16,6 +16,21 @@ impl InputSession {
                 text: String::new(),
             });
         }
+
+        // Accumulate committed text for neural context
+        if let Some(ref committed) = resp.commit {
+            self.committed_context.push_str(committed);
+        }
+
+        // GhostText mode: request ghost text generation after commit
+        if self.config.conversion_mode == ConversionMode::GhostText && resp.commit.is_some() {
+            self.ghost.generation += 1;
+            resp.ghost_request = Some(AsyncGhostRequest {
+                context: self.committed_context.clone(),
+                generation: self.ghost.generation,
+            });
+        }
+
         self.reset_state();
         resp
     }

--- a/engine/crates/lex-session/src/key_handlers.rs
+++ b/engine/crates/lex-session/src/key_handlers.rs
@@ -44,6 +44,7 @@ impl InputSession {
         // Falls back to direct commit if the text isn't handled by trie/romaji (e.g. \ in idle).
         } else if let Some(remapped) = settings().keymap_get(key_code, has_shift) {
             if self.abc_passthrough {
+                self.committed_context.push_str(remapped);
                 let mut r = KeyResponse::consumed();
                 r.commit = Some(remapped.to_string());
                 r
@@ -55,6 +56,7 @@ impl InputSession {
                     r
                 } else {
                     // Not handled by trie/romaji (e.g. \) — commit directly
+                    self.committed_context.push_str(remapped);
                     let mut r = KeyResponse::consumed();
                     r.commit = Some(remapped.to_string());
                     r
@@ -67,6 +69,7 @@ impl InputSession {
         } else if self.abc_passthrough {
             match text.chars().next() {
                 Some(c) if (' '..='~').contains(&c) => {
+                    self.committed_context.push_str(text);
                     let mut r = KeyResponse::consumed();
                     r.commit = Some(text.to_string());
                     r


### PR DESCRIPTION
## Summary
- `commit_composed()` (Escape commit) was missing `committed_context` accumulation and ghost request generation
- `try_auto_commit()` was missing `committed_context` accumulation, causing neural context to lose auto-committed text
- Direct-commit paths in `key_handlers.rs` (ABC passthrough, keymap remap) were also missing accumulation

## Test plan
- [x] `cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (318 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)