### PR TITLE
refactor: session cleanup — helpers, file splits, FFI tests

### DIFF
--- a/engine/crates/lex-core/src/dict/mod.rs
+++ b/engine/crates/lex-core/src/dict/mod.rs
@@ -10,6 +10,7 @@ mod entry;
 #[cfg(test)]
 mod tests;
 mod trie_dict;
+mod trie_dict_io;
 
 pub use composite::CompositeDictionary;
 pub use entry::DictEntry;

--- a/engine/crates/lex-core/src/dict/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict.rs
@@ -1,20 +1,18 @@
 use std::collections::HashMap;
-use std::fs::{self, File};
-use std::path::Path;
 
 use lexime_trie::{DoubleArray, DoubleArrayRef};
 use memmap2::Mmap;
 
-use super::{DictEntry, DictError, Dictionary, SearchResult};
+use super::{DictEntry, Dictionary, SearchResult};
 
-const MAGIC: &[u8; 4] = b"LXDX";
-const VERSION: u8 = 4;
+pub(super) const MAGIC: &[u8; 4] = b"LXDX";
+pub(super) const VERSION: u8 = 4;
 // magic(4) + version(1) + reserved(3) + trie_len(4) + pool_len(4) + entries_len(4) + reading_count(4) = 24
-const HEADER_SIZE: usize = 24;
+pub(super) const HEADER_SIZE: usize = 24;
 const ENTRY_SIZE: usize = 12; // str_offset(4) + str_len(2) + cost(2) + left_id(2) + right_id(2)
-const SLOT_SIZE: usize = 6; // entry_offset(4) + count(2)
+pub(super) const SLOT_SIZE: usize = 6; // entry_offset(4) + count(2)
 
