### PR TITLE
chore: bump lexime-trie 0.3.0 -> 0.4.0

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "lexime-trie"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe23327304e6c1bfa7181402976d258ef439a1f72ac9f08e999441572d854bb"
+checksum = "6459532e185323ddfdd5cd0918e7979e646744aa7fd8381d363220941b0e5863"
 
 [[package]]
 name = "libc"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -13,7 +13,7 @@ neural = ["candle-core", "candle-nn", "dep:anyhow"]
 
 [dependencies]
 tracing = { workspace = true }
-lexime-trie = "0.3.0"
+lexime-trie = "0.4"
 serde = { workspace = true }
 bincode = "1"
 crc32fast = "1"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -13,7 +13,7 @@ neural = ["candle-core", "candle-nn", "dep:anyhow"]
 
 [dependencies]
 tracing = { workspace = true }
-lexime-trie = "0.4"
+lexime-trie = "=0.4.0"
 serde = { workspace = true }
 bincode = "1"
 crc32fast = "1"

--- a/engine/crates/lex-core/src/dict/connection_io.rs
+++ b/engine/crates/lex-core/src/dict/connection_io.rs
@@ -45,12 +45,11 @@ impl ConnectionMatrix {
             }
         };
 
-        // `num_ids` is `u16`, so the product fits in `u32`; multiplication
-        // on `usize` is overflow-safe on every supported 64-bit target but
-        // can wrap on 32-bit. `checked_mul` surfaces the wrap cleanly.
-        let expected = (num_ids as usize)
-            .checked_mul(num_ids as usize)
-            .ok_or_else(|| DictError::Parse(format!("num_ids {num_ids} overflows usize")))?;
+        // `num_ids` is `u16`, so `num_ids² ≤ u32::MAX` and the product
+        // always fits in `usize` on every supported target (32-bit
+        // included). Plain multiplication is overflow-safe here.
+        let num_ids_usize = num_ids as usize;
+        let expected = num_ids_usize * num_ids_usize;
 
         // Auto-detect format: skip empty lines then peek at first data line
         while lines.peek().is_some_and(|line| line.trim().is_empty()) {
@@ -85,17 +84,20 @@ impl ConnectionMatrix {
                 let cost: i16 = fields[2]
                     .parse()
                     .map_err(|e| DictError::Parse(format!("cost: {e}")))?;
-                // `left_id` and `right_id` come from untrusted text input,
-                // so either can be up to `usize::MAX` and the product with
-                // `num_ids` would wrap. Use checked arithmetic; any
-                // overflow is reported as an out-of-bounds index.
-                let idx = (left_id)
-                    .checked_mul(num_ids as usize)
-                    .and_then(|p| p.checked_add(right_id))
-                    .filter(|&i| i < expected)
-                    .ok_or_else(|| {
-                        DictError::Parse(format!("index out of bounds: ({right_id}, {left_id})"))
-                    })?;
+                // `left_id` / `right_id` come from untrusted text input
+                // and can be anything up to `usize::MAX`. Validate each
+                // against `num_ids` explicitly: a product-only check
+                // (`idx < expected`) misses cases like `num_ids=2,
+                // left_id=0, right_id=2` where idx=2 lands in-range but
+                // refers to cell (1, 0). Once both fields are bounded by
+                // `num_ids ≤ u16::MAX`, `left_id · num_ids + right_id`
+                // provably fits in `u32`, so plain arithmetic is safe.
+                if left_id >= num_ids_usize || right_id >= num_ids_usize {
+                    return Err(DictError::Parse(format!(
+                        "id out of range: left_id={left_id}, right_id={right_id} (num_ids={num_ids})"
+                    )));
+                }
+                let idx = left_id * num_ids_usize + right_id;
                 costs[idx] = cost;
             }
             costs

--- a/engine/crates/lex-core/src/dict/connection_io.rs
+++ b/engine/crates/lex-core/src/dict/connection_io.rs
@@ -84,14 +84,12 @@ impl ConnectionMatrix {
                 let cost: i16 = fields[2]
                     .parse()
                     .map_err(|e| DictError::Parse(format!("cost: {e}")))?;
-                // `left_id` / `right_id` come from untrusted text input
-                // and can be anything up to `usize::MAX`. Validate each
-                // against `num_ids` explicitly: a product-only check
-                // (`idx < expected`) misses cases like `num_ids=2,
-                // left_id=0, right_id=2` where idx=2 lands in-range but
-                // refers to cell (1, 0). Once both fields are bounded by
-                // `num_ids ≤ u16::MAX`, `left_id · num_ids + right_id`
-                // provably fits in `u32`, so plain arithmetic is safe.
+                // Validate each ID against `num_ids` explicitly: a
+                // product-only check (`idx < expected`) would accept
+                // e.g. `num_ids=2, left_id=0, right_id=2` and write
+                // into cell (1, 0) instead of erroring. Once both
+                // fields are bounded, `left · num_ids + right` fits
+                // in `u32`, so plain arithmetic is safe.
                 if left_id >= num_ids_usize || right_id >= num_ids_usize {
                     return Err(DictError::Parse(format!(
                         "id out of range: left_id={left_id}, right_id={right_id} (num_ids={num_ids})"
@@ -183,9 +181,8 @@ impl ConnectionMatrix {
             return Err(DictError::InvalidHeader);
         }
         let roles = data[FIXED_HEADER_SIZE..roles_end].to_vec();
-        // `u16 * u16 * 2` fits in `u64` but *not* in a 32-bit `usize`.
-        // `checked_mul` turns that wrap into a clean `InvalidHeader`
-        // instead of a silent short-read past the buffer.
+        // `u16² · 2` can exceed a 32-bit `usize`; fall back to
+        // `InvalidHeader` instead of silently wrapping.
         let expected_bytes = (num_ids as usize)
             .checked_mul(num_ids as usize)
             .and_then(|n| n.checked_mul(2))
@@ -250,11 +247,9 @@ impl ConnectionMatrix {
 
     /// Helper: re-serialize a Mapped matrix.
     fn to_bytes_from_mapped(&self) -> Vec<u8> {
-        // `num_ids` has already been validated on the way in (loaded by
-        // `validate_header`), so the product is guaranteed to fit in
-        // `usize` on every target we care about. Use saturating
-        // arithmetic for the capacity hint — an exact figure is not
-        // required and we would rather over-allocate than panic.
+        // Saturating arithmetic for the capacity hint — it's advisory
+        // and over-allocating is preferable to panicking on a
+        // worst-case value.
         let n = (self.num_ids as usize).saturating_mul(self.num_ids as usize);
         let cap = FIXED_HEADER_SIZE
             .saturating_add(self.roles.len())

--- a/engine/crates/lex-core/src/dict/connection_io.rs
+++ b/engine/crates/lex-core/src/dict/connection_io.rs
@@ -45,7 +45,12 @@ impl ConnectionMatrix {
             }
         };
 
-        let expected = num_ids as usize * num_ids as usize;
+        // `num_ids` is `u16`, so the product fits in `u32`; multiplication
+        // on `usize` is overflow-safe on every supported 64-bit target but
+        // can wrap on 32-bit. `checked_mul` surfaces the wrap cleanly.
+        let expected = (num_ids as usize)
+            .checked_mul(num_ids as usize)
+            .ok_or_else(|| DictError::Parse(format!("num_ids {num_ids} overflows usize")))?;
 
         // Auto-detect format: skip empty lines then peek at first data line
         while lines.peek().is_some_and(|line| line.trim().is_empty()) {
@@ -80,12 +85,17 @@ impl ConnectionMatrix {
                 let cost: i16 = fields[2]
                     .parse()
                     .map_err(|e| DictError::Parse(format!("cost: {e}")))?;
-                let idx = left_id * num_ids as usize + right_id;
-                if idx >= expected {
-                    return Err(DictError::Parse(format!(
-                        "index out of bounds: ({right_id}, {left_id})"
-                    )));
-                }
+                // `left_id` and `right_id` come from untrusted text input,
+                // so either can be up to `usize::MAX` and the product with
+                // `num_ids` would wrap. Use checked arithmetic; any
+                // overflow is reported as an out-of-bounds index.
+                let idx = (left_id)
+                    .checked_mul(num_ids as usize)
+                    .and_then(|p| p.checked_add(right_id))
+                    .filter(|&i| i < expected)
+                    .ok_or_else(|| {
+                        DictError::Parse(format!("index out of bounds: ({right_id}, {left_id})"))
+                    })?;
                 costs[idx] = cost;
             }
             costs
@@ -164,12 +174,20 @@ impl ConnectionMatrix {
         let num_ids = u16::from_ne_bytes([data[5], data[6]]);
         let fw_min = u16::from_ne_bytes([data[7], data[8]]);
         let fw_max = u16::from_ne_bytes([data[9], data[10]]);
-        let roles_end = FIXED_HEADER_SIZE + num_ids as usize;
+        let roles_end = FIXED_HEADER_SIZE
+            .checked_add(num_ids as usize)
+            .ok_or(DictError::InvalidHeader)?;
         if data.len() < roles_end {
             return Err(DictError::InvalidHeader);
         }
         let roles = data[FIXED_HEADER_SIZE..roles_end].to_vec();
-        let expected_bytes = num_ids as usize * num_ids as usize * 2;
+        // `u16 * u16 * 2` fits in `u64` but *not* in a 32-bit `usize`.
+        // `checked_mul` turns that wrap into a clean `InvalidHeader`
+        // instead of a silent short-read past the buffer.
+        let expected_bytes = (num_ids as usize)
+            .checked_mul(num_ids as usize)
+            .and_then(|n| n.checked_mul(2))
+            .ok_or(DictError::InvalidHeader)?;
         let actual_bytes = data.len() - roles_end;
         if actual_bytes != expected_bytes {
             return Err(DictError::Parse(format!(
@@ -230,8 +248,16 @@ impl ConnectionMatrix {
 
     /// Helper: re-serialize a Mapped matrix.
     fn to_bytes_from_mapped(&self) -> Vec<u8> {
-        let n = self.num_ids as usize * self.num_ids as usize;
-        let mut buf = Vec::with_capacity(FIXED_HEADER_SIZE + self.roles.len() + n * 2);
+        // `num_ids` has already been validated on the way in (loaded by
+        // `validate_header`), so the product is guaranteed to fit in
+        // `usize` on every target we care about. Use saturating
+        // arithmetic for the capacity hint — an exact figure is not
+        // required and we would rather over-allocate than panic.
+        let n = (self.num_ids as usize).saturating_mul(self.num_ids as usize);
+        let cap = FIXED_HEADER_SIZE
+            .saturating_add(self.roles.len())
+            .saturating_add(n.saturating_mul(2));
+        let mut buf = Vec::with_capacity(cap);
         buf.extend_from_slice(MAGIC);
         buf.push(VERSION);
         buf.extend_from_slice(&self.num_ids.to_ne_bytes());

--- a/engine/crates/lex-core/src/dict/tests/connection.rs
+++ b/engine/crates/lex-core/src/dict/tests/connection.rs
@@ -113,6 +113,40 @@ fn test_mecab_triplet_sparse() {
     assert_eq!(m.cost(1, 1), 0);
 }
 
+fn assert_id_out_of_range(text: &str) {
+    match ConnectionMatrix::from_text(text) {
+        Err(DictError::Parse(msg)) => assert!(
+            msg.contains("id out of range"),
+            "unexpected parse error message: {msg}"
+        ),
+        Err(other) => panic!("expected DictError::Parse, got {other:?}"),
+        Ok(_) => panic!("expected error for out-of-range id, got Ok"),
+    }
+}
+
+#[test]
+fn test_mecab_triplet_right_id_out_of_range() {
+    // num_ids=2, right_id=2 is invalid (valid ids are 0..2).
+    // A product-only check (idx=0*2+2=2 < expected=4) would miss this
+    // and silently write to cell (left=1, right=0). Verify the explicit
+    // per-field range check rejects it instead.
+    assert_id_out_of_range("2 2\n2 0 10\n");
+}
+
+#[test]
+fn test_mecab_triplet_left_id_out_of_range() {
+    assert_id_out_of_range("2 2\n0 2 10\n"); // right_id=0, left_id=2
+}
+
+#[test]
+fn test_mecab_triplet_left_id_overflow() {
+    // `left_id = usize::MAX` — used to silently wrap past the index
+    // bounds check via `left_id * num_ids` before the per-field range
+    // check was in place. The per-field check catches this before any
+    // arithmetic runs.
+    assert_id_out_of_range(&format!("2 2\n0 {} 10\n", usize::MAX));
+}
+
 #[test]
 fn test_mecab_triplet_roundtrip() {
     let text = "2 2\n0 0 10\n0 1 20\n1 0 30\n1 1 40\n";

--- a/engine/crates/lex-core/src/dict/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict.rs
@@ -24,15 +24,10 @@ pub(super) struct OwnedMmap {
 }
 
 impl OwnedMmap {
-    /// Constructor. Returns `Err(DictError::InvalidHeader)` if
-    /// `offset + len` overflows `usize` or runs past `mmap.len()`.
-    ///
-    /// Callers in `trie_dict_io` already validate section ranges
-    /// up-front, so errors here indicate either a caller bug or a
-    /// header-validation path that didn't defend against the same
-    /// arithmetic. Returning `Result` instead of panicking keeps the
-    /// loader contract uniform: malformed on-disk data surfaces as
-    /// `DictError`, never a process abort.
+    /// Returns `Err(DictError::InvalidHeader)` if `offset + len`
+    /// overflows `usize` or runs past `mmap.len()`. Fallible rather
+    /// than panicking so malformed on-disk data surfaces as a
+    /// recoverable `DictError`.
     pub(super) fn new(mmap: Arc<Mmap>, offset: usize, len: usize) -> Result<Self, DictError> {
         let end = offset.checked_add(len).ok_or(DictError::InvalidHeader)?;
         if end > mmap.len() {

--- a/engine/crates/lex-core/src/dict/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict.rs
@@ -1,9 +1,48 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use lexime_trie::{DoubleArray, DoubleArrayRef};
+use lexime_trie::{DoubleArray, DoubleArrayBacked, StableBacking, TrieSearch};
 use memmap2::Mmap;
 
 use super::{DictEntry, Dictionary, SearchResult};
+
+/// Self-contained `AsRef<[u8]>` over a memory-mapped slice.
+///
+/// `DoubleArrayBacked` requires its backing type to implement
+/// `StableBacking`, which promises that `as_ref().as_ptr()` stays at
+/// the same address across moves of `Self`. `memmap2::Mmap` satisfies
+/// that in spirit — the OS-backed page mapping does not relocate —
+/// but the crate cannot blanket-impl `StableBacking` for it without
+/// an `memmap2` dep. This newtype wraps `Arc<Mmap>` so the trie
+/// dictionary and the adjacent string-pool / entry / index slices
+/// share the same mapping without copying, and exposes only the
+/// sub-slice for the embedded trie (offset + len are fixed at
+/// construction).
+pub(super) struct OwnedMmap {
+    mmap: Arc<Mmap>,
+    offset: usize,
+    len: usize,
+}
+
+impl OwnedMmap {
+    pub(super) fn new(mmap: Arc<Mmap>, offset: usize, len: usize) -> Self {
+        Self { mmap, offset, len }
+    }
+}
+
+impl AsRef<[u8]> for OwnedMmap {
+    fn as_ref(&self) -> &[u8] {
+        &self.mmap[self.offset..self.offset + self.len]
+    }
+}
+
+// SAFETY: `Arc<Mmap>` keeps the OS-backed page mapping alive for the
+// lifetime of `Self`. Moving `OwnedMmap` moves only the `Arc` handle
+// plus two `usize` fields — the pointer returned by `as_ref()` is
+// derived from the mapping's virtual address plus a fixed offset, so
+// it stays at the same address across moves. `Mmap` has no interior
+// mutability reachable through a shared reference.
+unsafe impl StableBacking for OwnedMmap {}
 
 pub(super) const MAGIC: &[u8; 4] = b"LXDX";
 pub(super) const VERSION: u8 = 4;
@@ -14,7 +53,7 @@ pub(super) const SLOT_SIZE: usize = 6; // entry_offset(4) + count(2)
 
 pub(super) enum TrieStore {
     Owned(DoubleArray<u8>),
-    MmapRef(DoubleArrayRef<'static, u8>),
+    MmapRef(DoubleArrayBacked<u8, OwnedMmap>),
 }
 
 /// Dispatch a method call on the inner trie, avoiding `Box<dyn Iterator>`.
@@ -118,7 +157,7 @@ impl ValuesStore {
 pub struct TrieDictionary {
     pub(super) trie: TrieStore,
     pub(super) values: ValuesStore,
-    pub(super) _mmap: Option<Mmap>,
+    pub(super) _mmap: Option<Arc<Mmap>>,
 }
 
 impl TrieDictionary {

--- a/engine/crates/lex-core/src/dict/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict.rs
@@ -13,26 +13,36 @@ use super::{DictEntry, Dictionary, SearchResult};
 /// the same address across moves of `Self`. `memmap2::Mmap` satisfies
 /// that in spirit — the OS-backed page mapping does not relocate —
 /// but the crate cannot blanket-impl `StableBacking` for it without
-/// an `memmap2` dep. This newtype wraps `Arc<Mmap>` so the trie
+/// a `memmap2` dep. This newtype wraps `Arc<Mmap>` so the trie
 /// dictionary and the adjacent string-pool / entry / index slices
 /// share the same mapping without copying, and exposes only the
-/// sub-slice for the embedded trie (offset + len are fixed at
-/// construction).
+/// sub-slice for the embedded trie (range is fixed at construction).
 pub(super) struct OwnedMmap {
     mmap: Arc<Mmap>,
     offset: usize,
-    len: usize,
+    end: usize,
 }
 
 impl OwnedMmap {
+    /// Constructor. `offset..offset + len` must fit within `mmap.len()`;
+    /// this is an internal invariant — callers in `trie_dict_io` validate
+    /// section ranges up-front, so a violation here is a bug.
     pub(super) fn new(mmap: Arc<Mmap>, offset: usize, len: usize) -> Self {
-        Self { mmap, offset, len }
+        let end = offset
+            .checked_add(len)
+            .expect("OwnedMmap range overflow: offset + len > usize::MAX");
+        assert!(
+            end <= mmap.len(),
+            "OwnedMmap range {offset}..{end} exceeds mmap length {}",
+            mmap.len()
+        );
+        Self { mmap, offset, end }
     }
 }
 
 impl AsRef<[u8]> for OwnedMmap {
     fn as_ref(&self) -> &[u8] {
-        &self.mmap[self.offset..self.offset + self.len]
+        &self.mmap[self.offset..self.end]
     }
 }
 

--- a/engine/crates/lex-core/src/dict/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use lexime_trie::{DoubleArray, DoubleArrayBacked, StableBacking, TrieSearch};
 use memmap2::Mmap;
 
-use super::{DictEntry, Dictionary, SearchResult};
+use super::{DictEntry, DictError, Dictionary, SearchResult};
 
 /// Self-contained `AsRef<[u8]>` over a memory-mapped slice.
 ///
@@ -24,19 +24,21 @@ pub(super) struct OwnedMmap {
 }
 
 impl OwnedMmap {
-    /// Constructor. `offset..offset + len` must fit within `mmap.len()`;
-    /// this is an internal invariant — callers in `trie_dict_io` validate
-    /// section ranges up-front, so a violation here is a bug.
-    pub(super) fn new(mmap: Arc<Mmap>, offset: usize, len: usize) -> Self {
-        let end = offset
-            .checked_add(len)
-            .expect("OwnedMmap range overflow: offset + len > usize::MAX");
-        assert!(
-            end <= mmap.len(),
-            "OwnedMmap range {offset}..{end} exceeds mmap length {}",
-            mmap.len()
-        );
-        Self { mmap, offset, end }
+    /// Constructor. Returns `Err(DictError::InvalidHeader)` if
+    /// `offset + len` overflows `usize` or runs past `mmap.len()`.
+    ///
+    /// Callers in `trie_dict_io` already validate section ranges
+    /// up-front, so errors here indicate either a caller bug or a
+    /// header-validation path that didn't defend against the same
+    /// arithmetic. Returning `Result` instead of panicking keeps the
+    /// loader contract uniform: malformed on-disk data surfaces as
+    /// `DictError`, never a process abort.
+    pub(super) fn new(mmap: Arc<Mmap>, offset: usize, len: usize) -> Result<Self, DictError> {
+        let end = offset.checked_add(len).ok_or(DictError::InvalidHeader)?;
+        if end > mmap.len() {
+            return Err(DictError::InvalidHeader);
+        }
+        Ok(Self { mmap, offset, end })
     }
 }
 

--- a/engine/crates/lex-core/src/dict/trie_dict_io.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict_io.rs
@@ -1,11 +1,12 @@
 use std::fs::{self, File};
 use std::path::Path;
+use std::sync::Arc;
 
-use lexime_trie::{DoubleArray, DoubleArrayRef};
+use lexime_trie::{DoubleArray, DoubleArrayBacked};
 use memmap2::Mmap;
 
 use super::trie_dict::{
-    TrieDictionary, TrieStore, ValuesStore, HEADER_SIZE, MAGIC, SLOT_SIZE, VERSION,
+    OwnedMmap, TrieDictionary, TrieStore, ValuesStore, HEADER_SIZE, MAGIC, SLOT_SIZE, VERSION,
 };
 use super::DictError;
 
@@ -111,7 +112,7 @@ impl TrieDictionary {
     pub fn open(path: &Path) -> Result<Self, DictError> {
         let file = File::open(path)?;
         // SAFETY: The file is opened read-only and the mapping is immutable.
-        let mmap = unsafe { Mmap::map(&file)? };
+        let mmap = Arc::new(unsafe { Mmap::map(&file)? });
 
         if mmap.len() < 5 {
             return Err(DictError::InvalidHeader);
@@ -146,17 +147,27 @@ impl TrieDictionary {
         let entries_start = pool_start + pool_len;
         let index_start = entries_start + entries_len;
 
-        // Zero-copy trie from mmap
-        let trie_ref =
-            DoubleArrayRef::<u8>::from_bytes_ref(&mmap[trie_start..trie_start + trie_len])?;
-        // SAFETY: The mmap is stored in self._mmap and will be dropped after trie and values
-        // (Rust drops fields in declaration order: trie, values, _mmap).
-        let trie_ref = unsafe {
-            std::mem::transmute::<DoubleArrayRef<'_, u8>, DoubleArrayRef<'static, u8>>(trie_ref)
-        };
+        // Zero-copy trie from mmap via DoubleArrayBacked + StableBacking
+        // newtype. The wrapper owns its own `Arc<Mmap>` clone so the
+        // mapping cannot be released out from under it, even if the
+        // surrounding `_mmap` slot is dropped first.
+        let backed = DoubleArrayBacked::<u8, OwnedMmap>::from_backing(OwnedMmap::new(
+            mmap.clone(),
+            trie_start,
+            trie_len,
+        ))?;
 
-        // SAFETY: The slices reference mmap data. The mmap is stored in self._mmap
-        // and will outlive these references (dropped last due to field order).
+        // The string pool / entry records / reading index are plain
+        // byte slices — not lexime-trie types — so `DoubleArrayBacked`
+        // doesn't cover them. Keep the self-referential transmute for
+        // those three; `_mmap` (an `Arc<Mmap>` clone) stays alive as
+        // long as `TrieDictionary`, and is dropped strictly after
+        // `values` thanks to field declaration order.
+        //
+        // SAFETY: Each slice references a region of the mmap. The
+        // `Arc<Mmap>` held in `_mmap` keeps the mapping alive for the
+        // lifetime of `self`; field drop order is trie → values →
+        // `_mmap`, so the mapping outlives every borrow.
         let string_pool = unsafe {
             std::mem::transmute::<&[u8], &'static [u8]>(&mmap[pool_start..pool_start + pool_len])
         };
@@ -170,7 +181,7 @@ impl TrieDictionary {
         };
 
         Ok(Self {
-            trie: TrieStore::MmapRef(trie_ref),
+            trie: TrieStore::MmapRef(backed),
             values: ValuesStore::MmapRef {
                 string_pool,
                 entries_data,

--- a/engine/crates/lex-core/src/dict/trie_dict_io.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict_io.rs
@@ -10,6 +10,57 @@ use super::trie_dict::{
 };
 use super::DictError;
 
+/// Validated byte offsets for each LXDX section.
+///
+/// Produced by [`SectionOffsets::compute`] which checks every step for
+/// `usize` overflow and ensures the last section ends within the buffer.
+/// Once constructed, the offsets are known-good and downstream slicing
+/// is panic-free.
+struct SectionOffsets {
+    trie_start: usize,
+    pool_start: usize,
+    entries_start: usize,
+    index_start: usize,
+    end: usize,
+}
+
+impl SectionOffsets {
+    fn compute(
+        buf_len: usize,
+        trie_len: usize,
+        pool_len: usize,
+        entries_len: usize,
+        reading_count: usize,
+    ) -> Result<Self, DictError> {
+        let index_len = reading_count
+            .checked_mul(SLOT_SIZE)
+            .ok_or(DictError::InvalidHeader)?;
+        let trie_start = HEADER_SIZE;
+        let pool_start = trie_start
+            .checked_add(trie_len)
+            .ok_or(DictError::InvalidHeader)?;
+        let entries_start = pool_start
+            .checked_add(pool_len)
+            .ok_or(DictError::InvalidHeader)?;
+        let index_start = entries_start
+            .checked_add(entries_len)
+            .ok_or(DictError::InvalidHeader)?;
+        let end = index_start
+            .checked_add(index_len)
+            .ok_or(DictError::InvalidHeader)?;
+        if buf_len < end {
+            return Err(DictError::InvalidHeader);
+        }
+        Ok(Self {
+            trie_start,
+            pool_start,
+            entries_start,
+            index_start,
+            end,
+        })
+    }
+}
+
 impl TrieDictionary {
     pub fn to_bytes(&self) -> Result<Vec<u8>, DictError> {
         let trie_data = match &self.trie {
@@ -80,26 +131,18 @@ impl TrieDictionary {
             u32::from_ne_bytes(data[16..20].try_into().expect("4-byte header field")) as usize;
         let reading_count =
             u32::from_ne_bytes(data[20..24].try_into().expect("4-byte header field")) as usize;
-        let index_len = reading_count * SLOT_SIZE;
 
-        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
-        if data.len() < expected {
-            return Err(DictError::InvalidHeader);
-        }
+        let sections =
+            SectionOffsets::compute(data.len(), trie_len, pool_len, entries_len, reading_count)?;
 
-        let trie_start = HEADER_SIZE;
-        let pool_start = trie_start + trie_len;
-        let entries_start = pool_start + pool_len;
-        let index_start = entries_start + entries_len;
-
-        let trie = DoubleArray::<u8>::from_bytes(&data[trie_start..trie_start + trie_len])?;
+        let trie = DoubleArray::<u8>::from_bytes(&data[sections.trie_start..sections.pool_start])?;
 
         Ok(Self {
             trie: TrieStore::Owned(trie),
             values: ValuesStore::Owned {
-                string_pool: data[pool_start..pool_start + pool_len].to_vec(),
-                entries_data: data[entries_start..entries_start + entries_len].to_vec(),
-                reading_index: data[index_start..index_start + index_len].to_vec(),
+                string_pool: data[sections.pool_start..sections.entries_start].to_vec(),
+                entries_data: data[sections.entries_start..sections.index_start].to_vec(),
+                reading_index: data[sections.index_start..sections.end].to_vec(),
             },
             _mmap: None,
         })
@@ -135,17 +178,9 @@ impl TrieDictionary {
             u32::from_ne_bytes(mmap[16..20].try_into().expect("4-byte header field")) as usize;
         let reading_count =
             u32::from_ne_bytes(mmap[20..24].try_into().expect("4-byte header field")) as usize;
-        let index_len = reading_count * SLOT_SIZE;
 
-        let expected = HEADER_SIZE + trie_len + pool_len + entries_len + index_len;
-        if mmap.len() < expected {
-            return Err(DictError::InvalidHeader);
-        }
-
-        let trie_start = HEADER_SIZE;
-        let pool_start = trie_start + trie_len;
-        let entries_start = pool_start + pool_len;
-        let index_start = entries_start + entries_len;
+        let sections =
+            SectionOffsets::compute(mmap.len(), trie_len, pool_len, entries_len, reading_count)?;
 
         // Zero-copy trie from mmap via DoubleArrayBacked + StableBacking
         // newtype. The wrapper owns its own `Arc<Mmap>` clone so the
@@ -153,7 +188,7 @@ impl TrieDictionary {
         // surrounding `_mmap` slot is dropped first.
         let backed = DoubleArrayBacked::<u8, OwnedMmap>::from_backing(OwnedMmap::new(
             mmap.clone(),
-            trie_start,
+            sections.trie_start,
             trie_len,
         ))?;
 
@@ -169,15 +204,17 @@ impl TrieDictionary {
         // lifetime of `self`; field drop order is trie → values →
         // `_mmap`, so the mapping outlives every borrow.
         let string_pool = unsafe {
-            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[pool_start..pool_start + pool_len])
+            std::mem::transmute::<&[u8], &'static [u8]>(
+                &mmap[sections.pool_start..sections.entries_start],
+            )
         };
         let entries_data = unsafe {
             std::mem::transmute::<&[u8], &'static [u8]>(
-                &mmap[entries_start..entries_start + entries_len],
+                &mmap[sections.entries_start..sections.index_start],
             )
         };
         let reading_index = unsafe {
-            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[index_start..index_start + index_len])
+            std::mem::transmute::<&[u8], &'static [u8]>(&mmap[sections.index_start..sections.end])
         };
 
         Ok(Self {

--- a/engine/crates/lex-core/src/dict/trie_dict_io.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict_io.rs
@@ -12,10 +12,11 @@ use super::DictError;
 
 /// Validated byte offsets for each LXDX section.
 ///
-/// Produced by [`SectionOffsets::compute`] which checks every step for
-/// `usize` overflow and ensures the last section ends within the buffer.
-/// Once constructed, the offsets are known-good and downstream slicing
-/// is panic-free.
+/// Produced by [`SectionOffsets::parse`], which also performs the
+/// magic / version / field reads so the two call sites (`open` and
+/// `from_bytes`) share a single source of truth for the on-disk
+/// layout. Once constructed, the offsets are known-good and
+/// downstream slicing is panic-free.
 struct SectionOffsets {
     trie_start: usize,
     pool_start: usize,
@@ -25,13 +26,29 @@ struct SectionOffsets {
 }
 
 impl SectionOffsets {
-    fn compute(
-        buf_len: usize,
-        trie_len: usize,
-        pool_len: usize,
-        entries_len: usize,
-        reading_count: usize,
-    ) -> Result<Self, DictError> {
+    /// Validate the LXDX header in `data` and compute section offsets.
+    fn parse(data: &[u8]) -> Result<Self, DictError> {
+        if data.len() < 5 {
+            return Err(DictError::InvalidHeader);
+        }
+        if &data[..4] != MAGIC {
+            return Err(DictError::InvalidMagic);
+        }
+        if data[4] != VERSION {
+            return Err(DictError::UnsupportedVersion(data[4]));
+        }
+        if data.len() < HEADER_SIZE {
+            return Err(DictError::InvalidHeader);
+        }
+
+        let read_u32 = |range: std::ops::Range<usize>| {
+            u32::from_ne_bytes(data[range].try_into().expect("4-byte header field")) as usize
+        };
+        let trie_len = read_u32(8..12);
+        let pool_len = read_u32(12..16);
+        let entries_len = read_u32(16..20);
+        let reading_count = read_u32(20..24);
+
         let index_len = reading_count
             .checked_mul(SLOT_SIZE)
             .ok_or(DictError::InvalidHeader)?;
@@ -48,7 +65,7 @@ impl SectionOffsets {
         let end = index_start
             .checked_add(index_len)
             .ok_or(DictError::InvalidHeader)?;
-        if buf_len < end {
+        if data.len() < end {
             return Err(DictError::InvalidHeader);
         }
         Ok(Self {
@@ -110,31 +127,7 @@ impl TrieDictionary {
     }
 
     pub fn from_bytes(data: &[u8]) -> Result<Self, DictError> {
-        if data.len() < 5 {
-            return Err(DictError::InvalidHeader);
-        }
-        if &data[..4] != MAGIC {
-            return Err(DictError::InvalidMagic);
-        }
-        if data[4] != VERSION {
-            return Err(DictError::UnsupportedVersion(data[4]));
-        }
-        if data.len() < HEADER_SIZE {
-            return Err(DictError::InvalidHeader);
-        }
-
-        let trie_len =
-            u32::from_ne_bytes(data[8..12].try_into().expect("4-byte header field")) as usize;
-        let pool_len =
-            u32::from_ne_bytes(data[12..16].try_into().expect("4-byte header field")) as usize;
-        let entries_len =
-            u32::from_ne_bytes(data[16..20].try_into().expect("4-byte header field")) as usize;
-        let reading_count =
-            u32::from_ne_bytes(data[20..24].try_into().expect("4-byte header field")) as usize;
-
-        let sections =
-            SectionOffsets::compute(data.len(), trie_len, pool_len, entries_len, reading_count)?;
-
+        let sections = SectionOffsets::parse(data)?;
         let trie = DoubleArray::<u8>::from_bytes(&data[sections.trie_start..sections.pool_start])?;
 
         Ok(Self {
@@ -156,53 +149,24 @@ impl TrieDictionary {
         let file = File::open(path)?;
         // SAFETY: The file is opened read-only and the mapping is immutable.
         let mmap = Arc::new(unsafe { Mmap::map(&file)? });
+        let sections = SectionOffsets::parse(&mmap)?;
+        let trie_len = sections.pool_start - sections.trie_start;
 
-        if mmap.len() < 5 {
-            return Err(DictError::InvalidHeader);
-        }
-        if &mmap[..4] != MAGIC {
-            return Err(DictError::InvalidMagic);
-        }
-        if mmap[4] != VERSION {
-            return Err(DictError::UnsupportedVersion(mmap[4]));
-        }
-        if mmap.len() < HEADER_SIZE {
-            return Err(DictError::InvalidHeader);
-        }
-
-        let trie_len =
-            u32::from_ne_bytes(mmap[8..12].try_into().expect("4-byte header field")) as usize;
-        let pool_len =
-            u32::from_ne_bytes(mmap[12..16].try_into().expect("4-byte header field")) as usize;
-        let entries_len =
-            u32::from_ne_bytes(mmap[16..20].try_into().expect("4-byte header field")) as usize;
-        let reading_count =
-            u32::from_ne_bytes(mmap[20..24].try_into().expect("4-byte header field")) as usize;
-
-        let sections =
-            SectionOffsets::compute(mmap.len(), trie_len, pool_len, entries_len, reading_count)?;
-
-        // Zero-copy trie from mmap via DoubleArrayBacked + StableBacking
-        // newtype. The wrapper owns its own `Arc<Mmap>` clone so the
-        // mapping cannot be released out from under it, even if the
-        // surrounding `_mmap` slot is dropped first.
+        // The trie backing owns its own `Arc<Mmap>` clone so the mapping
+        // cannot be released out from under it even if the surrounding
+        // `_mmap` slot is dropped first.
         let backed = DoubleArrayBacked::<u8, OwnedMmap>::from_backing(OwnedMmap::new(
             mmap.clone(),
             sections.trie_start,
             trie_len,
         )?)?;
 
-        // The string pool / entry records / reading index are plain
-        // byte slices — not lexime-trie types — so `DoubleArrayBacked`
-        // doesn't cover them. Keep the self-referential transmute for
-        // those three; `_mmap` (an `Arc<Mmap>` clone) stays alive as
-        // long as `TrieDictionary`, and is dropped strictly after
-        // `values` thanks to field declaration order.
-        //
-        // SAFETY: Each slice references a region of the mmap. The
-        // `Arc<Mmap>` held in `_mmap` keeps the mapping alive for the
-        // lifetime of `self`; field drop order is trie → values →
-        // `_mmap`, so the mapping outlives every borrow.
+        // SAFETY: `DoubleArrayBacked` only owns the trie slice; the
+        // string pool / entry records / reading index are plain byte
+        // slices so we keep the self-referential transmute for them.
+        // `_mmap` stores a clone of the `Arc<Mmap>` and field drop
+        // order (trie → values → `_mmap`) guarantees the mapping
+        // outlives every borrow.
         let string_pool = unsafe {
             std::mem::transmute::<&[u8], &'static [u8]>(
                 &mmap[sections.pool_start..sections.entries_start],

--- a/engine/crates/lex-core/src/dict/trie_dict_io.rs
+++ b/engine/crates/lex-core/src/dict/trie_dict_io.rs
@@ -190,7 +190,7 @@ impl TrieDictionary {
             mmap.clone(),
             sections.trie_start,
             trie_len,
-        ))?;
+        )?)?;
 
         // The string pool / entry records / reading index are plain
         // byte slices — not lexime-trie types — so `DoubleArrayBacked`

--- a/engine/crates/lex-core/src/romaji/trie.rs
+++ b/engine/crates/lex-core/src/romaji/trie.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use lexime_trie::DoubleArray;
+use lexime_trie::{DoubleArray, TrieSearch};
 
 use super::config::{parse_romaji_toml, RomajiConfigError};
 use super::table::DEFAULT_TOML;

--- a/engine/quarantine-allowlist.toml
+++ b/engine/quarantine-allowlist.toml
@@ -5,5 +5,6 @@
 [allow]
 candle-core = "0.10.2"
 candle-nn = "0.10.2"
-# Own crate — v3 binary format + CSR children layout (see supply-chain/audits.toml).
-lexime-trie = "0.3.0"
+# Own crate — TrieSearch trait split + DoubleArrayBacked owner wrapper
+# (see supply-chain/audits.toml).
+lexime-trie = "0.4.0"

--- a/engine/supply-chain/audits.toml
+++ b/engine/supply-chain/audits.toml
@@ -11,6 +11,11 @@ who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.2 -> 0.3.0"
 
+[[audits.lexime-trie]]
+who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+
 [[audits.rustls-webpki]]
 who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

- `lexime-trie` 0.3.0 → 0.4.0。`TrieSearch` トレイト分離 + `DoubleArrayBacked<L, B: StableBacking>` owner wrapper を導入したバージョン。
- 既存の transmute ベースの自己参照パターンを `DoubleArrayBacked::from_backing(OwnedMmap)` に置換。
- バイナリフォーマットは v3 のまま非変更。`.dict` 再ビルド不要。

## 0.4.0 の主なブレーキング変更

- **`TrieSearch<L>` トレイト化**: `exact_match` / `common_prefix_search` / `predictive_search` / `probe` / `node_slot_count` が `DoubleArray` / `DoubleArrayRef` から剥がされ `TrieSearch` のメソッドに。call site で `use lexime_trie::TrieSearch;` が必要。
- **`num_nodes()` → `node_slot_count()`**: 本リポジトリでは未使用（viterbi.rs の同名ローカル変数は無関係）。
- **`DoubleArrayRef::from_bytes_ref` → `from_bytes`**: 本 PR では呼び出し自体を削除しているため間接対応のみ。
- **`CodeMapper` / `Node` を非公開化、`Label::ALPHABET_SIZE` 削除**: 本リポジトリで触っていないので影響なし。
- **`TrieSearch` は dyn-incompatible** (RPIT)。`&dyn TrieSearch<L>` は使えず generic bound 限定。

## 追加された `DoubleArrayBacked<L, B: StableBacking>`

`DoubleArrayRef` + そのバイト buffer を同じ struct で所有したい時に使う owner wrapper。今まで自前で `mem::transmute<DoubleArrayRef<'_, u8>, DoubleArrayRef<'static, u8>>` していたユースケースを正規のルートに載せ替えられる。

`B: StableBacking` は「`as_ref()` のアドレスが `B` の move をまたいで安定」「共有参照経由で内部可変性を持たない」ことを要求する unsafe trait。`memmap2::Mmap` のような外部型は local newtype にして `unsafe impl` する。

## 本リポジトリへの適用

`TrieDictionary::open()` が保持していた 2 種の transmute のうち、`DoubleArrayRef<'static, u8>` 側を `DoubleArrayBacked` に置換。

### `OwnedMmap` newtype

```rust
pub(super) struct OwnedMmap {
    mmap: Arc<Mmap>,
    offset: usize,
    len: usize,
}

impl AsRef<[u8]> for OwnedMmap {
    fn as_ref(&self) -> &[u8] {
        &self.mmap[self.offset..self.offset + self.len]
    }
}

unsafe impl StableBacking for OwnedMmap {}
```

LXDX コンテナには trie / string pool / entry records / reading index の 4 セクションが順に並んでいる。`OwnedMmap` は trie セクションだけを切り出す形で `as_ref()` を実装し、`Arc<Mmap>` を保持することでマッピングを生かし続ける。

### `_mmap: Option<Mmap>` → `Option<Arc<Mmap>>`

trie backing と values 側 (`string_pool` / `entries_data` / `reading_index`) が同じマッピングを共有する必要があるため `Arc` 化。

### values 側の transmute は残す

string pool / entry records / reading index は単なる `&[u8]` スライスで `lexime-trie` の型ではないため、`DoubleArrayBacked` ではカバーできない。これらは従来通りの `&'static [u8]` transmute を保持。フィールド drop order (trie → values → `_mmap`) は変わらないので mapping が最後まで生存することは保証される。

CHANGELOG のマイグレーションノート 5 にある「`open()` が他の `&'static` slice も持っていればそれらは `DoubleArrayBacked` ではカバーされないので別途 bundling が必要」の部分に該当。今回はスコープ外として維持。

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`: 全 pass
- [x] `mise run accuracy`: 64/64 (100%)
- [x] `mise run accuracy-history`: 6/6 (100%)
- [x] `mise run audit`: cargo-deny / cargo-vet / quarantine / build-scripts pass
- [x] 既存の `.dict` (v3 format) が再ビルドなしで読めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)