### PR TITLE
fix: add top-level permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- ワークフロートップレベルに `permissions: { contents: read }` を追加
- CodeQL の `actions/missing-workflow-permissions` アラート 7件を解消

## Test plan

- [ ] CI が正常に動作すること（permissions 制限で失敗しないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)