### PR TITLE
fix: increase settings window height

### DIFF
--- a/Sources/SettingsWindowController.swift
+++ b/Sources/SettingsWindowController.swift
@@ -19,10 +19,10 @@ class SettingsWindowController {
 
         let settingsView = SettingsView()
         let hostingView = NSHostingView(rootView: settingsView)
-        hostingView.frame = NSRect(x: 0, y: 0, width: 540, height: 600)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 540, height: 700)
 
         let win = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 540, height: 600),
+            contentRect: NSRect(x: 0, y: 0, width: 540, height: 700),
             styleMask: [.titled, .closable, .resizable],
             backing: .buffered,
             defer: false


### PR DESCRIPTION
## Summary

- Increase settings window initial height from 600px to 700px
- The developer tab's reset buttons were hidden below the fold

## Test plan

- [x] Open settings window → developer tab → all buttons visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)