### PR TITLE
refactor: clean up stale comments after ghost/neural removal

### DIFF
--- a/engine/crates/lex-core/src/candidates/neural.rs
+++ b/engine/crates/lex-core/src/candidates/neural.rs
@@ -14,6 +14,8 @@ use super::{generate_punctuation_candidates, punctuation_alternatives, Candidate
 /// Uses speculative decode (Viterbi draft + GPT-2 verify) as the #1 candidate,
 /// followed by standard Viterbi N-best candidates. Falls back to standard
 /// candidate generation on neural failure.
+///
+/// Not used in the IME runtime (too slow). Retained for research via `dictool neural-score`.
 pub fn generate(
     scorer: &mut NeuralScorer,
     dict: &dyn Dictionary,

--- a/engine/crates/lex-core/src/candidates/strategy.rs
+++ b/engine/crates/lex-core/src/candidates/strategy.rs
@@ -6,9 +6,10 @@ use super::CandidateResponse;
 
 /// Strategy for candidate generation.
 ///
-/// `Standard` and `Predictive` are stateless.  `Neural` carries a mutable
-/// reference to the scorer plus the preceding context string, because
-/// speculative decoding needs both.
+/// `Standard` and `Predictive` are used in the IME runtime.
+/// `Neural` is retained for research only (not integrated into the FFI layer
+/// due to inference latency). It carries a mutable reference to the scorer
+/// plus the preceding context string for speculative decoding.
 pub enum CandidateStrategy<'a> {
     Standard,
     Predictive,

--- a/engine/crates/lex-core/src/neural/mod.rs
+++ b/engine/crates/lex-core/src/neural/mod.rs
@@ -3,6 +3,10 @@
 //! This module provides neural language model scoring for re-ranking
 //! Viterbi N-best candidates. It loads a GGUF quantized GPT-2 model
 //! and computes log-probabilities for candidate strings.
+//!
+//! **Note**: This module is retained for research and benchmarking only
+//! (via `dictool neural-score`). It is not integrated into the IME runtime
+//! because inference latency is too high for interactive use.
 
 mod gpt2;
 mod scoring;

--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -86,7 +86,7 @@ impl InputSession {
         let prefix_text = std::mem::take(&mut c.prefix.text);
         let committed_text = format!("{}{}", prefix_text, committed_surface);
 
-        // Accumulate for neural context
+        // Accumulate committed text for context
         self.committed_context.push_str(&committed_text);
 
         let mut resp = KeyResponse::consumed();

--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -14,7 +14,7 @@ impl InputSession {
             });
         }
 
-        // Accumulate committed text for neural context
+        // Accumulate committed text for context
         if let Some(ref committed) = resp.commit {
             self.committed_context.push_str(committed);
         }
@@ -53,7 +53,7 @@ impl InputSession {
             }
         }
 
-        // Accumulate committed text for neural context
+        // Accumulate committed text for context
         if let Some(ref committed) = resp.commit {
             self.committed_context.push_str(committed);
         }

--- a/engine/crates/lex-session/src/lib.rs
+++ b/engine/crates/lex-session/src/lib.rs
@@ -44,7 +44,7 @@ pub struct InputSession {
     /// ABC passthrough mode: all keys pass through to app, except Kana.
     abc_passthrough: bool,
 
-    // Accumulated committed text for neural context
+    // Accumulated committed text (conversion context)
     committed_context: String,
 }
 
@@ -115,7 +115,7 @@ impl InputSession {
         std::mem::take(&mut self.history_records)
     }
 
-    /// Get the accumulated committed text for use as neural context.
+    /// Get the accumulated committed text (conversion context).
     pub fn committed_context(&self) -> String {
         self.committed_context.clone()
     }

--- a/engine/crates/lex-session/src/tests/auto_commit.rs
+++ b/engine/crates/lex-session/src/tests/auto_commit.rs
@@ -1,2 +1,0 @@
-// Auto-commit tests are in other test modules.
-// This file previously contained GhostText-specific tests.

--- a/engine/crates/lex-session/src/tests/mod.rs
+++ b/engine/crates/lex-session/src/tests/mod.rs
@@ -1,4 +1,3 @@
-mod auto_commit;
 mod basic;
 mod candidates;
 mod corpus;


### PR DESCRIPTION
## Summary
- Remove "neural" from `committed_context` comments — field is retained for general context, not neural-specific
- Add research-only doc comments to `neural/mod.rs`, `candidates/neural.rs`, `CandidateStrategy` enum
- Delete empty `tests/auto_commit.rs` (only had a ghost text removal note)

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)