-enum TrieStore {
+pub(super) enum TrieStore {
     Owned(DoubleArray<u8>),
     MmapRef(DoubleArrayRef<'static, u8>),
 }
@@ -33,7 +31,7 @@ macro_rules! with_trie {
     };
 }
 
-enum ValuesStore {
+pub(super) enum ValuesStore {
     Owned {
         string_pool: Vec<u8>,
         entries_data: Vec<u8>,
@@ -47,21 +45,21 @@ enum ValuesStore {
 }
 
 impl ValuesStore {
-    fn string_pool(&self) -> &[u8] {
+    pub(super) fn string_pool(&self) -> &[u8] {
         match self {
             ValuesStore::Owned { string_pool, .. } => string_pool,
             ValuesStore::MmapRef { string_pool, .. } => string_pool,
         }
     }
 
-    fn entries_data(&self) -> &[u8] {
+    pub(super) fn entries_data(&self) -> &[u8] {
         match self {
             ValuesStore::Owned { entries_data, .. } => entries_data,
             ValuesStore::MmapRef { entries_data, .. } => entries_data,
         }
     }
 
-    fn reading_index(&self) -> &[u8] {
+    pub(super) fn reading_index(&self) -> &[u8] {
         match self {
             ValuesStore::Owned { reading_index, .. } => reading_index,
             ValuesStore::MmapRef { reading_index, .. } => reading_index,
@@ -118,9 +116,9 @@ impl ValuesStore {
 }
 
 pub struct TrieDictionary {
-    trie: TrieStore,
-    values: ValuesStore,
-    _mmap: Option<Mmap>,
+    pub(super) trie: TrieStore,
+    pub(super) values: ValuesStore,
+    pub(super) _mmap: Option<Mmap>,
 }
 
 impl TrieDictionary {
@@ -174,170 +172,6 @@ impl TrieDictionary {
             },
             _mmap: None,
         }
-    }
-
-    pub fn to_bytes(&self) -> Result<Vec<u8>, DictError> {
-        let trie_data = match &self.trie {
-            TrieStore::Owned(da) => da.as_bytes(),
-            TrieStore::MmapRef(_) => {
-                return Err(DictError::Parse(
-                    "cannot serialize mmap-backed dictionary".into(),
-                ));
-            }
-        };
-
-        let pool = self.values.string_pool();
-        let entries = self.values.entries_data();
-        let index = self.values.reading_index();
-
-        let trie_len: u32 = trie_data
-            .len()
-            .try_into()
-            .map_err(|_| DictError::Parse("trie data exceeds u32::MAX".to_string()))?;
-        let pool_len: u32 = pool
-            .len()
-            .try_into()
-            .map_err(|_| DictError::Parse("string pool exceeds u32::MAX".to_string()))?;
-        let entries_len: u32 = entries
-            .len()
-            .try_into()
-            .map_err(|_| DictError::Parse("entries data exceeds u32::MAX".to_string()))?;
-        let reading_count: u32 = (index.len() / SLOT_SIZE) as u32;
-
-        let total = HEADER_SIZE + trie_data.len() + pool.len() + entries.len() + index.len();
-        let mut buf = Vec::with_capacity(total);
-        buf.extend_from_slice(MAGIC);
-        buf.push(VERSION);
-        buf.extend_from_slice(&[0u8; 3]); // reserved
-        buf.extend_from_slice(&trie_len.to_ne_bytes());
-        buf.extend_from_slice(&pool_len.to_ne_bytes());
-        buf.extend_from_slice(&entries_len.to_ne_bytes());
-        buf.extend_from_slice(&reading_count.to_ne_bytes());
-        buf.extend_from_slice(&trie_data);
-        buf.extend_from_slice(pool);
-        buf.extend_from_slice(entries);
-        buf.extend_from_slice(index);
-
-        Ok(buf)
-    }
-
-    pub fn from_bytes(data: &[u8]) -> Result<Self, DictError> {
-        if data.len() < 5 {
-            return Err(DictError::InvalidHeader);
-        }
-        if &data[..4] != MAGIC {
-            return Err(DictError::InvalidMagic);
-        }
-        if data[4] != VERSION {
-            return Err(DictError::UnsupportedVersion(data[4]));
-        }
-        if data.len() < HEADER_SIZE {
-            return Err(DictError::InvalidHeader);
-        }
-
-        let trie_len = u32::from_ne_bytes(data[8..12].try_into().unwrap()) as usize;
-        let pool_len = u32::from_ne_bytes(data[12..16].try_into().unwrap()) as usize;
-        let entries_len = u32::from_ne_bytes(data[16..20].try_into().unwrap()) as usize;
-        let reading_count = u32::from_ne_bytes(data[20..24].try_into().unwrap()) as usize;
-        let index_len = reading_count * SLOT_SIZE;
-
-        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
-        if data.len() < expected {
-            return Err(DictError::InvalidHeader);
-        }
-
-        let trie_start = HEADER_SIZE;
-        let pool_start = trie_start + trie_len;
-        let entries_start = pool_start + pool_len;
-        let index_start = entries_start + entries_len;
-
-        let trie = DoubleArray::<u8>::from_bytes(&data[trie_start..trie_start + trie_len])?;
-
-        Ok(Self {
-            trie: TrieStore::Owned(trie),
-            values: ValuesStore::Owned {
-                string_pool: data[pool_start..pool_start + pool_len].to_vec(),
-                entries_data: data[entries_start..entries_start + entries_len].to_vec(),
-                reading_index: data[index_start..index_start + index_len].to_vec(),
-            },
-            _mmap: None,
-        })
-    }
-
-    /// Open a dictionary file, using mmap for zero-copy access.
-    ///
-    /// Both the trie and values data are referenced directly from the
-    /// memory-mapped region, eliminating ~60-80MB of heap allocation.
-    pub fn open(path: &Path) -> Result<Self, DictError> {
-        let file = File::open(path)?;
-        // SAFETY: The file is opened read-only and the mapping is immutable.
-        let mmap = unsafe { Mmap::map(&file)? };
-
-        if mmap.len() < 5 {
-            return Err(DictError::InvalidHeader);
-        }
-        if &mmap[..4] != MAGIC {
-            return Err(DictError::InvalidMagic);
-        }
-        if mmap[4] != VERSION {
-            return Err(DictError::UnsupportedVersion(mmap[4]));
-        }
-        if mmap.len() < HEADER_SIZE {
-            return Err(DictError::InvalidHeader);
-        }
-
-        let trie_len = u32::from_ne_bytes(mmap[8..12].try_into().unwrap()) as usize;
-        let pool_len = u32::from_ne_bytes(mmap[12..16].try_into().unwrap()) as usize;
-        let entries_len = u32::from_ne_bytes(mmap[16..20].try_into().unwrap()) as usize;
-        let reading_count = u32::from_ne_bytes(mmap[20..24].try_into().unwrap()) as usize;
-        let index_len = reading_count * SLOT_SIZE;
-
-        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
-        if mmap.len() < expected {
-            return Err(DictError::InvalidHeader);
-        }
-
-        let trie_start = HEADER_SIZE;
-        let pool_start = trie_start + trie_len;
-        let entries_start = pool_start + pool_len;
-        let index_start = entries_start + entries_len;
-
-        // Zero-copy trie from mmap
-        let trie_ref =
-            DoubleArrayRef::<u8>::from_bytes_ref(&mmap[trie_start..trie_start + trie_len])?;
-        // SAFETY: The mmap is stored in self._mmap and will be dropped after trie and values
-        // (Rust drops fields in declaration order: trie, values, _mmap).
-        let trie_ref = unsafe {
-            std::mem::transmute::<DoubleArrayRef<'_, u8>, DoubleArrayRef<'static, u8>>(trie_ref)
-        };
-
-        // SAFETY: The slices reference mmap data. The mmap is stored in self._mmap
-        // and will outlive these references (dropped last due to field order).
-        let string_pool = unsafe {
-            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[pool_start..pool_start + pool_len])
-        };
-        let entries_data = unsafe {
-            std::mem::transmute::<&[u8], &'static [u8]>(
-                &mmap[entries_start..entries_start + entries_len],
-            )
-        };
-        let reading_index = unsafe {
-            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[index_start..index_start + index_len])
-        };
-
-        Ok(Self {
-            trie: TrieStore::MmapRef(trie_ref),
-            values: ValuesStore::MmapRef {
-                string_pool,
-                entries_data,
-                reading_index,
-            },
-            _mmap: Some(mmap),
-        })
-    }
-
-    pub fn save(&self, path: &Path) -> Result<(), DictError> {
-        Ok(fs::write(path, self.to_bytes()?)?)
     }
 
     /// Iterate over all `(reading, entries)` pairs in the trie.

--- a/engine/crates/lex-core/src/dict/trie_dict_io.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict_io.rs
@@ -1,0 +1,176 @@
+use std::fs::{self, File};
+use std::path::Path;
+
+use lexime_trie::{DoubleArray, DoubleArrayRef};
+use memmap2::Mmap;
+
+use super::trie_dict::{
+    TrieDictionary, TrieStore, ValuesStore, HEADER_SIZE, MAGIC, SLOT_SIZE, VERSION,
+};
+use super::DictError;
+
+impl TrieDictionary {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, DictError> {
+        let trie_data = match &self.trie {
+            TrieStore::Owned(da) => da.as_bytes(),
+            TrieStore::MmapRef(_) => {
+                return Err(DictError::Parse(
+                    "cannot serialize mmap-backed dictionary".into(),
+                ));
+            }
+        };
+
+        let pool = self.values.string_pool();
+        let entries = self.values.entries_data();
+        let index = self.values.reading_index();
+
+        let trie_len: u32 = trie_data
+            .len()
+            .try_into()
+            .map_err(|_| DictError::Parse("trie data exceeds u32::MAX".to_string()))?;
+        let pool_len: u32 = pool
+            .len()
+            .try_into()
+            .map_err(|_| DictError::Parse("string pool exceeds u32::MAX".to_string()))?;
+        let entries_len: u32 = entries
+            .len()
+            .try_into()
+            .map_err(|_| DictError::Parse("entries data exceeds u32::MAX".to_string()))?;
+        let reading_count: u32 = (index.len() / SLOT_SIZE) as u32;
+
+        let total = HEADER_SIZE + trie_data.len() + pool.len() + entries.len() + index.len();
+        let mut buf = Vec::with_capacity(total);
+        buf.extend_from_slice(MAGIC);
+        buf.push(VERSION);
+        buf.extend_from_slice(&[0u8; 3]); // reserved
+        buf.extend_from_slice(&trie_len.to_ne_bytes());
+        buf.extend_from_slice(&pool_len.to_ne_bytes());
+        buf.extend_from_slice(&entries_len.to_ne_bytes());
+        buf.extend_from_slice(&reading_count.to_ne_bytes());
+        buf.extend_from_slice(&trie_data);
+        buf.extend_from_slice(pool);
+        buf.extend_from_slice(entries);
+        buf.extend_from_slice(index);
+
+        Ok(buf)
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, DictError> {
+        if data.len() < 5 {
+            return Err(DictError::InvalidHeader);
+        }
+        if &data[..4] != MAGIC {
+            return Err(DictError::InvalidMagic);
+        }
+        if data[4] != VERSION {
+            return Err(DictError::UnsupportedVersion(data[4]));
+        }
+        if data.len() < HEADER_SIZE {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_len = u32::from_ne_bytes(data[8..12].try_into().unwrap()) as usize;
+        let pool_len = u32::from_ne_bytes(data[12..16].try_into().unwrap()) as usize;
+        let entries_len = u32::from_ne_bytes(data[16..20].try_into().unwrap()) as usize;
+        let reading_count = u32::from_ne_bytes(data[20..24].try_into().unwrap()) as usize;
+        let index_len = reading_count * SLOT_SIZE;
+
+        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
+        if data.len() < expected {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_start = HEADER_SIZE;
+        let pool_start = trie_start + trie_len;
+        let entries_start = pool_start + pool_len;
+        let index_start = entries_start + entries_len;
+
+        let trie = DoubleArray::<u8>::from_bytes(&data[trie_start..trie_start + trie_len])?;
+
+        Ok(Self {
+            trie: TrieStore::Owned(trie),
+            values: ValuesStore::Owned {
+                string_pool: data[pool_start..pool_start + pool_len].to_vec(),
+                entries_data: data[entries_start..entries_start + entries_len].to_vec(),
+                reading_index: data[index_start..index_start + index_len].to_vec(),
+            },
+            _mmap: None,
+        })
+    }
+
+    /// Open a dictionary file, using mmap for zero-copy access.
+    ///
+    /// Both the trie and values data are referenced directly from the
+    /// memory-mapped region, eliminating ~60-80MB of heap allocation.
+    pub fn open(path: &Path) -> Result<Self, DictError> {
+        let file = File::open(path)?;
+        // SAFETY: The file is opened read-only and the mapping is immutable.
+        let mmap = unsafe { Mmap::map(&file)? };
+
+        if mmap.len() < 5 {
+            return Err(DictError::InvalidHeader);
+        }
+        if &mmap[..4] != MAGIC {
+            return Err(DictError::InvalidMagic);
+        }
+        if mmap[4] != VERSION {
+            return Err(DictError::UnsupportedVersion(mmap[4]));
+        }
+        if mmap.len() < HEADER_SIZE {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_len = u32::from_ne_bytes(mmap[8..12].try_into().unwrap()) as usize;
+        let pool_len = u32::from_ne_bytes(mmap[12..16].try_into().unwrap()) as usize;
+        let entries_len = u32::from_ne_bytes(mmap[16..20].try_into().unwrap()) as usize;
+        let reading_count = u32::from_ne_bytes(mmap[20..24].try_into().unwrap()) as usize;
+        let index_len = reading_count * SLOT_SIZE;
+
+        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
+        if mmap.len() < expected {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let trie_start = HEADER_SIZE;
+        let pool_start = trie_start + trie_len;
+        let entries_start = pool_start + pool_len;
+        let index_start = entries_start + entries_len;
+
+        // Zero-copy trie from mmap
+        let trie_ref =
+            DoubleArrayRef::<u8>::from_bytes_ref(&mmap[trie_start..trie_start + trie_len])?;
+        // SAFETY: The mmap is stored in self._mmap and will be dropped after trie and values
+        // (Rust drops fields in declaration order: trie, values, _mmap).
+        let trie_ref = unsafe {
+            std::mem::transmute::<DoubleArrayRef<'_, u8>, DoubleArrayRef<'static, u8>>(trie_ref)
+        };
+
+        // SAFETY: The slices reference mmap data. The mmap is stored in self._mmap
+        // and will outlive these references (dropped last due to field order).
+        let string_pool = unsafe {
+            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[pool_start..pool_start + pool_len])
+        };
+        let entries_data = unsafe {
+            std::mem::transmute::<&[u8], &'static [u8]>(
+                &mmap[entries_start..entries_start + entries_len],
+            )
+        };
+        let reading_index = unsafe {
+            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[index_start..index_start + index_len])
+        };
+
+        Ok(Self {
+            trie: TrieStore::MmapRef(trie_ref),
+            values: ValuesStore::MmapRef {
+                string_pool,
+                entries_data,
+                reading_index,
+            },
+            _mmap: Some(mmap),
+        })
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), DictError> {
+        Ok(fs::write(path, self.to_bytes()?)?)
+    }
+}

--- a/engine/crates/lex-core/src/user_history/mod.rs
+++ b/engine/crates/lex-core/src/user_history/mod.rs
@@ -3,14 +3,12 @@
 //! Records confirmed conversions and uses frequency × recency scoring to
 //! promote learned candidates in subsequent sessions.
 
+mod persistence;
 #[cfg(test)]
 mod tests;
 pub mod wal;
 
 use std::collections::HashMap;
-use std::fs;
-use std::io;
-use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -18,15 +16,15 @@ use serde::{Deserialize, Serialize};
 use crate::dict::DictEntry;
 use crate::settings::settings;
 
-const MAGIC: &[u8; 4] = b"LXUD";
-const VERSION: u8 = 1;
+pub(super) const MAGIC: &[u8; 4] = b"LXUD";
+pub(super) const VERSION: u8 = 1;
 
 #[derive(Clone)]
 pub struct UserHistory {
     /// reading → (surface → HistoryEntry)
-    unigrams: HashMap<String, HashMap<String, HistoryEntry>>,
+    pub(super) unigrams: HashMap<String, HashMap<String, HistoryEntry>>,
     /// prev_surface → ((next_reading, next_surface) → HistoryEntry)
-    bigrams: HashMap<String, HashMap<(String, String), HistoryEntry>>,
+    pub(super) bigrams: HashMap<String, HashMap<(String, String), HistoryEntry>>,
 }
 
 #[derive(Clone)]
@@ -46,26 +44,26 @@ impl HistoryEntry {
 
 /// Flat serialization format for bincode.
 #[derive(Serialize, Deserialize)]
-struct UserHistoryData {
-    unigrams: Vec<UnigramRecord>,
-    bigrams: Vec<BigramRecord>,
+pub(super) struct UserHistoryData {
+    pub(super) unigrams: Vec<UnigramRecord>,
+    pub(super) bigrams: Vec<BigramRecord>,
 }
 
 #[derive(Serialize, Deserialize)]
-struct UnigramRecord {
-    reading: String,
-    surface: String,
-    frequency: u32,
-    last_used: u64,
+pub(super) struct UnigramRecord {
+    pub(super) reading: String,
+    pub(super) surface: String,
+    pub(super) frequency: u32,
+    pub(super) last_used: u64,
 }
 
 #[derive(Serialize, Deserialize)]
-struct BigramRecord {
-    prev_surface: String,
-    next_reading: String,
-    next_surface: String,
-    frequency: u32,
-    last_used: u64,
+pub(super) struct BigramRecord {
+    pub(super) prev_surface: String,
+    pub(super) next_reading: String,
+    pub(super) next_surface: String,
+    pub(super) frequency: u32,
+    pub(super) last_used: u64,
 }
 
 pub fn now_epoch() -> u64 {
@@ -242,114 +240,6 @@ impl UserHistory {
         });
 
         with_boost.iter().map(|(_, _, e)| (*e).clone()).collect()
-    }
-
-    /// Serialize to bytes (LXUD format).
-    pub fn to_bytes(&self) -> Result<Vec<u8>, io::Error> {
-        let data = self.to_data();
-        let body = bincode::serialize(&data).map_err(io::Error::other)?;
-
-        let mut buf = Vec::with_capacity(5 + body.len());
-        buf.extend_from_slice(MAGIC);
-        buf.push(VERSION);
-        buf.extend_from_slice(&body);
-        Ok(buf)
-    }
-
-    /// Deserialize from bytes (LXUD format).
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, io::Error> {
-        if bytes.len() < 5 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "too short"));
-        }
-        if &bytes[0..4] != MAGIC {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "bad magic"));
-        }
-        if bytes[4] != VERSION {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "unsupported version",
-            ));
-        }
-        let data: UserHistoryData = bincode::deserialize(&bytes[5..])
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-
-        Ok(Self::from_data(data))
-    }
-
-    /// Atomic write: write to .tmp then rename.
-    pub fn save(&self, path: &Path) -> Result<(), io::Error> {
-        let bytes = self.to_bytes()?;
-        let tmp = path.with_extension("tmp");
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&tmp, &bytes)?;
-        fs::rename(&tmp, path)?;
-        Ok(())
-    }
-
-    /// Open from file, returning empty UserHistory if file doesn't exist.
-    pub fn open(path: &Path) -> Result<Self, io::Error> {
-        match fs::read(path) {
-            Ok(bytes) => Self::from_bytes(&bytes),
-            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::new()),
-            Err(e) => Err(e),
-        }
-    }
-
-    fn to_data(&self) -> UserHistoryData {
-        let mut unigrams = Vec::new();
-        for (reading, inner) in &self.unigrams {
-            for (surface, entry) in inner {
-                unigrams.push(UnigramRecord {
-                    reading: reading.clone(),
-                    surface: surface.clone(),
-                    frequency: entry.frequency,
-                    last_used: entry.last_used,
-                });
-            }
-        }
-
-        let mut bigrams = Vec::new();
-        for (prev, inner) in &self.bigrams {
-            for ((next_r, next_s), entry) in inner {
-                bigrams.push(BigramRecord {
-                    prev_surface: prev.clone(),
-                    next_reading: next_r.clone(),
-                    next_surface: next_s.clone(),
-                    frequency: entry.frequency,
-                    last_used: entry.last_used,
-                });
-            }
-        }
-
-        UserHistoryData { unigrams, bigrams }
-    }
-
-    fn from_data(data: UserHistoryData) -> Self {
-        let mut unigrams: HashMap<String, HashMap<String, HistoryEntry>> = HashMap::new();
-        for rec in data.unigrams {
-            unigrams.entry(rec.reading).or_default().insert(
-                rec.surface,
-                HistoryEntry {
-                    frequency: rec.frequency,
-                    last_used: rec.last_used,
-                },
-            );
-        }
-
-        let mut bigrams: HashMap<String, HashMap<(String, String), HistoryEntry>> = HashMap::new();
-        for rec in data.bigrams {
-            bigrams.entry(rec.prev_surface).or_default().insert(
-                (rec.next_reading, rec.next_surface),
-                HistoryEntry {
-                    frequency: rec.frequency,
-                    last_used: rec.last_used,
-                },
-            );
-        }
-
-        Self { unigrams, bigrams }
     }
 
     /// Evict lowest-score entries when exceeding capacity.

--- a/engine/crates/lex-core/src/user_history/persistence.rs
+++ b/engine/crates/lex-core/src/user_history/persistence.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use super::{
+    BigramRecord, HistoryEntry, UnigramRecord, UserHistory, UserHistoryData, MAGIC, VERSION,
+};
+
+impl UserHistory {
+    /// Serialize to bytes (LXUD format).
+    pub fn to_bytes(&self) -> Result<Vec<u8>, io::Error> {
+        let data = self.to_data();
+        let body = bincode::serialize(&data).map_err(io::Error::other)?;
+
+        let mut buf = Vec::with_capacity(5 + body.len());
+        buf.extend_from_slice(MAGIC);
+        buf.push(VERSION);
+        buf.extend_from_slice(&body);
+        Ok(buf)
+    }
+
+    /// Deserialize from bytes (LXUD format).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, io::Error> {
+        if bytes.len() < 5 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "too short"));
+        }
+        if &bytes[0..4] != MAGIC {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "bad magic"));
+        }
+        if bytes[4] != VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unsupported version",
+            ));
+        }
+        let data: UserHistoryData = bincode::deserialize(&bytes[5..])
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        Ok(Self::from_data(data))
+    }
+
+    /// Atomic write: write to .tmp then rename.
+    pub fn save(&self, path: &Path) -> Result<(), io::Error> {
+        let bytes = self.to_bytes()?;
+        let tmp = path.with_extension("tmp");
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&tmp, &bytes)?;
+        fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Open from file, returning empty UserHistory if file doesn't exist.
+    pub fn open(path: &Path) -> Result<Self, io::Error> {
+        match fs::read(path) {
+            Ok(bytes) => Self::from_bytes(&bytes),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::new()),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub(super) fn to_data(&self) -> UserHistoryData {
+        let mut unigrams = Vec::new();
+        for (reading, inner) in &self.unigrams {
+            for (surface, entry) in inner {
+                unigrams.push(UnigramRecord {
+                    reading: reading.clone(),
+                    surface: surface.clone(),
+                    frequency: entry.frequency,
+                    last_used: entry.last_used,
+                });
+            }
+        }
+
+        let mut bigrams = Vec::new();
+        for (prev, inner) in &self.bigrams {
+            for ((next_r, next_s), entry) in inner {
+                bigrams.push(BigramRecord {
+                    prev_surface: prev.clone(),
+                    next_reading: next_r.clone(),
+                    next_surface: next_s.clone(),
+                    frequency: entry.frequency,
+                    last_used: entry.last_used,
+                });
+            }
+        }
+
+        UserHistoryData { unigrams, bigrams }
+    }
+
+    pub(super) fn from_data(data: UserHistoryData) -> Self {
+        let mut unigrams: std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, HistoryEntry>,
+        > = std::collections::HashMap::new();
+        for rec in data.unigrams {
+            unigrams.entry(rec.reading).or_default().insert(
+                rec.surface,
+                HistoryEntry {
+                    frequency: rec.frequency,
+                    last_used: rec.last_used,
+                },
+            );
+        }
+
+        let mut bigrams: std::collections::HashMap<
+            String,
+            std::collections::HashMap<(String, String), HistoryEntry>,
+        > = std::collections::HashMap::new();
+        for rec in data.bigrams {
+            bigrams.entry(rec.prev_surface).or_default().insert(
+                (rec.next_reading, rec.next_surface),
+                HistoryEntry {
+                    frequency: rec.frequency,
+                    last_used: rec.last_used,
+                },
+            );
+        }
+
+        Self { unigrams, bigrams }
+    }
+}

