### PR TITLE
fix: increase nbest from 5 to 20

### DIFF
--- a/engine/crates/lex-core/src/default_settings.toml
+++ b/engine/crates/lex-core/src/default_settings.toml
@@ -19,7 +19,7 @@ max_unigrams = 10000
 max_bigrams = 10000
 
 [candidates]
-nbest = 5
+nbest = 20
 max_results = 20
 
 [keymap]

--- a/engine/crates/lex-core/src/settings.rs
+++ b/engine/crates/lex-core/src/settings.rs
@@ -218,7 +218,7 @@ mod tests {
         assert!((s.history.half_life_hours - 168.0).abs() < f64::EPSILON);
         assert_eq!(s.history.max_unigrams, 10000);
         assert_eq!(s.history.max_bigrams, 10000);
-        assert_eq!(s.candidates.nbest, 5);
+        assert_eq!(s.candidates.nbest, 20);
         assert_eq!(s.candidates.max_results, 20);
         // Keymap defaults
         assert_eq!(s.keymap_get(10, false), Some("]"));


### PR DESCRIPTION
## Summary

- Increase N-best path count from 5 to 20 in `default_settings.toml`
- Multi-segment composite candidates (e.g. 吐かない = 吐か+ない, ranked #7) were missing with nbest=5

## Performance

Benchmarked with a long input (きょうはいいてんきですねわたしはがくせいです):

| nbest | latency |
|-------|---------|
| 5     | ~25ms   |
| 10    | ~24ms   |
| 20    | ~24ms   |

No measurable difference — N-best backtracking is lightweight compared to lattice construction.

## Test plan

- [x] `cargo test --workspace --all-features` pass
- [x] `mise run build && mise run install && mise run reload`
- [x] 「はかない」で「吐かない」が候補に出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)