### PR TITLE
chore: upgrade lexime-trie to 0.5 with TrieError preservation

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1055,9 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "lexime-trie"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6459532e185323ddfdd5cd0918e7979e646744aa7fd8381d363220941b0e5863"
+version = "0.5.0"
 
 [[package]]
 name = "libc"

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1056,6 +1056,8 @@ dependencies = [
 [[package]]
 name = "lexime-trie"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d3b4b4b1e7abfe138a96bb60b3e00e8272dc3a6044d989e5199344a0ec209b"
 
 [[package]]
 name = "libc"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -13,7 +13,7 @@ neural = ["candle-core", "candle-nn", "dep:anyhow"]
 
 [dependencies]
 tracing = { workspace = true }
-lexime-trie = { version = "=0.5.0", path = "../../../../lexime-trie" }
+lexime-trie = "=0.5.0"
 serde = { workspace = true }
 bincode = "1"
 crc32fast = "1"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -13,7 +13,7 @@ neural = ["candle-core", "candle-nn", "dep:anyhow"]
 
 [dependencies]
 tracing = { workspace = true }
-lexime-trie = "=0.4.0"
+lexime-trie = { version = "=0.5.0", path = "../../../../lexime-trie" }
 serde = { workspace = true }
 bincode = "1"
 crc32fast = "1"

--- a/engine/crates/lex-core/src/candidates/predictive.rs
+++ b/engine/crates/lex-core/src/candidates/predictive.rs
@@ -124,7 +124,7 @@ pub fn generate(
     }
 
     // Sort chained phrases by length descending (longest first = most Copilot-like)
-    chained_phrases.sort_by(|a, b| b.1.cmp(&a.1));
+    chained_phrases.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     // Add chained phrases first (longest completions)
     for (phrase, _) in &chained_phrases {

--- a/engine/crates/lex-core/src/dict/mod.rs
+++ b/engine/crates/lex-core/src/dict/mod.rs
@@ -21,15 +21,10 @@ use std::io;
 /// Unified error type for dictionary and connection-matrix binary I/O.
 ///
 /// Covers loading/saving both `TrieDictionary` (LXDX) and
-/// `ConnectionMatrix` (LXCX) files. Previously these were separate
-/// `DictError` and `ConnectionError` enums with overlapping variants.
-///
-/// Marked `#[non_exhaustive]` so additional failure categories can be
-/// introduced without a breaking change. `InvalidMagic` /
-/// `InvalidHeader` / `UnsupportedVersion` refer to lexime's own LXDX
-/// and LXCX formats; failures bubbling up from the embedded
-/// `lexime_trie` loader come through the dedicated `Trie` variant with
-/// the original `TrieError` preserved.
+/// `ConnectionMatrix` (LXCX) files. `InvalidMagic` / `InvalidHeader` /
+/// `UnsupportedVersion` refer to lexime's own LXDX/LXCX framing;
+/// failures from the embedded `lexime_trie` loader bubble up through
+/// the dedicated `Trie` variant.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum DictError {

--- a/engine/crates/lex-core/src/dict/mod.rs
+++ b/engine/crates/lex-core/src/dict/mod.rs
@@ -23,7 +23,15 @@ use std::io;
 /// Covers loading/saving both `TrieDictionary` (LXDX) and
 /// `ConnectionMatrix` (LXCX) files. Previously these were separate
 /// `DictError` and `ConnectionError` enums with overlapping variants.
+///
+/// Marked `#[non_exhaustive]` so additional failure categories can be
+/// introduced without a breaking change. `InvalidMagic` /
+/// `InvalidHeader` / `UnsupportedVersion` refer to lexime's own LXDX
+/// and LXCX formats; failures bubbling up from the embedded
+/// `lexime_trie` loader come through the dedicated `Trie` variant with
+/// the original `TrieError` preserved.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DictError {
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
@@ -37,6 +45,13 @@ pub enum DictError {
     #[error("unsupported version: {0}")]
     UnsupportedVersion(u8),
 
+    /// Failure bubbled up from the `lexime_trie` loader for the embedded
+    /// trie section. Preserves the original `TrieError` variant so
+    /// callers can distinguish (e.g.) alignment problems from structural
+    /// corruption without string-matching on messages.
+    #[error("trie load failed: {0}")]
+    Trie(#[from] lexime_trie::TrieError),
+
     #[error("serialization error: {0}")]
     Serialize(bincode::Error),
 
@@ -45,17 +60,6 @@ pub enum DictError {
 
     #[error("parse error: {0}")]
     Parse(String),
-}
-
-impl From<lexime_trie::TrieError> for DictError {
-    fn from(e: lexime_trie::TrieError) -> Self {
-        match e {
-            lexime_trie::TrieError::InvalidMagic => DictError::InvalidMagic,
-            lexime_trie::TrieError::InvalidVersion => DictError::UnsupportedVersion(0),
-            lexime_trie::TrieError::TruncatedData => DictError::InvalidHeader,
-            lexime_trie::TrieError::MisalignedData => DictError::Parse("misaligned data".into()),
-        }
-    }
 }
 
 pub struct SearchResult {

--- a/engine/crates/lex-core/src/dict/tests/trie_dict.rs
+++ b/engine/crates/lex-core/src/dict/tests/trie_dict.rs
@@ -163,6 +163,39 @@ fn test_unsupported_version() {
 }
 
 #[test]
+fn test_embedded_trie_error_preserved() {
+    // Failures from the embedded `lexime_trie` loader must bubble up
+    // through `DictError::Trie(_)` with the original `TrieError`
+    // variant (and payload) intact, not flattened onto `InvalidHeader`
+    // / `UnsupportedVersion(0)` / `Parse(_)` as in the pre-0.5 mapping.
+    //
+    // Construct a valid LXDX outer frame with `trie_len = 24` pointing
+    // at an LXTR header that declares version 99. `DictError::Trie`
+    // must carry `TrieError::InvalidVersion(99)`.
+    use lexime_trie::TrieError;
+
+    let mut bytes = Vec::with_capacity(48);
+    bytes.extend_from_slice(b"LXDX");
+    bytes.push(4); // LXDX VERSION
+    bytes.extend_from_slice(&[0, 0, 0]); // reserved
+    bytes.extend_from_slice(&24u32.to_ne_bytes()); // trie_len
+    bytes.extend_from_slice(&0u32.to_ne_bytes()); // pool_len
+    bytes.extend_from_slice(&0u32.to_ne_bytes()); // entries_len
+    bytes.extend_from_slice(&0u32.to_ne_bytes()); // reading_count
+
+    bytes.extend_from_slice(b"LXTR");
+    bytes.push(99); // bogus LXTR version
+    bytes.extend_from_slice(&[0u8; 19]); // rest of LXTR 24-byte header
+
+    match TrieDictionary::from_bytes(&bytes) {
+        Err(DictError::Trie(TrieError::InvalidVersion(99))) => {}
+        Err(DictError::Trie(other)) => panic!("expected InvalidVersion(99), got Trie({other:?})"),
+        Err(other) => panic!("expected DictError::Trie, got {other:?}"),
+        Ok(_) => panic!("expected error on corrupt embedded trie"),
+    }
+}
+
+#[test]
 fn test_predict_ranked_cost_order() {
     let dict = sample_dict();
     let results = dict.predict_ranked("かん", 100, 200);

--- a/engine/crates/lex-core/src/numeric.rs
+++ b/engine/crates/lex-core/src/numeric.rs
@@ -127,11 +127,9 @@ fn consume_digit_or_rendaku_prefix(s: &str, unit_val: u64) -> Option<(u64, usize
                 return Some((8, "はっ".len()));
             }
         }
-        1000 => {
+        1000 if s.starts_with("はっ") => {
             // はっせん(8000)
-            if s.starts_with("はっ") {
-                return Some((8, "はっ".len()));
-            }
+            return Some((8, "はっ".len()));
         }
         10 => {
             // じっ as prefix for じゅう (じっ = 10, used in じっかい etc., but also standalone)

--- a/engine/crates/lex-core/src/user_history/mod.rs
+++ b/engine/crates/lex-core/src/user_history/mod.rs
@@ -205,7 +205,7 @@ impl UserHistory {
             .map(|((reading, surface), entry)| (reading.clone(), surface.clone(), entry.boost(now)))
             .filter(|(_, _, boost)| *boost > 0)
             .collect();
-        results.sort_by(|a, b| b.2.cmp(&a.2));
+        results.sort_by_key(|b| std::cmp::Reverse(b.2));
         results
     }
 
@@ -220,7 +220,7 @@ impl UserHistory {
             .map(|(surface, entry)| (surface.clone(), entry.boost(now)))
             .filter(|(_, boost)| *boost > 0)
             .collect();
-        results.sort_by(|a, b| b.1.cmp(&a.1));
+        results.sort_by_key(|b| std::cmp::Reverse(b.1));
         results
     }
 

--- a/engine/quarantine-allowlist.toml
+++ b/engine/quarantine-allowlist.toml
@@ -5,6 +5,6 @@
 [allow]
 candle-core = "0.10.2"
 candle-nn = "0.10.2"
-# Own crate — TrieSearch trait split + DoubleArrayBacked owner wrapper
+# Own crate — TrieError non_exhaustive + InvalidVersion(u8) + InvalidStructure
 # (see supply-chain/audits.toml).
-lexime-trie = "0.4.0"
+lexime-trie = "0.5.0"

--- a/engine/supply-chain/audits.toml
+++ b/engine/supply-chain/audits.toml
@@ -16,6 +16,11 @@ who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
 
+[[audits.lexime-trie]]
+who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.0"
+
 [[audits.rustls-webpki]]
 who = "SAKAI, Kazuaki <kaz.july.7@gmail.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

- lexime-trie 0.5.0 の TrieError 再設計に追随
- `DictError::Trie(#[from] lexime_trie::TrieError)` を追加し、旧い手書き `impl From<TrieError>` の lossy な変換テーブルを削除
- `DictError` に `#[non_exhaustive]` 付与

## 背景

lexime-trie 0.5 で以下が入りました ([lexime-trie#26](https://github.com/send/lexime-trie/pull/26)):
- `TrieError::InvalidVersion` が `u8` payload を持つようになった
- 新バリアント `InvalidStructure` (truncation と構造破損の分離)
- `#[non_exhaustive]` 化

旧い `From<TrieError> for DictError` は情報ロスしていました:
- `InvalidVersion → UnsupportedVersion(0)` (バージョンが常に 0)
- `TruncatedData → InvalidHeader` (LXTR 由来の truncation が LXDX の header 問題と混ざる)
- `MisalignedData → Parse("misaligned data")` (string round-trip)

本 PR では `DictError::Trie` に全面委譲することで全ての情報を保全します。

## Test plan

- [x] `cargo test -p lex-core` (314 pass)
- [x] `cargo check --workspace`
- [x] `Cargo.toml` は `lexime-trie = "=0.5.0"` 固定

🤖 Generated with [Claude Code](https://claude.com/claude-code)