--- a/engine/crates/lex-session/src/key_handlers.rs
+++ b/engine/crates/lex-session/src/key_handlers.rs
@@ -11,6 +11,13 @@ use super::types::{
 use super::InputSession;
 
 impl InputSession {
+    /// Ensure candidates are generated (lazy generate on first demand).
+    fn ensure_candidates(&mut self) {
+        if self.comp().candidates.is_empty() && !self.comp().kana.is_empty() {
+            self.update_candidates();
+        }
+    }
+
     /// Process a key event. Returns a KeyResponse describing what the caller should do.
     ///
     /// `flags`: bit 0 = shift, bit 1 = has_modifier (Cmd/Ctrl/Opt)
@@ -129,18 +136,12 @@ impl InputSession {
     pub(super) fn handle_composing(&mut self, key_code: u16, text: &str) -> KeyResponse {
         match key_code {
             key::ENTER => {
-                // Lazy generate: ensure candidates are available for commit
-                if self.comp().candidates.is_empty() && !self.comp().kana.is_empty() {
-                    self.update_candidates();
-                }
+                self.ensure_candidates();
                 self.commit_current_state()
             }
 
             key::SPACE => {
-                // Lazy generate: ensure candidates for Space cycling
-                if self.comp().candidates.is_empty() && !self.comp().kana.is_empty() {
-                    self.update_candidates();
-                }
+                self.ensure_candidates();
                 let c = self.comp();
                 if !c.candidates.is_empty() {
                     if c.candidates.selected == 0 && c.candidates.surfaces.len() > 1 {
@@ -159,10 +160,7 @@ impl InputSession {
             }
 
             key::DOWN => {
-                // Lazy generate: ensure candidates for arrow cycling
-                if self.comp().candidates.is_empty() && !self.comp().kana.is_empty() {
-                    self.update_candidates();
-                }
+                self.ensure_candidates();
                 let c = self.comp();
                 if !c.candidates.is_empty() {
                     c.candidates.selected = super::types::cyclic_index(
@@ -177,10 +175,7 @@ impl InputSession {
             }
 
             key::UP => {
-                // Lazy generate: ensure candidates for arrow cycling
-                if self.comp().candidates.is_empty() && !self.comp().kana.is_empty() {
-                    self.update_candidates();
-                }
+                self.ensure_candidates();
                 let c = self.comp();
                 if !c.candidates.is_empty() {
                     c.candidates.selected = super::types::cyclic_index(
@@ -195,10 +190,7 @@ impl InputSession {
             }
 
             key::TAB => {
-                // Tab in composing: always commit
-                if self.comp().candidates.is_empty() && !self.comp().kana.is_empty() {
-                    self.update_candidates();
-                }
+                self.ensure_candidates();
                 self.commit_current_state()
             }
 

--- a/engine/src/api/session.rs
+++ b/engine/src/api/session.rs
@@ -114,10 +114,6 @@ impl LexSession {
     fn set_abc_passthrough(&self, enabled: bool) {
         self.session.lock().unwrap().set_abc_passthrough(enabled);
     }
-
-    fn committed_context(&self) -> String {
-        self.session.lock().unwrap().committed_context()
-    }
 }
 
 impl LexSession {


### PR DESCRIPTION
## Summary
- Extract `ensure_candidates()` helper in `key_handlers.rs`, replacing 5 duplicated lazy-generate patterns (Enter, Space, Down, Up, Tab)
- Split `trie_dict.rs` IO methods (`to_bytes`, `from_bytes`, `open`, `save`) into `trie_dict_io.rs` (~170 lines)
- Split `user_history/mod.rs` persistence methods into `persistence.rs` (~120 lines)
- Remove unused `committed_context()` from FFI layer (`api/session.rs`)
- Add 9 FFI boundary tests for `convert_to_events` in `api/types.rs`

Addresses review items: L3 (ensure_candidates), L4 (file splits), L6 (committedContext FFI removal), M8 (FFI boundary tests)

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — 318 tests pass (249 core + 50 session + 10 engine + 9 cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)