### PR TITLE
fix: add te-form kanji penalty to prefer hiragana auxiliary verbs

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -902,6 +902,7 @@ version = "0.1.0"
 dependencies = [
  "lex-core",
  "lex-session",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "tracing-appender",

--- a/engine/crates/lex-core/src/default_settings.toml
+++ b/engine/crates/lex-core/src/default_settings.toml
@@ -10,6 +10,7 @@ unknown_word_cost = 10000
 length_variance_weight = 2000
 structure_cost_filter = 4000
 non_independent_kanji_penalty = 3000
+te_form_kanji_penalty = 3500
 
 [history]
 boost_per_use = 3000

--- a/engine/crates/lex-core/src/settings.rs
+++ b/engine/crates/lex-core/src/settings.rs
@@ -96,10 +96,16 @@ pub struct RerankerSettings {
     pub structure_cost_filter: i64,
     #[serde(default = "default_non_independent_kanji_penalty")]
     pub non_independent_kanji_penalty: i64,
+    #[serde(default = "default_te_form_kanji_penalty")]
+    pub te_form_kanji_penalty: i64,
 }
 
 fn default_non_independent_kanji_penalty() -> i64 {
     3000
+}
+
+fn default_te_form_kanji_penalty() -> i64 {
+    3500
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -177,6 +183,7 @@ fn validate(s: &Settings) -> Result<(), SettingsError> {
     check_non_negative!(reranker.length_variance_weight);
     check_non_negative!(reranker.structure_cost_filter);
     check_non_negative!(reranker.non_independent_kanji_penalty);
+    check_non_negative!(reranker.te_form_kanji_penalty);
 
     check_non_negative!(history.boost_per_use);
     check_non_negative!(history.max_boost);
@@ -213,6 +220,7 @@ mod tests {
         assert_eq!(s.reranker.length_variance_weight, 2000);
         assert_eq!(s.reranker.structure_cost_filter, 4000);
         assert_eq!(s.reranker.non_independent_kanji_penalty, 3000);
+        assert_eq!(s.reranker.te_form_kanji_penalty, 3500);
         assert_eq!(s.history.boost_per_use, 3000);
         assert_eq!(s.history.max_boost, 15000);
         assert!((s.history.half_life_hours - 168.0).abs() < f64::EPSILON);

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -243,6 +243,14 @@ tags = ["length-variance", "particle"]
 pr = "#146"
 note = "2-segment paths were incorrectly penalized by length variance"
 
+[[cases]]
+reading = "よんでみる"
+expected = "読んでみる"
+category = "regression"
+tags = ["te-form", "auxiliary-verb"]
+issue = "#173"
+note = "読んで見る が mixed_script_bonus で top-1 になる問題"
+
 # ═══════════════════════════════════════════════════════════════════
 # Katakana loanwords (dictionary entry vs KatakanaRewriter)
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Reranker にて形後の漢字動詞ペナルティ (`te_form_kanji_penalty = 3500`) を追加
- て/で (function word) + 漢字サーフェスのパターンを検出し、ひらがな補助動詞（みる/いく/くる/おく等）を優先
- `mixed_script_bonus` (3000) を相殺しつつマージンを確保

Closes #173

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings` pass
- [x] `cargo test --workspace --all-features` — 全テスト pass（新規テスト 2 件含む）
- [x] `mise run accuracy` — 100% pass (52/52), regression ケース `よんでみる→読んでみる` 追加
- [x] `mise run accuracy-history` — 100% pass (5/5), regression なし
- [x] `mise run build && mise run install && mise run reload` で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)