### PR TITLE
fix: scale script_cost bonus by reading length

### DIFF
--- a/engine/crates/lex-core/src/converter/cost.rs
+++ b/engine/crates/lex-core/src/converter/cost.rs
@@ -10,7 +10,7 @@ use super::lattice::LatticeNode;
 /// - Contains Latin/ASCII (e.g. death, tie, thai): heavy penalty
 /// - All-katakana (e.g. タラ, オッ): penalty (positive)
 /// - Otherwise (pure hiragana, etc.): no adjustment
-pub fn script_cost(surface: &str) -> i64 {
+pub fn script_cost(surface: &str, reading_chars: usize) -> i64 {
     let s = settings();
     let mut has_kanji = false;
     let mut has_kana = false;
@@ -29,10 +29,11 @@ pub fn script_cost(surface: &str) -> i64 {
             all_katakana = false;
         }
     }
+    let scale = reading_chars.min(3) as i64;
     if has_kanji && has_kana {
-        -s.cost.mixed_script_bonus
+        -s.cost.mixed_script_bonus * scale / 3
     } else if has_kanji {
-        -s.cost.pure_kanji_bonus
+        -s.cost.pure_kanji_bonus * scale / 3
     } else if all_katakana {
         s.cost.katakana_penalty
     } else {

--- a/engine/crates/lex-core/src/converter/explain.rs
+++ b/engine/crates/lex-core/src/converter/explain.rs
@@ -108,7 +108,7 @@ fn explain_segments(scored: &ScoredPath, conn: Option<&ConnectionMatrix>) -> Vec
                 surface: seg.surface.clone(),
                 word_cost: seg.word_cost as i64,
                 segment_penalty: settings().cost.segment_penalty,
-                script_cost: script_cost(&seg.surface),
+                script_cost: script_cost(&seg.surface, seg.reading.chars().count()),
                 connection_cost: connection,
                 left_id: seg.left_id,
                 right_id: seg.right_id,

--- a/engine/crates/lex-core/src/converter/reranker.rs
+++ b/engine/crates/lex-core/src/converter/reranker.rs
@@ -104,7 +104,11 @@ pub fn rerank(paths: &mut Vec<ScoredPath>, conn: Option<&ConnectionMatrix>) {
         }
 
         // Script cost: penalise katakana / Latin surfaces, reward kanji+kana.
-        let total_script: i64 = path.segments.iter().map(|s| script_cost(&s.surface)).sum();
+        let total_script: i64 = path
+            .segments
+            .iter()
+            .map(|s| script_cost(&s.surface, s.reading.chars().count()))
+            .sum();
         path.viterbi_cost += total_script;
 
         // Non-independent kanji penalty: penalise kanji surfaces for 非自立

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -273,6 +273,22 @@ category = "regression"
 tags = ["partial-hiragana"]
 note = "した方がいい は PartialHiraganaRewriter で生成されるが history boost なしでは top-1 にならない"
 
+[[cases]]
+reading = "どれ"
+expected = "どれ"
+category = "regression"
+tags = ["pronoun", "mixed-script-bonus"]
+note = "取れ が mixed_script_bonus で top-1 になっていた — reading長スケーリングで修正"
+
+[[cases]]
+reading = "どれぐらい"
+expected = "どれぐらい"
+category = "regression"
+tags = ["pronoun", "mixed-script-bonus"]
+skip = true
+issue = "#187"
+note = "取れぐらい が top-1 — word_cost + connection cost の差が大きく script scaling だけでは不足"
+
 # ═══════════════════════════════════════════════════════════════════
 # Katakana loanwords (dictionary entry vs KatakanaRewriter)
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `mixed_script_bonus` / `pure_kanji_bonus` を reading のかな文字数でスケーリング (`min(chars, 3) / 3`)
- 短い reading のセグメントで bonus の相対的インパクトが大きすぎて Viterbi の順位を逆転していた問題を修正
- 「どれ」→「取れ」の逆転を解消。「どれぐらい」は connection cost の差が大きく別途対応が必要 (#187)

### スケーリング

| reading 長 | mixed_script_bonus | pure_kanji_bonus |
|-----------|-------------------|-----------------|
| 1 char | -1000 (1/3) | -333 (1/3) |
| 2 chars | -2000 (2/3) | -666 (2/3) |
| 3+ chars | -3000 (full) | -1000 (full) |

Penalty 系 (katakana, latin) はスケーリングなし。

### before/after (accuracy)

```
# before
Pass rate: 98.2% (56/57) — どれ FAIL

# after
Pass rate: 100.0% (57/57) — どれ PASS
```

accuracy-history も全 pass 維持。

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` — 346 passed
- [x] `mise run accuracy` — 100% (57/57, 4 skipped)
- [x] `mise run accuracy-history` — 100% (6/6)
- [x] `mise run build && mise run install && mise run reload` で実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)