### PR TITLE
docs: update SPEC.md and README.md to reflect current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ mise run install
 | Tab | 確定 |
 | ↑↓ | 候補を選択 |
 | Backspace | 1 文字削除 |
+| Fn+Delete | 選択中の候補の学習履歴を削除 |
 | Escape | ひらがなで確定 |
 | 英数キー | 英数 (Lexime) に切替 |
 | かなキー | ひらがな (Lexime) に切替 |


### PR DESCRIPTION
## Summary

- Add ForwardDelete (Fn+Delete) to key operation tables in both SPEC.md and README.md
- Document `LearningRecord::Deletion` variant and history deletion mechanics
- Fix `handle_key` signature (was `handle_key(key_code, text, flags)`, now `handle_key(event: LexKeyEvent)`)
- Add `keymap_get` to top-level functions table
- Add `clear()` to `LexUserHistory` description
- Remove `committed_context()` from public API docs (not exported via UniFFI)

## Test plan

- [x] Documentation-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)