### PR TITLE
chore: bump lexime-trie 0.2.2 -> 0.3.0

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "lexime-trie"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ec7d6a2ef7cb8895de4d5bea8cbd206c37641f79b0e99c9db5d33a830ff5c6"
+checksum = "0fe23327304e6c1bfa7181402976d258ef439a1f72ac9f08e999441572d854bb"
 
 [[package]]
 name = "libc"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -13,7 +13,7 @@ neural = ["candle-core", "candle-nn", "dep:anyhow"]
 
 [dependencies]
 tracing = { workspace = true }
-lexime-trie = "0.2.2"
+lexime-trie = "0.3.0"
 serde = { workspace = true }
 bincode = "1"
 crc32fast = "1"

--- a/engine/quarantine-allowlist.toml
+++ b/engine/quarantine-allowlist.toml
@@ -5,5 +5,5 @@
 [allow]
 candle-core = "0.10.2"
 candle-nn = "0.10.2"
-# Own crate — sibling-chain ordering fix (see supply-chain/audits.toml).
-lexime-trie = "0.2.2"
+# Own crate — v3 binary format + CSR children layout (see supply-chain/audits.toml).
+lexime-trie = "0.3.0"

--- a/engine/supply-chain/audits.toml
+++ b/engine/supply-chain/audits.toml
@@ -6,6 +6,11 @@ who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.1 -> 0.2.2"
 
+[[audits.lexime-trie]]
+who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.2 -> 0.3.0"
+
 [[audits.rustls-webpki]]
 who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
 criteria = "safe-to-deploy"

--- a/mise.toml
+++ b/mise.toml
@@ -58,11 +58,10 @@ depends = ["fetch-dict-mozc"]
 sources = [
   "engine/data/mozc-raw/.stamp",
   "engine/data/mozc-raw/id.def",
-  "engine/crates/lex-cli/src/bin/dictool.rs",
-  "engine/crates/lex-cli/src/commands/dict_ops.rs",
-  "engine/crates/lex-cli/src/dict_source/mod.rs",
-  "engine/crates/lex-cli/src/dict_source/mozc.rs",
-  "engine/crates/lex-cli/src/dict_source/pos_map.rs",
+  "engine/crates/**/*.rs",
+  "engine/crates/**/*.toml",
+  "engine/Cargo.toml",
+  "engine/Cargo.lock",
 ]
 outputs = ["engine/data/lexime-mozc.dict"]
 run = """
@@ -79,9 +78,10 @@ depends = ["fetch-dict-mozc"]
 sources = [
   "engine/data/mozc-raw/connection_single_column.txt",
   "engine/data/mozc-raw/id.def",
-  "engine/crates/lex-cli/src/bin/dictool.rs",
-  "engine/crates/lex-cli/src/commands/dict_ops.rs",
-  "engine/crates/lex-cli/src/dict_source/pos_map.rs",
+  "engine/crates/**/*.rs",
+  "engine/crates/**/*.toml",
+  "engine/Cargo.toml",
+  "engine/Cargo.lock",
 ]
 outputs = ["engine/data/lexime.conn"]
 run = """
@@ -112,13 +112,11 @@ sources = [
   "engine/data/mozc-raw/.stamp",
   "engine/data/mozc-raw/id.def",
   "engine/data/symbols-raw/.stamp",
-  "engine/crates/lex-cli/src/bin/dictool.rs",
-  "engine/crates/lex-cli/src/commands/dict_ops.rs",
-  "engine/crates/lex-cli/src/dict_source/mod.rs",
-  "engine/crates/lex-cli/src/dict_source/mozc.rs",
-  "engine/crates/lex-cli/src/dict_source/pos_map.rs",
-  "engine/crates/lex-cli/src/dict_source/symbols.rs",
   "engine/crates/lex-cli/src/dict_source/symbols.tsv",
+  "engine/crates/**/*.rs",
+  "engine/crates/**/*.toml",
+  "engine/Cargo.toml",
+  "engine/Cargo.lock",
 ]
 outputs = ["engine/data/lexime.dict"]
 run = """


### PR DESCRIPTION
## Summary

- `lexime-trie` 0.2.2 → 0.3.0 bump。バイナリフォーマット v3 化 + CSR children layout 移行版。
- 公開 API は不変で lex-core 側のコード変更は不要。
- v2 形式の `.dict` ファイルは `0.3` で読めなくなるため再ビルド必須。

## 0.3.0 の主なブレーキング変更

- **Binary format v2 削除**。v2 buffer は `TrieError::InvalidVersion` を返すようになった。
- 内部レイアウト: `siblings: Vec<u32>` → CSR `child_offsets` + `children_list`。
  - `predictive_search_2char_prefix` **-47%**（v3 作業の目玉）
  - `from_bytes` +46%（children_list ぶんコピーが増える）、`build` +36%、`probe` +7%
  - `exact_match` / `common_prefix_search` / `from_bytes_ref` は noise 内
- ルートノードが `nodes[1]` に移動、`nodes[0]` は invalid sentinel。
- `CodeMapper::reverse` が `Option<u32>` を返すように（内部のみ）。
- `DoubleArray::build` が `2^31 - 1` を超える key 数を明示的に拒否。
- `validate_cheap` が `child_offsets.len() == nodes.len() + 1` を検証。

## 本リポジトリへの影響

lex-core が触っているのは以下のみで、いずれもシグネチャ不変:

- `DoubleArray::{build, as_bytes, from_bytes}`
- `DoubleArrayRef::from_bytes_ref`
- `exact_match` / `predictive_search` / `common_prefix_search` / `probe`
- `TrieError` の各 variant

したがって Rust 側のコード変更はゼロ。`.dict` は rebuild が必要。

## 変更内容

- `engine/crates/lex-core/Cargo.toml`: `0.2.2` → `0.3.0`
- `engine/Cargo.lock`: lexime-trie v0.3.0 へ更新
- `engine/quarantine-allowlist.toml`: 自作クレートなので 0.3.0 を allowlist（v3 format 変更）
- `engine/supply-chain/audits.toml`: `0.2.2 -> 0.3.0` の audit delta を追加

## サイズへの影響

`mise run dict-clean && mise run dict` で再ビルドした結果:

- `lexime.dict`: **130 MB → 110 MB**（CSR レイアウトが効いて圧縮された）

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `mise run dict-clean && mise run dict`（再ビルド成功）
- [x] `mise run accuracy`: 64/64 pass (100%)
- [x] `mise run accuracy-history`: 6/6 pass (100%)
- [x] `mise run audit`: cargo-deny / cargo-vet / quarantine / build-scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)