### PR TITLE
refactor: PooledStr enum + Range<usize> for positions

### DIFF
--- a/engine/crates/lex-core/src/candidates/standard.rs
+++ b/engine/crates/lex-core/src/candidates/standard.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use tracing::{debug, debug_span};
 
-use crate::converter::{convert_nbest_from_lattice, Lattice};
+use crate::converter::Lattice;
 use crate::dict::connection::ConnectionMatrix;
 use crate::dict::Dictionary;
 use crate::settings::settings;
@@ -27,7 +27,12 @@ pub(super) fn generate_normal_candidates(
     //    lattice search), so it cannot cause fragmentation. Time-decayed
     //    boosts (half-life 168h) prevent stale history from dominating.
     let nbest = settings().candidates.nbest;
-    let paths = convert_nbest_from_lattice(lattice, dict, conn, history, nbest);
+    let ctx = crate::converter::ConversionContext {
+        dict,
+        conn,
+        history,
+    };
+    let paths = ctx.convert_nbest_from_lattice(lattice, nbest);
 
     let mut nbest_paths = Vec::new();
     for path in &paths {

--- a/engine/crates/lex-core/src/converter/constrained.rs
+++ b/engine/crates/lex-core/src/converter/constrained.rs
@@ -12,7 +12,7 @@ use super::viterbi::ConvertedSegment;
 
 /// Confirmed prefix constraint for constrained Viterbi.
 ///
-/// Segments within the prefix are matched by (pos, reading, surface).
+/// Segments within the prefix are matched by (char_range, reading, surface).
 /// Nodes that contradict the fixed prefix receive a prohibitive cost.
 pub(crate) struct PrefixConstraint {
     /// Fixed segments: (char_range, reading, surface)

--- a/engine/crates/lex-core/src/converter/constrained.rs
+++ b/engine/crates/lex-core/src/converter/constrained.rs
@@ -4,17 +4,19 @@
 //! this module constrains the lattice so that those segments are fixed,
 //! allowing re-exploration only of the suffix.
 
+use std::ops::Range;
+
 use super::cost::{CostFunction, DefaultCostFunction};
 use super::lattice::Lattice;
 use super::viterbi::ConvertedSegment;
 
 /// Confirmed prefix constraint for constrained Viterbi.
 ///
-/// Segments within the prefix are matched by (start, end, reading, surface).
+/// Segments within the prefix are matched by (pos, reading, surface).
 /// Nodes that contradict the fixed prefix receive a prohibitive cost.
 pub(crate) struct PrefixConstraint {
-    /// Fixed segments: (start_char, end_char, reading, surface)
-    segments: Vec<(usize, usize, String, String)>,
+    /// Fixed segments: (char_range, reading, surface)
+    segments: Vec<(Range<usize>, String, String)>,
     /// Total character length of the prefix
     prefix_char_end: usize,
 }
@@ -27,7 +29,7 @@ impl PrefixConstraint {
         for seg in confirmed {
             let char_len = seg.reading.chars().count();
             let end = pos + char_len;
-            segments.push((pos, end, seg.reading.clone(), seg.surface.clone()));
+            segments.push((pos..end, seg.reading.clone(), seg.surface.clone()));
             pos = end;
         }
         Self {
@@ -48,9 +50,9 @@ impl PrefixConstraint {
 
     /// Check if a lattice node matches a fixed segment exactly.
     fn matches_fixed_segment(&self, lattice: &Lattice, idx: usize) -> bool {
-        self.segments.iter().any(|(start, end, reading, surface)| {
-            lattice.start(idx) == *start
-                && lattice.end(idx) == *end
+        self.segments.iter().any(|(pos, reading, surface)| {
+            lattice.start(idx) == pos.start
+                && lattice.end(idx) == pos.end
                 && lattice.reading(idx) == *reading
                 && lattice.surface(idx) == *surface
         })
@@ -250,7 +252,7 @@ mod tests {
     fn test_boundary_spanning_node_rejected() {
         // A node that starts in prefix and ends after should be rejected
         let constraint = PrefixConstraint {
-            segments: vec![(0, 2, "きょ".to_string(), "虚".to_string())],
+            segments: vec![(0..2, "きょ".to_string(), "虚".to_string())],
             prefix_char_end: 2,
         };
 
@@ -279,11 +281,11 @@ mod tests {
         assert_eq!(constraint.segments.len(), 2);
         assert_eq!(
             constraint.segments[0],
-            (0, 3, "きょう".to_string(), "今日".to_string())
+            (0..3, "きょう".to_string(), "今日".to_string())
         );
         assert_eq!(
             constraint.segments[1],
-            (3, 4, "は".to_string(), "は".to_string())
+            (3..4, "は".to_string(), "は".to_string())
         );
     }
 }

--- a/engine/crates/lex-core/src/converter/features.rs
+++ b/engine/crates/lex-core/src/converter/features.rs
@@ -180,6 +180,28 @@ pub fn compute_structure_cost(
     sc
 }
 
+/// Configuration for feature extraction shared across paths.
+pub struct FeatureConfig<'a> {
+    pub conn: Option<&'a ConnectionMatrix>,
+    pub dict: Option<&'a dyn Dictionary>,
+    pub structure_cap: i64,
+    pub prefix_floor: i64,
+}
+
+impl FeatureConfig<'_> {
+    /// Extract features from a path.
+    ///
+    /// If `precomputed_structure_cost` is `Some`, reuses the value instead of
+    /// recomputing the transition-cost sum.
+    pub fn extract(
+        &self,
+        path: &ScoredPath,
+        precomputed_structure_cost: Option<i64>,
+    ) -> PathFeatures {
+        extract_features(path, self, precomputed_structure_cost)
+    }
+}
+
 /// Extract features from a path.
 ///
 /// If `precomputed_structure_cost` is `Some`, reuses the value instead of
@@ -187,15 +209,13 @@ pub fn compute_structure_cost(
 /// which already computes it for the hard filter).
 pub fn extract_features(
     path: &ScoredPath,
-    conn: Option<&ConnectionMatrix>,
-    dict: Option<&dyn Dictionary>,
-    structure_cap: i64,
-    prefix_floor: i64,
+    cfg: &FeatureConfig<'_>,
     precomputed_structure_cost: Option<i64>,
 ) -> PathFeatures {
     let mut f = PathFeatures {
-        structure_cost: precomputed_structure_cost
-            .unwrap_or_else(|| compute_structure_cost(path, conn, structure_cap, prefix_floor)),
+        structure_cost: precomputed_structure_cost.unwrap_or_else(|| {
+            compute_structure_cost(path, cfg.conn, cfg.structure_cap, cfg.prefix_floor)
+        }),
         ..Default::default()
     };
 
@@ -206,7 +226,7 @@ pub fn extract_features(
             .iter()
             .filter_map(|s| {
                 let len = s.reading.chars().count() as i64;
-                if len > 1 && !conn.is_some_and(|c| c.is_function_word(s.left_id)) {
+                if len > 1 && !cfg.conn.is_some_and(|c| c.is_function_word(s.left_id)) {
                     Some(len)
                 } else {
                     None
@@ -230,7 +250,7 @@ pub fn extract_features(
         .sum();
 
     // Per-segment features
-    if let Some(c) = conn {
+    if let Some(c) = cfg.conn {
         for (i, seg) in path.segments.iter().enumerate() {
             // Te-form kanji
             let prev = if i > 0 {
@@ -242,7 +262,7 @@ pub fn extract_features(
                 f.te_kanji_count += 1;
             }
             // Single-char kanji content word
-            if is_single_char_kanji_penalised(seg, i, &path.segments, c, dict) {
+            if is_single_char_kanji_penalised(seg, i, &path.segments, c, cfg.dict) {
                 f.single_kanji_count += 1;
             }
         }

--- a/engine/crates/lex-core/src/converter/lattice.rs
+++ b/engine/crates/lex-core/src/converter/lattice.rs
@@ -12,6 +12,14 @@ struct StringSpan {
     len: u16,
 }
 
+/// A string that is either already pooled (reuse existing span) or
+/// new (will be appended to the pool on use).
+#[derive(Clone, Copy)]
+enum PooledStr<'a> {
+    New(&'a str),
+    Reuse(StringSpan),
+}
+
 /// The lattice: all possible segmentations of a kana string.
 ///
 /// Stores node data in Structure-of-Arrays (SoA) layout for cache-friendly
@@ -94,44 +102,40 @@ impl Lattice {
     }
 
     /// Append a node to the lattice.
-    ///
-    /// `reading_span` / `surface_span` allow reusing already-pooled spans
-    /// (e.g. shared reading within a SearchResult, or reading == surface
-    /// for fallback nodes). Pass `None` to append the string to the pool.
-    #[allow(clippy::too_many_arguments)]
     fn push_node(
         &mut self,
-        start: usize,
-        end: usize,
-        reading: &str,
-        reading_span: Option<StringSpan>,
-        surface: &str,
-        surface_span: Option<StringSpan>,
+        pos: std::ops::Range<usize>,
+        reading: PooledStr<'_>,
+        surface: PooledStr<'_>,
         cost: i16,
         left_id: u16,
         right_id: u16,
     ) -> usize {
         let idx = self.costs.len();
 
-        // SoA numeric
-        self.starts.push(start);
-        self.ends.push(end);
+        self.starts.push(pos.start);
+        self.ends.push(pos.end);
         self.costs.push(cost);
         self.left_ids.push(left_id);
         self.right_ids.push(right_id);
 
-        // String pool
-        let r_span = reading_span.unwrap_or_else(|| self.pool_string(reading));
+        let r_span = self.resolve(reading);
+        let s_span = self.resolve(surface);
         self.reading_spans.push(r_span);
-
-        let s_span = surface_span.unwrap_or_else(|| self.pool_string(surface));
         self.surface_spans.push(s_span);
 
-        // Index tables
-        self.nodes_by_end[end].push(idx);
-        self.nodes_by_start[start].push(idx);
+        self.nodes_by_end[pos.end].push(idx);
+        self.nodes_by_start[pos.start].push(idx);
 
         idx
+    }
+
+    /// Resolve a `PooledStr` to a `StringSpan`, appending to the pool if new.
+    fn resolve(&mut self, s: PooledStr<'_>) -> StringSpan {
+        match s {
+            PooledStr::Reuse(span) => span,
+            PooledStr::New(s) => self.pool_string(s),
+        }
     }
 
     /// Append a string to the pool and return its span.
@@ -155,7 +159,12 @@ impl Lattice {
         let mut lattice = Self::new(input, char_count);
         for &(start, end, reading, surface, cost, left_id, right_id) in nodes {
             lattice.push_node(
-                start, end, reading, None, surface, None, cost, left_id, right_id,
+                start..end,
+                PooledStr::New(reading),
+                PooledStr::New(surface),
+                cost,
+                left_id,
+                right_id,
             );
         }
         lattice
@@ -325,18 +334,15 @@ fn add_nodes_for_range(
             lattice.max_reading_chars = lattice.max_reading_chars.max(reading_char_count);
             let reading_span = lattice.pool_string(&result.reading);
             for entry in &result.entries {
-                let surface_span = if entry.surface == result.reading {
-                    Some(reading_span)
+                let surface = if entry.surface == result.reading {
+                    PooledStr::Reuse(reading_span)
                 } else {
-                    None
+                    PooledStr::New(&entry.surface)
                 };
                 lattice.push_node(
-                    start,
-                    end,
-                    &result.reading,
-                    Some(reading_span),
-                    &entry.surface,
-                    surface_span,
+                    start..end,
+                    PooledStr::Reuse(reading_span),
+                    surface,
                     entry.cost,
                     entry.left_id,
                     entry.right_id,
@@ -351,14 +357,11 @@ fn add_nodes_for_range(
             let next_offset = byte_offsets.get(start + 1).copied().unwrap_or(kana.len());
             let ch = &kana[byte_offsets[start]..next_offset];
             // reading == surface for fallback — pool once, reuse for both
-            let span = lattice.pool_string(ch);
+            let span = PooledStr::Reuse(lattice.pool_string(ch));
             lattice.push_node(
-                start,
-                start + 1,
-                ch,
-                Some(span),
-                ch,
-                Some(span),
+                start..start + 1,
+                span,
+                span,
                 settings().cost.unknown_word_cost,
                 0,
                 0,

--- a/engine/crates/lex-core/src/converter/lattice.rs
+++ b/engine/crates/lex-core/src/converter/lattice.rs
@@ -138,6 +138,11 @@ impl Lattice {
         }
     }
 
+    /// Append a string to the pool and return a reusable `PooledStr`.
+    fn pool(&mut self, s: &str) -> PooledStr<'static> {
+        PooledStr::Reuse(self.pool_string(s))
+    }
+
     /// Append a string to the pool and return its span.
     fn pool_string(&mut self, s: &str) -> StringSpan {
         let offset = u32::try_from(self.string_pool.len()).expect("string pool offset overflow");
@@ -332,16 +337,16 @@ fn add_nodes_for_range(
             }
 
             lattice.max_reading_chars = lattice.max_reading_chars.max(reading_char_count);
-            let reading_span = lattice.pool_string(&result.reading);
+            let reading = lattice.pool(&result.reading);
             for entry in &result.entries {
                 let surface = if entry.surface == result.reading {
-                    PooledStr::Reuse(reading_span)
+                    reading
                 } else {
                     PooledStr::New(&entry.surface)
                 };
                 lattice.push_node(
                     start..end,
-                    PooledStr::Reuse(reading_span),
+                    reading,
                     surface,
                     entry.cost,
                     entry.left_id,
@@ -357,7 +362,7 @@ fn add_nodes_for_range(
             let next_offset = byte_offsets.get(start + 1).copied().unwrap_or(kana.len());
             let ch = &kana[byte_offsets[start]..next_offset];
             // reading == surface for fallback — pool once, reuse for both
-            let span = PooledStr::Reuse(lattice.pool_string(ch));
+            let span = lattice.pool(ch);
             lattice.push_node(
                 start..start + 1,
                 span,

--- a/engine/crates/lex-core/src/converter/mod.rs
+++ b/engine/crates/lex-core/src/converter/mod.rs
@@ -116,6 +116,9 @@ pub fn convert(
     conn: Option<&ConnectionMatrix>,
     kana: &str,
 ) -> Vec<ConvertedSegment> {
+    if kana.is_empty() {
+        return Vec::new();
+    }
     let ctx = ConversionContext {
         dict,
         conn,
@@ -132,6 +135,9 @@ pub fn convert_with_history(
     history: &UserHistory,
     kana: &str,
 ) -> Vec<ConvertedSegment> {
+    if kana.is_empty() {
+        return Vec::new();
+    }
     let ctx = ConversionContext {
         dict,
         conn,
@@ -148,6 +154,9 @@ pub fn convert_nbest(
     kana: &str,
     n: usize,
 ) -> Vec<Vec<ConvertedSegment>> {
+    if kana.is_empty() || n == 0 {
+        return Vec::new();
+    }
     let ctx = ConversionContext {
         dict,
         conn,
@@ -165,6 +174,9 @@ pub fn convert_nbest_with_history(
     kana: &str,
     n: usize,
 ) -> Vec<Vec<ConvertedSegment>> {
+    if kana.is_empty() || n == 0 {
+        return Vec::new();
+    }
     let ctx = ConversionContext {
         dict,
         conn,

--- a/engine/crates/lex-core/src/converter/mod.rs
+++ b/engine/crates/lex-core/src/converter/mod.rs
@@ -40,72 +40,70 @@ pub use viterbi::ConvertedSegment;
 #[allow(unused_imports)]
 pub(crate) use viterbi::{viterbi_nbest, RichSegment, ScoredPath};
 
-// ---------------------------------------------------------------------------
-// Primary API — lattice is an explicit parameter
-// ---------------------------------------------------------------------------
-
-/// 1-best conversion from a pre-built lattice.
+/// Shared conversion resources: dictionary, connection matrix, and user history.
 ///
-/// Pass `history` to enable user-history reranking (boosts previously
-/// selected candidates). The oversample factor is higher with history
-/// to ensure enough diversity for the reranker.
-pub fn convert_from_lattice(
-    lattice: &Lattice,
-    dict: &dyn Dictionary,
-    conn: Option<&ConnectionMatrix>,
-    history: Option<&UserHistory>,
-) -> Vec<ConvertedSegment> {
-    if lattice.input.is_empty() {
-        return Vec::new();
-    }
-    let cost_fn = DefaultCostFunction::new(conn);
-    let oversample = if history.is_some() { 30 } else { 10 };
-    let mut paths = viterbi_nbest(lattice, &cost_fn, oversample);
-    postprocess(
-        &mut paths,
-        lattice,
-        conn,
-        Some(dict),
-        history,
-        &lattice.input,
-        1,
-    )
-    .into_iter()
-    .next()
-    .unwrap_or_default()
+/// Groups the `(dict, conn, history)` triple that appears across conversion
+/// and candidate generation APIs.
+pub struct ConversionContext<'a> {
+    pub dict: &'a dyn Dictionary,
+    pub conn: Option<&'a ConnectionMatrix>,
+    pub history: Option<&'a UserHistory>,
 }
 
-/// N-best conversion from a pre-built lattice.
-///
-/// Internally generates more candidates than `n`, applies reranking,
-/// then returns the top `n` distinct paths. With history the oversample
-/// is set to `max(n*3, 50)` for diversity.
-pub fn convert_nbest_from_lattice(
-    lattice: &Lattice,
-    dict: &dyn Dictionary,
-    conn: Option<&ConnectionMatrix>,
-    history: Option<&UserHistory>,
-    n: usize,
-) -> Vec<Vec<ConvertedSegment>> {
-    if lattice.input.is_empty() || n == 0 {
-        return Vec::new();
+impl ConversionContext<'_> {
+    /// Build a lattice from a kana string.
+    pub fn build_lattice(&self, kana: &str) -> Lattice {
+        build_lattice(self.dict, kana)
     }
-    let cost_fn = DefaultCostFunction::new(conn);
-    let oversample = if history.is_some() {
-        (n * 3).max(50)
-    } else {
-        n * 3
-    };
-    let mut paths = viterbi_nbest(lattice, &cost_fn, oversample);
-    postprocess(
-        &mut paths,
-        lattice,
-        conn,
-        Some(dict),
-        history,
-        &lattice.input,
-        n,
-    )
+
+    /// 1-best conversion from a pre-built lattice.
+    pub fn convert_from_lattice(&self, lattice: &Lattice) -> Vec<ConvertedSegment> {
+        if lattice.input.is_empty() {
+            return Vec::new();
+        }
+        let cost_fn = DefaultCostFunction::new(self.conn);
+        let oversample = if self.history.is_some() { 30 } else { 10 };
+        let mut paths = viterbi_nbest(lattice, &cost_fn, oversample);
+        postprocess(
+            &mut paths,
+            lattice,
+            self.conn,
+            Some(self.dict),
+            self.history,
+            &lattice.input,
+            1,
+        )
+        .into_iter()
+        .next()
+        .unwrap_or_default()
+    }
+
+    /// N-best conversion from a pre-built lattice.
+    pub fn convert_nbest_from_lattice(
+        &self,
+        lattice: &Lattice,
+        n: usize,
+    ) -> Vec<Vec<ConvertedSegment>> {
+        if lattice.input.is_empty() || n == 0 {
+            return Vec::new();
+        }
+        let cost_fn = DefaultCostFunction::new(self.conn);
+        let oversample = if self.history.is_some() {
+            (n * 3).max(50)
+        } else {
+            n * 3
+        };
+        let mut paths = viterbi_nbest(lattice, &cost_fn, oversample);
+        postprocess(
+            &mut paths,
+            lattice,
+            self.conn,
+            Some(self.dict),
+            self.history,
+            &lattice.input,
+            n,
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -118,11 +116,13 @@ pub fn convert(
     conn: Option<&ConnectionMatrix>,
     kana: &str,
 ) -> Vec<ConvertedSegment> {
-    if kana.is_empty() {
-        return Vec::new();
-    }
-    let lattice = build_lattice(dict, kana);
-    convert_from_lattice(&lattice, dict, conn, None)
+    let ctx = ConversionContext {
+        dict,
+        conn,
+        history: None,
+    };
+    let lattice = ctx.build_lattice(kana);
+    ctx.convert_from_lattice(&lattice)
 }
 
 /// 1-best conversion with history-aware reranking.
@@ -132,11 +132,13 @@ pub fn convert_with_history(
     history: &UserHistory,
     kana: &str,
 ) -> Vec<ConvertedSegment> {
-    if kana.is_empty() {
-        return Vec::new();
-    }
-    let lattice = build_lattice(dict, kana);
-    convert_from_lattice(&lattice, dict, conn, Some(history))
+    let ctx = ConversionContext {
+        dict,
+        conn,
+        history: Some(history),
+    };
+    let lattice = ctx.build_lattice(kana);
+    ctx.convert_from_lattice(&lattice)
 }
 
 /// Convert a kana string to the N-best segmentations.
@@ -146,11 +148,13 @@ pub fn convert_nbest(
     kana: &str,
     n: usize,
 ) -> Vec<Vec<ConvertedSegment>> {
-    if kana.is_empty() || n == 0 {
-        return Vec::new();
-    }
-    let lattice = build_lattice(dict, kana);
-    convert_nbest_from_lattice(&lattice, dict, conn, None, n)
+    let ctx = ConversionContext {
+        dict,
+        conn,
+        history: None,
+    };
+    let lattice = ctx.build_lattice(kana);
+    ctx.convert_nbest_from_lattice(&lattice, n)
 }
 
 /// N-best conversion with history-aware reranking.
@@ -161,11 +165,13 @@ pub fn convert_nbest_with_history(
     kana: &str,
     n: usize,
 ) -> Vec<Vec<ConvertedSegment>> {
-    if kana.is_empty() || n == 0 {
-        return Vec::new();
-    }
-    let lattice = build_lattice(dict, kana);
-    convert_nbest_from_lattice(&lattice, dict, conn, Some(history), n)
+    let ctx = ConversionContext {
+        dict,
+        conn,
+        history: Some(history),
+    };
+    let lattice = ctx.build_lattice(kana);
+    ctx.convert_nbest_from_lattice(&lattice, n)
 }
 
 // ---------------------------------------------------------------------------
@@ -175,8 +181,7 @@ pub fn convert_nbest_with_history(
 /// N-best Viterbi with a prefix constraint (for speculative decoding).
 #[cfg(feature = "neural")]
 pub(crate) fn convert_nbest_constrained(
-    dict: &dyn Dictionary,
-    conn: Option<&ConnectionMatrix>,
+    ctx: &ConversionContext<'_>,
     kana: &str,
     constraint: &constrained::PrefixConstraint,
     n: usize,
@@ -184,11 +189,11 @@ pub(crate) fn convert_nbest_constrained(
     if kana.is_empty() || n == 0 {
         return Vec::new();
     }
-    let cost_fn = constrained::PrefixConstrainedCost::new(conn, constraint);
-    let lattice = build_lattice(dict, kana);
+    let cost_fn = constrained::PrefixConstrainedCost::new(ctx.conn, constraint);
+    let lattice = build_lattice(ctx.dict, kana);
     let oversample = n * 3;
     let mut paths = viterbi_nbest(&lattice, &cost_fn, oversample);
-    reranker::rerank(&mut paths, conn, Some(dict));
+    reranker::rerank(&mut paths, ctx.conn, Some(ctx.dict));
     paths.truncate(n);
     paths
 }

--- a/engine/crates/lex-core/src/converter/reranker.rs
+++ b/engine/crates/lex-core/src/converter/reranker.rs
@@ -5,7 +5,7 @@ use crate::dict::Dictionary;
 use crate::settings::settings;
 use crate::user_history::UserHistory;
 
-use super::features::{compute_structure_cost, extract_features, FeatureWeights};
+use super::features::{compute_structure_cost, FeatureConfig, FeatureWeights};
 use super::viterbi::ScoredPath;
 
 /// Rerank N-best Viterbi paths by applying post-hoc features.
@@ -83,8 +83,14 @@ pub fn rerank(
     let weights = FeatureWeights::from_settings();
     let need_dict = weights.single_kanji != 0;
     let dict_for_features = if need_dict { dict } else { None };
+    let fcfg = FeatureConfig {
+        conn,
+        dict: dict_for_features,
+        structure_cap: cap,
+        prefix_floor,
+    };
     for (path, &sc) in paths.iter_mut().zip(kept_sc.iter()) {
-        let features = extract_features(path, conn, dict_for_features, cap, prefix_floor, Some(sc));
+        let features = fcfg.extract(path, Some(sc));
         path.viterbi_cost += features.weighted_cost(&weights);
     }
 
@@ -477,7 +483,13 @@ mod tests {
 
         // CW single-char kanji — should count
         let cw_path = path(vec![seg("ね", "根", 1)], 100);
-        let cw_features = extract_features(&cw_path, Some(&conn), None, cap, prefix_floor, None);
+        let fcfg = FeatureConfig {
+            conn: Some(&conn),
+            dict: None,
+            structure_cap: cap,
+            prefix_floor,
+        };
+        let cw_features = fcfg.extract(&cw_path, None);
         assert_eq!(
             cw_features.single_kanji_count, 1,
             "CW single-char kanji should be counted"
@@ -485,7 +497,7 @@ mod tests {
 
         // FW single-char — should NOT count (role checked)
         let fw_path = path(vec![seg("ね", "根", 2)], 100); // FW POS
-        let fw_features = extract_features(&fw_path, Some(&conn), None, cap, prefix_floor, None);
+        let fw_features = fcfg.extract(&fw_path, None);
         assert_eq!(
             fw_features.single_kanji_count, 0,
             "FW should not trigger single-char kanji feature"
@@ -532,7 +544,13 @@ mod tests {
 
         // "は" (FW, not て/で) + "見る" (kanji) — should NOT trigger te-form
         let ha_path = path(vec![seg("は", "は", 2), seg("みる", "見る", 1)], 100);
-        let ha_features = extract_features(&ha_path, Some(&conn), None, cap, prefix_floor, None);
+        let fcfg = FeatureConfig {
+            conn: Some(&conn),
+            dict: None,
+            structure_cap: cap,
+            prefix_floor,
+        };
+        let ha_features = fcfg.extract(&ha_path, None);
         assert_eq!(
             ha_features.te_kanji_count, 0,
             "は is not て/で — no te-form kanji"
@@ -540,7 +558,7 @@ mod tests {
 
         // "で" (FW, て/で) + "見る" (kanji) — should trigger te-form
         let de_path = path(vec![seg("で", "で", 2), seg("みる", "見る", 1)], 100);
-        let de_features = extract_features(&de_path, Some(&conn), None, cap, prefix_floor, None);
+        let de_features = fcfg.extract(&de_path, None);
         assert_eq!(
             de_features.te_kanji_count, 1,
             "で + kanji should trigger te-form"

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -6,6 +6,20 @@ use crate::unicode::{hiragana_to_katakana, is_hiragana, is_kanji, is_katakana};
 use super::lattice::Lattice;
 use super::viterbi::ScoredPath;
 
+/// Position of a segment within a path: its index and character range.
+#[derive(Clone, Copy)]
+struct SegmentPos {
+    idx: usize,
+    start: usize,
+    end: usize,
+}
+
+impl SegmentPos {
+    fn char_range(self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+}
+
 /// A rewriter that generates new candidates from the N-best list.
 ///
 /// Implementations return new candidates without mutating the input.
@@ -172,10 +186,15 @@ impl Rewriter for KanjiVariantRewriter<'_> {
                     continue;
                 }
 
+                let spos = SegmentPos {
+                    idx: seg_idx,
+                    start: seg_start,
+                    end: seg_end,
+                };
                 if seg_char_len == 2 {
-                    self.kanji_variants_exact(path, seg_idx, seg_start, seg_end, &mut new_paths);
+                    self.kanji_variants_exact(path, spos, &mut new_paths);
                 } else {
-                    self.kanji_variants_subsplit(path, seg_idx, seg_start, seg_end, &mut new_paths);
+                    self.kanji_variants_subsplit(path, spos, &mut new_paths);
                 }
             }
         }
@@ -215,14 +234,12 @@ impl KanjiVariantRewriter<'_> {
     fn kanji_variants_exact(
         &self,
         path: &ScoredPath,
-        seg_idx: usize,
-        seg_start: usize,
-        seg_end: usize,
+        seg: SegmentPos,
         new_paths: &mut Vec<ScoredPath>,
     ) {
-        for idx in self.top_kanji_at(seg_start..seg_end) {
+        for idx in self.top_kanji_at(seg.char_range()) {
             let mut new_segments = path.segments.clone();
-            new_segments[seg_idx] = self.lattice.to_rich_segment(idx);
+            new_segments[seg.idx] = self.lattice.to_rich_segment(idx);
             new_paths.push(ScoredPath {
                 segments: new_segments,
                 viterbi_cost: path.viterbi_cost.saturating_add(2000),
@@ -235,17 +252,15 @@ impl KanjiVariantRewriter<'_> {
     fn kanji_variants_subsplit(
         &self,
         path: &ScoredPath,
-        seg_idx: usize,
-        seg_start: usize,
-        seg_end: usize,
+        seg: SegmentPos,
         new_paths: &mut Vec<ScoredPath>,
     ) {
-        let mid = seg_start + 2;
-        if mid >= seg_end {
+        let mid = seg.start + 2;
+        if mid >= seg.end {
             return;
         }
 
-        let kanji_indices = self.top_kanji_at(seg_start..mid);
+        let kanji_indices = self.top_kanji_at(seg.start..mid);
         if kanji_indices.is_empty() {
             return;
         }
@@ -259,7 +274,7 @@ impl KanjiVariantRewriter<'_> {
             .copied()
             .filter(|&idx| {
                 let s = self.lattice.surface(idx);
-                self.lattice.end(idx) == seg_end
+                self.lattice.end(idx) == seg.end
                     && s == self.lattice.reading(idx)
                     && s.chars().all(is_hiragana)
             })
@@ -271,8 +286,8 @@ impl KanjiVariantRewriter<'_> {
         for kanji_idx in kanji_indices {
             let mut new_segments = path.segments.clone();
             let right_seg = self.lattice.to_rich_segment(right_idx);
-            new_segments[seg_idx] = self.lattice.to_rich_segment(kanji_idx);
-            new_segments.insert(seg_idx + 1, right_seg);
+            new_segments[seg.idx] = self.lattice.to_rich_segment(kanji_idx);
+            new_segments.insert(seg.idx + 1, right_seg);
             new_paths.push(ScoredPath {
                 segments: new_segments,
                 viterbi_cost: path.viterbi_cost.saturating_add(2000),

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -194,16 +194,16 @@ impl Rewriter for KanjiVariantRewriter<'_> {
 }
 
 impl KanjiVariantRewriter<'_> {
-    /// Top kanji node indices at [start, end), sorted by cost, up to MAX_KANJI_PER_SEGMENT.
-    fn top_kanji_at(&self, start: usize, end: usize) -> Vec<usize> {
-        let Some(indices) = self.lattice.nodes_by_start.get(start) else {
+    /// Top kanji node indices at `pos`, sorted by cost, up to MAX_KANJI_PER_SEGMENT.
+    fn top_kanji_at(&self, pos: std::ops::Range<usize>) -> Vec<usize> {
+        let Some(indices) = self.lattice.nodes_by_start.get(pos.start) else {
             return Vec::new();
         };
         let mut kanji: Vec<usize> = indices
             .iter()
             .copied()
             .filter(|&idx| {
-                self.lattice.end(idx) == end && self.lattice.surface(idx).chars().any(is_kanji)
+                self.lattice.end(idx) == pos.end && self.lattice.surface(idx).chars().any(is_kanji)
             })
             .collect();
         kanji.sort_by_key(|&idx| self.lattice.cost(idx));
@@ -220,7 +220,7 @@ impl KanjiVariantRewriter<'_> {
         seg_end: usize,
         new_paths: &mut Vec<ScoredPath>,
     ) {
-        for idx in self.top_kanji_at(seg_start, seg_end) {
+        for idx in self.top_kanji_at(seg_start..seg_end) {
             let mut new_segments = path.segments.clone();
             new_segments[seg_idx] = self.lattice.to_rich_segment(idx);
             new_paths.push(ScoredPath {
@@ -245,7 +245,7 @@ impl KanjiVariantRewriter<'_> {
             return;
         }
 
-        let kanji_indices = self.top_kanji_at(seg_start, mid);
+        let kanji_indices = self.top_kanji_at(seg_start..mid);
         if kanji_indices.is_empty() {
             return;
         }
@@ -300,7 +300,7 @@ impl KanjiVariantRewriter<'_> {
 
         for pos in 1..char_count.saturating_sub(2) {
             let end = pos + 2;
-            let kanji_indices = self.top_kanji_at(pos, end);
+            let kanji_indices = self.top_kanji_at(pos..end);
             if kanji_indices.is_empty() {
                 continue;
             }

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -213,7 +213,7 @@ impl Rewriter for KanjiVariantRewriter<'_> {
 }
 
 impl KanjiVariantRewriter<'_> {
-    /// Top kanji node indices at `pos`, sorted by cost, up to MAX_KANJI_PER_SEGMENT.
+    /// Top kanji node indices in span `pos` (`[start, end)`), sorted by cost, up to MAX_KANJI_PER_SEGMENT.
     fn top_kanji_at(&self, pos: std::ops::Range<usize>) -> Vec<usize> {
         let Some(indices) = self.lattice.nodes_by_start.get(pos.start) else {
             return Vec::new();

--- a/engine/crates/lex-core/src/converter/tune.rs
+++ b/engine/crates/lex-core/src/converter/tune.rs
@@ -130,15 +130,15 @@ pub fn precompute_cases(
             paths.extend(reseg);
 
             // Extract features and pair with paths
+            let fcfg = FeatureConfig {
+                conn: Some(conn),
+                dict: Some(dict),
+                structure_cap: cap,
+                prefix_floor,
+            };
             let mut paired: Vec<(ScoredPath, PathFeatures)> = paths
                 .into_iter()
                 .map(|p| {
-                    let fcfg = FeatureConfig {
-                        conn: Some(conn),
-                        dict: Some(dict),
-                        structure_cap: cap,
-                        prefix_floor,
-                    };
                     let f = fcfg.extract(&p, None);
                     (p, f)
                 })

--- a/engine/crates/lex-core/src/converter/tune.rs
+++ b/engine/crates/lex-core/src/converter/tune.rs
@@ -119,6 +119,13 @@ pub fn precompute_cases(
     let filter = s.reranker.structure_cost_filter;
     let cost_fn = DefaultCostFunction::new(Some(conn));
 
+    let fcfg = FeatureConfig {
+        conn: Some(conn),
+        dict: Some(dict),
+        structure_cap: cap,
+        prefix_floor,
+    };
+
     cases
         .iter()
         .map(|(reading, expected)| {
@@ -128,14 +135,6 @@ pub fn precompute_cases(
             // Resegment
             let reseg = resegment::resegment(&paths, &lattice, Some(conn));
             paths.extend(reseg);
-
-            // Extract features and pair with paths
-            let fcfg = FeatureConfig {
-                conn: Some(conn),
-                dict: Some(dict),
-                structure_cap: cap,
-                prefix_floor,
-            };
             let mut paired: Vec<(ScoredPath, PathFeatures)> = paths
                 .into_iter()
                 .map(|p| {

--- a/engine/crates/lex-core/src/converter/tune.rs
+++ b/engine/crates/lex-core/src/converter/tune.rs
@@ -9,7 +9,7 @@ use crate::dict::Dictionary;
 use crate::settings::settings;
 
 use super::cost::DefaultCostFunction;
-use super::features::extract_features;
+use super::features::FeatureConfig;
 pub use super::features::{FeatureWeights, PathFeatures};
 use super::lattice::build_lattice;
 use super::resegment;
@@ -133,7 +133,13 @@ pub fn precompute_cases(
             let mut paired: Vec<(ScoredPath, PathFeatures)> = paths
                 .into_iter()
                 .map(|p| {
-                    let f = extract_features(&p, Some(conn), Some(dict), cap, prefix_floor, None);
+                    let fcfg = FeatureConfig {
+                        conn: Some(conn),
+                        dict: Some(dict),
+                        structure_cap: cap,
+                        prefix_floor,
+                    };
+                    let f = fcfg.extract(&p, None);
                     (p, f)
                 })
                 .collect();

--- a/engine/crates/lex-core/src/neural/speculative.rs
+++ b/engine/crates/lex-core/src/neural/speculative.rs
@@ -133,6 +133,11 @@ pub fn speculative_decode(
     }
 
     // 3. Speculative decode loop
+    let conv_ctx = crate::converter::ConversionContext {
+        dict,
+        conn,
+        history: None,
+    };
     let mut current = draft_segments;
     let mut confirmed_counts = Vec::new();
     let mut converged = false;
@@ -161,13 +166,8 @@ pub fn speculative_decode(
                 // Build constraint and re-search
                 let constraint = PrefixConstraint::from_confirmed(&confirmed_prefix);
                 let viterbi_start = Instant::now();
-                let ctx = crate::converter::ConversionContext {
-                    dict,
-                    conn,
-                    history: None,
-                };
                 let new_paths =
-                    convert_nbest_constrained(&ctx, kana, &constraint, config.nbest_per_pass);
+                    convert_nbest_constrained(&conv_ctx, kana, &constraint, config.nbest_per_pass);
                 viterbi_latency += viterbi_start.elapsed();
 
                 if new_paths.is_empty() {

--- a/engine/crates/lex-core/src/neural/speculative.rs
+++ b/engine/crates/lex-core/src/neural/speculative.rs
@@ -161,8 +161,13 @@ pub fn speculative_decode(
                 // Build constraint and re-search
                 let constraint = PrefixConstraint::from_confirmed(&confirmed_prefix);
                 let viterbi_start = Instant::now();
+                let ctx = crate::converter::ConversionContext {
+                    dict,
+                    conn,
+                    history: None,
+                };
                 let new_paths =
-                    convert_nbest_constrained(dict, conn, kana, &constraint, config.nbest_per_pass);
+                    convert_nbest_constrained(&ctx, kana, &constraint, config.nbest_per_pass);
                 viterbi_latency += viterbi_start.elapsed();
 
                 if new_paths.is_empty() {

--- a/engine/crates/lex-session/src/candidate_gen.rs
+++ b/engine/crates/lex-session/src/candidate_gen.rs
@@ -1,5 +1,5 @@
 use lex_core::candidates::CandidateResponse;
-use lex_core::converter::{build_lattice, convert_from_lattice, ConvertedSegment};
+use lex_core::converter::{build_lattice, ConversionContext, ConvertedSegment};
 
 use super::response::{build_marked_text, build_marked_text_and_candidates};
 use super::types::{AsyncCandidateRequest, KeyResponse, SessionState, MAX_CANDIDATES};
@@ -58,12 +58,12 @@ impl InputSession {
 
             let segments = {
                 let h_guard = self.history.as_ref().and_then(|h| h.read().ok());
-                convert_from_lattice(
-                    &lattice,
-                    &*self.dict,
-                    self.conn.as_deref(),
-                    h_guard.as_deref(),
-                )
+                let ctx = ConversionContext {
+                    dict: &*self.dict,
+                    conn: self.conn.as_deref(),
+                    history: h_guard.as_deref(),
+                };
+                ctx.convert_from_lattice(&lattice)
             };
             let surface: String = segments.iter().map(|s| s.surface.as_str()).collect();
             let c = self.comp();


### PR DESCRIPTION
## Summary

繰り返し出現するパラメータパターンを構造体に抽出し、メソッドを追加。

### 構造体抽出

| 構造体 | 置換対象 | 使用箇所 |
|--------|---------|---------|
| `ConversionContext { dict, conn, history }` | `(dict, conn, history)` 3点セット | converter, candidates, session (9+ call sites) |
| `PooledStr` enum (`New` / `Reuse`) | `(str, Option<StringSpan>)` ペア | lattice push_node |
| `SegmentPos { idx, start, end }` | `(seg_idx, seg_start, seg_end)` | rewriter 2 メソッド |
| `FeatureConfig { conn, dict, structure_cap, prefix_floor }` | 4 引数の spread | reranker, tune (6 call sites) |

### メソッド追加

| 構造体 | メソッド | 効果 |
|--------|---------|------|
| `ConversionContext` | `build_lattice`, `convert_from_lattice`, `convert_nbest_from_lattice` | free function → method |
| `FeatureConfig` | `extract(path, precomputed)` | free function → method |
| `SegmentPos` | `char_range() -> Range<usize>` | `seg.start..seg.end` → `seg.char_range()` |
| `Lattice` | `pool(str) -> PooledStr` | `PooledStr::Reuse(lattice.pool_string(s))` → `lattice.pool(s)` |

### その他

- `Range<usize>` で `(start, end)` ペアを統一 (`push_node`, `top_kanji_at`, `PrefixConstraint.segments`)
- `push_node` params: 10 → 6, `#[allow(clippy::too_many_arguments)]` 削除

## Test plan

- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)