### PR TITLE
refactor: unify explain with postprocess via Observer trait

### DIFF
--- a/engine/crates/lex-core/src/converter/explain.rs
+++ b/engine/crates/lex-core/src/converter/explain.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 
 use crate::dict::connection::ConnectionMatrix;
@@ -9,7 +11,7 @@ use crate::settings::settings;
 use super::cost::{conn_cost, script_cost, DefaultCostFunction};
 use super::features::{is_single_char_kanji_penalised, is_te_form_kanji_penalised};
 use super::lattice::{build_lattice, Lattice};
-use super::reranker;
+use super::postprocess::{postprocess_observed, PostprocessContext, PostprocessObserver};
 use super::viterbi::{viterbi_nbest, ScoredPath};
 
 /// Full diagnostic result for a single reading.
@@ -85,7 +87,11 @@ pub struct ExplainSegment {
     pub right_id: u16,
 }
 
-/// Build a key string from a ScoredPath for cost tracking across reranker passes.
+// ---------------------------------------------------------------------------
+// Observer that captures cost snapshots for explain diagnostics
+// ---------------------------------------------------------------------------
+
+/// Build a key string from a ScoredPath for cost tracking across pipeline stages.
 /// Uses ASCII control characters (US=\x1f, RS=\x1e) as delimiters to avoid
 /// collisions with any reading/surface content.
 fn path_key(path: &ScoredPath) -> String {
@@ -95,6 +101,42 @@ fn path_key(path: &ScoredPath) -> String {
         .collect::<Vec<_>>()
         .join("\x1e")
 }
+
+struct ExplainObserver {
+    /// viterbi_cost before resegment/rerank — the raw Viterbi output.
+    original_costs: HashMap<String, i64>,
+    /// viterbi_cost after resegment + rerank (before history_rerank).
+    post_rerank_costs: HashMap<String, i64>,
+}
+
+impl ExplainObserver {
+    fn new() -> Self {
+        Self {
+            original_costs: HashMap::new(),
+            post_rerank_costs: HashMap::new(),
+        }
+    }
+}
+
+impl PostprocessObserver for ExplainObserver {
+    fn after_viterbi(&mut self, paths: &[ScoredPath]) {
+        self.original_costs = paths
+            .iter()
+            .map(|p| (path_key(p), p.viterbi_cost))
+            .collect();
+    }
+
+    fn after_rerank(&mut self, paths: &[ScoredPath]) {
+        self.post_rerank_costs = paths
+            .iter()
+            .map(|p| (path_key(p), p.viterbi_cost))
+            .collect();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-segment cost breakdown
+// ---------------------------------------------------------------------------
 
 /// Build per-segment cost breakdown from a ScoredPath.
 fn explain_segments(
@@ -152,7 +194,15 @@ fn explain_segments(
         .collect()
 }
 
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 /// Run the full conversion pipeline and capture detailed cost breakdown.
+///
+/// Uses `postprocess_observed` to follow the exact same pipeline as
+/// production conversion, with an observer that records cost snapshots
+/// at each stage for diagnostic output.
 pub fn explain(
     dict: &dyn Dictionary,
     conn: Option<&ConnectionMatrix>,
@@ -160,7 +210,14 @@ pub fn explain(
     kana: &str,
     n: usize,
 ) -> ExplainResult {
-    use std::collections::HashMap;
+    if kana.is_empty() {
+        return ExplainResult {
+            reading: String::new(),
+            lattice_char_count: 0,
+            lattice_nodes: Vec::new(),
+            paths: Vec::new(),
+        };
+    }
 
     let lattice = build_lattice(dict, kana);
     let lattice_nodes: Vec<ExplainNode> = (0..lattice.node_count())
@@ -171,39 +228,31 @@ pub fn explain(
     let oversample = (n * 3).max(50);
     let mut raw_paths = viterbi_nbest(&lattice, &cost_fn, oversample);
 
-    // 1. Record original viterbi costs
-    let original_costs: HashMap<String, i64> = raw_paths
-        .iter()
-        .map(|p| (path_key(p), p.viterbi_cost))
-        .collect();
+    let mut observer = ExplainObserver::new();
+    let ctx = PostprocessContext {
+        lattice: &lattice,
+        conn,
+        dict: Some(dict),
+        history,
+        kana,
+        n,
+    };
+    let final_paths = postprocess_observed(&mut raw_paths, &ctx, &mut observer);
 
-    // 2. Apply real reranker (structure cost + length variance + script cost)
-    reranker::rerank(&mut raw_paths, conn, Some(dict));
-
-    // 3. Record post-rerank costs
-    let post_rerank_costs: HashMap<String, i64> = raw_paths
-        .iter()
-        .map(|p| (path_key(p), p.viterbi_cost))
-        .collect();
-
-    // 4. Apply history reranker
-    if let Some(h) = history {
-        reranker::history_rerank(&mut raw_paths, h);
-    }
-
-    // 5. Truncate to requested count
-    raw_paths.truncate(n);
-
-    // 6. Build explained paths with cost deltas
-    let paths: Vec<ExplainPath> = raw_paths
+    let paths: Vec<ExplainPath> = final_paths
         .iter()
         .map(|scored| {
             let key = path_key(scored);
-            let original = original_costs
+            let original = observer
+                .original_costs
                 .get(&key)
                 .copied()
                 .unwrap_or(scored.viterbi_cost);
-            let post_rerank = post_rerank_costs.get(&key).copied().unwrap_or(original);
+            let post_rerank = observer
+                .post_rerank_costs
+                .get(&key)
+                .copied()
+                .unwrap_or(original);
             let rerank_delta = post_rerank - original;
             let history_boost = post_rerank - scored.viterbi_cost;
             ExplainPath {

--- a/engine/crates/lex-core/src/converter/explain.rs
+++ b/engine/crates/lex-core/src/converter/explain.rs
@@ -202,9 +202,9 @@ pub fn explain(
     kana: &str,
     n: usize,
 ) -> ExplainResult {
-    if kana.is_empty() {
+    if kana.is_empty() || n == 0 {
         return ExplainResult {
-            reading: String::new(),
+            reading: kana.to_string(),
             lattice_char_count: 0,
             lattice_nodes: Vec::new(),
             paths: Vec::new(),

--- a/engine/crates/lex-core/src/converter/explain.rs
+++ b/engine/crates/lex-core/src/converter/explain.rs
@@ -102,20 +102,12 @@ fn path_key(path: &ScoredPath) -> String {
         .join("\x1e")
 }
 
+#[derive(Default)]
 struct ExplainObserver {
     /// viterbi_cost before resegment/rerank — the raw Viterbi output.
     original_costs: HashMap<String, i64>,
     /// viterbi_cost after resegment + rerank (before history_rerank).
     post_rerank_costs: HashMap<String, i64>,
-}
-
-impl ExplainObserver {
-    fn new() -> Self {
-        Self {
-            original_costs: HashMap::new(),
-            post_rerank_costs: HashMap::new(),
-        }
-    }
 }
 
 impl PostprocessObserver for ExplainObserver {
@@ -228,7 +220,7 @@ pub fn explain(
     let oversample = (n * 3).max(50);
     let mut raw_paths = viterbi_nbest(&lattice, &cost_fn, oversample);
 
-    let mut observer = ExplainObserver::new();
+    let mut observer = ExplainObserver::default();
     let ctx = PostprocessContext {
         lattice: &lattice,
         conn,

--- a/engine/crates/lex-core/src/converter/lattice.rs
+++ b/engine/crates/lex-core/src/converter/lattice.rs
@@ -604,6 +604,67 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    fn test_extend_real_dict_junbi() {
+        use crate::dict::TrieDictionary;
+        let dict_path = std::path::PathBuf::from(
+            std::env::var("LEXIME_DICT").unwrap_or_else(|_| "data/lexime.dict".to_string()),
+        );
+        if !dict_path.exists() {
+            eprintln!("skipping: dict not found at {:?}", dict_path);
+            return;
+        }
+        let dict = TrieDictionary::open(&dict_path).unwrap();
+
+        let input = "じゅんびをしましょうか";
+        let chars: Vec<char> = input.chars().collect();
+
+        // Build one char at a time via extend
+        let first: String = chars[..1].iter().collect();
+        let mut lattice = build_lattice(&dict, &first);
+        for i in 2..=chars.len() {
+            let prefix: String = chars[..i].iter().collect();
+            lattice.extend(&dict, &prefix);
+        }
+
+        // Full build
+        let full = build_lattice(&dict, input);
+
+        let ext_set = node_set(&lattice);
+        let full_set = node_set(&full);
+
+        let missing: Vec<_> = full_set.difference(&ext_set).collect();
+        let extra: Vec<_> = ext_set.difference(&full_set).collect();
+
+        if !missing.is_empty() {
+            eprintln!("MISSING from extend ({} nodes):", missing.len());
+            for n in &missing {
+                eprintln!(
+                    "  [{},{}] {} -> {} cost={} L={} R={}",
+                    n.0, n.1, n.5, n.6, n.2, n.3, n.4
+                );
+            }
+        }
+        if !extra.is_empty() {
+            eprintln!("EXTRA in extend ({} nodes):", extra.len());
+            for n in &extra {
+                eprintln!(
+                    "  [{},{}] {} -> {} cost={} L={} R={}",
+                    n.0, n.1, n.5, n.6, n.2, n.3, n.4
+                );
+            }
+        }
+
+        assert_eq!(
+            ext_set,
+            full_set,
+            "extend lattice differs from full build: {} missing, {} extra",
+            missing.len(),
+            extra.len()
+        );
+    }
+
+    #[test]
     fn test_string_pool_reading_dedup() {
         let dict = test_dict();
         let lattice = build_lattice(&dict, "きょう");

--- a/engine/crates/lex-core/src/converter/postprocess.rs
+++ b/engine/crates/lex-core/src/converter/postprocess.rs
@@ -10,6 +10,44 @@ use super::resegment;
 use super::rewriter;
 use super::viterbi::{ConvertedSegment, RichSegment, ScoredPath};
 
+// ---------------------------------------------------------------------------
+// Observer trait — allows explain to capture intermediate cost snapshots
+// without duplicating the pipeline.
+// ---------------------------------------------------------------------------
+
+/// Observer for the postprocess pipeline.
+///
+/// Default methods are no-ops. The generic parameter is monomorphized,
+/// so `NoopObserver` compiles to zero overhead in production.
+pub(crate) trait PostprocessObserver {
+    /// Called after viterbi paths are collected, before resegment/rerank.
+    fn after_viterbi(&mut self, _paths: &[ScoredPath]) {}
+    /// Called after resegment + rerank + hiragana rewriters, before history_rerank.
+    fn after_rerank(&mut self, _paths: &[ScoredPath]) {}
+}
+
+/// No-op observer for production use.
+struct NoopObserver;
+impl PostprocessObserver for NoopObserver {}
+
+// ---------------------------------------------------------------------------
+// Pipeline context — groups the shared parameters
+// ---------------------------------------------------------------------------
+
+/// Shared context for the postprocess pipeline.
+pub(crate) struct PostprocessContext<'a> {
+    pub lattice: &'a Lattice,
+    pub conn: Option<&'a ConnectionMatrix>,
+    pub dict: Option<&'a dyn Dictionary>,
+    pub history: Option<&'a UserHistory>,
+    pub kana: &'a str,
+    pub n: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
 /// Shared post-processing pipeline: resegment → rerank → hiragana_rewrite → history_rerank → take(n) → rewrite → group.
 pub(super) fn postprocess(
     paths: &mut Vec<ScoredPath>,
@@ -20,36 +58,63 @@ pub(super) fn postprocess(
     kana: &str,
     n: usize,
 ) -> Vec<Vec<ConvertedSegment>> {
-    let _span = debug_span!("postprocess", n, paths_in = paths.len()).entered();
+    let ctx = PostprocessContext {
+        lattice,
+        conn,
+        dict,
+        history,
+        kana,
+        n,
+    };
+    postprocess_observed(paths, &ctx, &mut NoopObserver)
+        .into_iter()
+        .map(|p| p.into_segments())
+        .collect()
+}
+
+/// Post-processing pipeline with an observer for diagnostic hooks.
+///
+/// Returns `Vec<ScoredPath>` (before `into_segments()`) so callers like
+/// `explain` can inspect the final segment-level detail.
+pub(crate) fn postprocess_observed<O: PostprocessObserver>(
+    paths: &mut Vec<ScoredPath>,
+    ctx: &PostprocessContext<'_>,
+    observer: &mut O,
+) -> Vec<ScoredPath> {
+    let _span = debug_span!("postprocess", n = ctx.n, paths_in = paths.len()).entered();
+
+    observer.after_viterbi(paths);
 
     // Generate alternative segmentations from the lattice before reranking,
     // so the reranker can compare them on equal footing with Viterbi paths.
-    let reseg_paths = resegment::resegment(paths, lattice, conn);
+    let reseg_paths = resegment::resegment(paths, ctx.lattice, ctx.conn);
     paths.extend(reseg_paths);
 
-    reranker::rerank(paths, conn, dict);
+    reranker::rerank(paths, ctx.conn, ctx.dict);
 
     // Hiragana variant must run BEFORE history_rerank so that whole-path
     // unigram boosts (×5) can promote a previously-selected hiragana variant.
     let hiragana_rw = rewriter::HiraganaVariantRewriter;
     let partial_rw = rewriter::PartialHiraganaRewriter;
-    rewriter::run_rewriters(&[&hiragana_rw, &partial_rw], paths, kana);
+    rewriter::run_rewriters(&[&hiragana_rw, &partial_rw], paths, ctx.kana);
+
+    observer.after_rerank(paths);
 
     // Remember the pure-Viterbi best surface before history reranking.
     // History boosts per-segment unigrams (e.g. き→機 from past "機械") which can
     // push fragmented single-char paths above the statistically correct compound
     // path (e.g. きがし→気がし). Preserving the Viterbi #1 ensures it is always
     // available as a candidate.
-    let viterbi_best_key = if history.is_some() && !paths.is_empty() {
+    let viterbi_best_key = if ctx.history.is_some() && !paths.is_empty() {
         Some(paths[0].surface_key())
     } else {
         None
     };
 
-    if let Some(h) = history {
+    if let Some(h) = ctx.history {
         reranker::history_rerank(paths, h);
     }
-    let mut top: Vec<ScoredPath> = paths.drain(..n.min(paths.len())).collect();
+    let mut top: Vec<ScoredPath> = paths.drain(..ctx.n.min(paths.len())).collect();
 
     // If the Viterbi #1 was pushed out of the top-n by history boosts, pull it
     // back in (after the history-preferred #1, or at 0 if top is empty).
@@ -64,17 +129,19 @@ pub(super) fn postprocess(
     }
     // Truncate Viterbi paths to n before rewriters so that rewriter-added
     // candidates (numeric, katakana) are not immediately pruned.
-    top.truncate(n);
+    top.truncate(ctx.n);
     let numeric_rw = rewriter::NumericRewriter;
     let katakana_rw = rewriter::KatakanaRewriter;
-    let kanji_rw = rewriter::KanjiVariantRewriter { lattice };
-    rewriter::run_rewriters(&[&numeric_rw, &katakana_rw, &kanji_rw], &mut top, kana);
-    if let Some(c) = conn {
+    let kanji_rw = rewriter::KanjiVariantRewriter {
+        lattice: ctx.lattice,
+    };
+    rewriter::run_rewriters(&[&numeric_rw, &katakana_rw, &kanji_rw], &mut top, ctx.kana);
+    if let Some(c) = ctx.conn {
         for path in &mut top {
             group_segments(&mut path.segments, c);
         }
     }
-    top.into_iter().map(|p| p.into_segments()).collect()
+    top
 }
 
 /// Group morpheme-level segments into phrase-level segments (bunsetsu).

--- a/engine/crates/lex-session/src/tests/corpus.rs
+++ b/engine/crates/lex-session/src/tests/corpus.rs
@@ -46,6 +46,7 @@ const REAL_DICT_CORPUS: &[(&str, &str)] = &[
     ("nihongo", "日本語"),
     ("kyouhaiitenki", "今日はいい天気"),
     ("watashihagakuseidesu", "私は学生です"),
+    ("junbiwoshimashouka", "準備をしましょうか"),
 ];
 
 fn real_dict_paths() -> Option<(PathBuf, PathBuf)> {

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -328,7 +328,7 @@ reading = "じゅんびをしましょうか"
 expected = "準備をしましょうか"
 category = "regression"
 tags = ["particle", "auxiliary"]
-note = "script bonus on 1-char kanji (死/化) must not beat hiragana し/か"
+note = "auxiliary し/ましょう/か must not fragment into 島+消化 etc."
 
 # ═══════════════════════════════════════════════════════════════════
 # Katakana loanwords (dictionary entry vs KatakanaRewriter)

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -323,6 +323,13 @@ category = "regression"
 tags = ["kanji-variant"]
 note = "方が is ideal but ほうが is acceptable — 邦画 must not be top-1"
 
+[[cases]]
+reading = "じゅんびをしましょうか"
+expected = "準備をしましょうか"
+category = "regression"
+tags = ["particle", "auxiliary"]
+note = "script bonus on 1-char kanji (死/化) must not beat hiragana し/か"
+
 # ═══════════════════════════════════════════════════════════════════
 # Katakana loanwords (dictionary entry vs KatakanaRewriter)
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- explain が postprocess パイプラインを独自に再実装していたため、resegment / rewriters / group_segments が欠落し、実機の変換結果と乖離していた
- `PostprocessObserver` トレイト + `PostprocessContext` を導入し、explain が `postprocess_observed()` を通じて本番と同一のパイプラインを実行するよう統一
- production パスは `NoopObserver` で monomorphization によりゼロコスト
- `じゅんびをしましょうか` → `準備をしましょうか` の accuracy / HeadlessIME テストケースを追加
- 実辞書での lattice extend vs build_lattice 一致検証テストを追加

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `mise run accuracy` (64/64 pass)
- [x] `mise run accuracy-history` (6/6 pass)
- [x] 実機で「じゅんびをしましょうか」→「準備をしましょうか」を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)