### PR TITLE
refactor: Swift cleanup — access control, localization, safety

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Menu */
+"設定..." = "Settings...";
+
 /* Settings Window */
 "Lexime 設定" = "Lexime Settings";
 

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Menu */
+"設定..." = "設定...";
+
 /* Settings Window */
 "Lexime 設定" = "Lexime 設定";
 

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -7,10 +7,10 @@ class LeximeInputController: IMKInputController {
 
     // MARK: - State
 
-    var session: LexSession?
+    private var session: LexSession?
 
     /// Tracks the currently displayed marked text so composedString stays in sync.
-    var currentDisplay: String?
+    private var currentDisplay: String?
 
     var isComposing: Bool {
         guard let session else { return false }
@@ -110,14 +110,14 @@ class LeximeInputController: IMKInputController {
             case .switchToAbc:
                 selectABCInputSource()
             case .schedulePoll:
-                schedulePollTimer(client: client)
+                schedulePollTimer()
             }
         }
     }
 
     // MARK: - Poll Timer
 
-    private func schedulePollTimer(client: IMKTextInput) {
+    private func schedulePollTimer() {
         guard pollTimer == nil else { return }
         var idleTicks = 0
         pollTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
@@ -164,7 +164,7 @@ class LeximeInputController: IMKInputController {
     override func menu() -> NSMenu! {
         let menu = NSMenu()
         let settingsItem = NSMenuItem(
-            title: "設定...",
+            title: NSLocalizedString("設定...", comment: "Settings menu item"),
             action: #selector(showSettings),
             keyEquivalent: ","
         )
@@ -214,8 +214,8 @@ class LeximeInputController: IMKInputController {
         let modeID = value as? String ?? ""
 
         if modeID == Self.romanModeID {
-            if isComposing, let client = sender as? IMKTextInput {
-                let resp = session!.commit()
+            if isComposing, let session, let client = sender as? IMKTextInput {
+                let resp = session.commit()
                 applyEvents(resp, client: client)
             }
             session?.setAbcPassthrough(enabled: true)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -84,7 +84,6 @@ struct DeveloperSettingsView: View {
                             }
                         }
                         .buttonStyle(.borderedProminent)
-                        .tint(.orange)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Make `session` and `currentDisplay` private (not accessed outside controller)
- Remove unused `client` parameter from `schedulePollTimer()`
- Replace `session!` force unwrap with `guard let session` in `setValue`
- Localize settings menu item with `NSLocalizedString`
- Remove ineffective `.tint(.orange)` on macOS bordered button
- Add "設定..." to Localizable.strings (en/ja)
- Skip M5 (onChange deprecation) — requires macOS 14+ but deployment target is 13.0

## Test plan
- [x] `mise run build` succeeds
- [ ] Menu shows "Settings..." (English) / "設定..." (Japanese)

🤖 Generated with [Claude Code](https://claude.com/claude-code)