### PR TITLE
fix: revert to Lexime on wake and retry if TISSelectInputSource fails

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -1,3 +1,4 @@
+import Carbon
 import Foundation
 
 // MARK: - Input Source IDs
@@ -11,6 +12,29 @@ enum LeximeInputSourceID {
     private static let bundleID = Bundle.main.bundleIdentifier ?? "sh.send.inputmethod.Lexime"
     static let japanese = bundleID + ".Japanese"
     static let roman = bundleID + ".Roman"
+    static let standardABC = "com.apple.keylayout.ABC"
+}
+
+// MARK: - TIS helpers
+
+enum InputSource {
+    static func currentID() -> String? {
+        guard let src = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return nil }
+        guard let ref = TISGetInputSourceProperty(src, kTISPropertyInputSourceID) else { return nil }
+        return Unmanaged<CFString>.fromOpaque(ref).takeUnretainedValue() as String
+    }
+
+    static func isCurrentStandardABC() -> Bool {
+        currentID() == LeximeInputSourceID.standardABC
+    }
+
+    static func select(id: String) {
+        let conditions = [kTISPropertyInputSourceID as String: id] as CFDictionary
+        guard let list = TISCreateInputSourceList(conditions, false)?.takeRetainedValue()
+                as? [TISInputSource],
+              let source = list.first else { return }
+        TISSelectInputSource(source)
+    }
 }
 
 // MARK: - UserDefaults Keys

--- a/Sources/InputSourceMonitor.swift
+++ b/Sources/InputSourceMonitor.swift
@@ -8,8 +8,6 @@ import Foundation
 /// awareness (polls for release before reverting).
 final class InputSourceMonitor: NSObject {
 
-    private static let abcSourceID = "com.apple.keylayout.ABC"
-
     /// Suppress notifications for this many seconds after init (avoid startup noise).
     private static let startupQuietPeriod: TimeInterval = 5
     /// Delay before auto-reverting non-secure ABC switch.
@@ -18,11 +16,9 @@ final class InputSourceMonitor: NSObject {
     private static let secureInputPollInterval: TimeInterval = 0.5
     /// Maximum polling duration for secure input (give up after this).
     private static let secureInputPollTimeout: TimeInterval = 60
-    /// Delay after wake before rechecking input source.
+    /// macOS needs a beat after wake before TIS calls reliably take effect.
     private static let wakeRecheckDelay: TimeInterval = 1.0
-    /// Interval between retry attempts when revert fails.
     private static let revertRetryInterval: TimeInterval = 0.05
-    /// Max retry attempts verifying revert took effect.
     private static let revertRetryMaxAttempts = 5
 
     private let startTime = Date()
@@ -53,11 +49,7 @@ final class InputSourceMonitor: NSObject {
     // MARK: - Input Source Change Handling
 
     @objc private func inputSourceDidChange() {
-        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return }
-        guard let idRef = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else { return }
-        let sourceID = Unmanaged<CFString>.fromOpaque(idRef).takeUnretainedValue() as String
-
-        guard sourceID == Self.abcSourceID else { return }
+        guard InputSource.isCurrentStandardABC() else { return }
 
         // Startup quiet period
         guard Date().timeIntervalSince(startTime) >= Self.startupQuietPeriod else {
@@ -90,7 +82,7 @@ final class InputSourceMonitor: NSObject {
         NSLog("Lexime: wake detected, rechecking input source in %.1fs", Self.wakeRecheckDelay)
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.wakeRecheckDelay) { [weak self] in
             guard let self else { return }
-            guard self.isCurrentInputSourceAbc() else { return }
+            guard InputSource.isCurrentStandardABC() else { return }
             if IsSecureEventInputEnabled() {
                 NSLog("Lexime: wake on ABC during secure input, polling for release")
                 self.startSecureInputPolling()
@@ -123,31 +115,14 @@ final class InputSourceMonitor: NSObject {
         }
     }
 
-    private func selectLeximeRoman() {
-        let conditions = [
-            kTISPropertyInputSourceID as String: LeximeInputSourceID.roman
-        ] as CFDictionary
-        guard let list = TISCreateInputSourceList(conditions, false)?.takeRetainedValue()
-                as? [TISInputSource],
-              let source = list.first else { return }
-        TISSelectInputSource(source)
-    }
-
-    private func isCurrentInputSourceAbc() -> Bool {
-        guard let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return false }
-        guard let idRef = TISGetInputSourceProperty(current, kTISPropertyInputSourceID) else { return false }
-        let id = Unmanaged<CFString>.fromOpaque(idRef).takeUnretainedValue() as String
-        return id == Self.abcSourceID
-    }
-
     /// TISSelectInputSource can silently fail during wake or other input source
     /// transitions. Verify the switch took effect and retry if still on ABC.
     private func revertFromAbcWithRetry(attempt: Int = 0) {
-        selectLeximeRoman()
+        InputSource.select(id: LeximeInputSourceID.roman)
         guard attempt + 1 < Self.revertRetryMaxAttempts else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.revertRetryInterval) { [weak self] in
             guard let self else { return }
-            guard self.isCurrentInputSourceAbc() else { return }
+            guard InputSource.isCurrentStandardABC() else { return }
             self.revertFromAbcWithRetry(attempt: attempt + 1)
         }
     }

--- a/Sources/InputSourceMonitor.swift
+++ b/Sources/InputSourceMonitor.swift
@@ -117,13 +117,14 @@ final class InputSourceMonitor: NSObject {
 
     /// TISSelectInputSource can silently fail during wake or other input source
     /// transitions. Verify the switch took effect and retry if still on ABC.
+    /// Bails if the current source is no longer ABC — the user/system may have
+    /// moved off ABC during the caller's delay, and we must not force them back.
     private func revertFromAbcWithRetry(attempt: Int = 0) {
+        guard InputSource.isCurrentStandardABC() else { return }
         InputSource.select(id: LeximeInputSourceID.roman)
         guard attempt + 1 < Self.revertRetryMaxAttempts else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.revertRetryInterval) { [weak self] in
-            guard let self else { return }
-            guard InputSource.isCurrentStandardABC() else { return }
-            self.revertFromAbcWithRetry(attempt: attempt + 1)
+            self?.revertFromAbcWithRetry(attempt: attempt + 1)
         }
     }
 

--- a/Sources/InputSourceMonitor.swift
+++ b/Sources/InputSourceMonitor.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon
 import Foundation
 
@@ -17,6 +18,12 @@ final class InputSourceMonitor: NSObject {
     private static let secureInputPollInterval: TimeInterval = 0.5
     /// Maximum polling duration for secure input (give up after this).
     private static let secureInputPollTimeout: TimeInterval = 60
+    /// Delay after wake before rechecking input source.
+    private static let wakeRecheckDelay: TimeInterval = 1.0
+    /// Interval between retry attempts when revert fails.
+    private static let revertRetryInterval: TimeInterval = 0.05
+    /// Max retry attempts verifying revert took effect.
+    private static let revertRetryMaxAttempts = 5
 
     private let startTime = Date()
     private var secureInputTimer: Timer?
@@ -28,12 +35,19 @@ final class InputSourceMonitor: NSObject {
             name: NSNotification.Name("com.apple.Carbon.TISNotifySelectedKeyboardInputSourceChanged"),
             object: nil
         )
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(didWake),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
         NSLog("Lexime: InputSourceMonitor started")
     }
 
     deinit {
         secureInputTimer?.invalidate()
         DistributedNotificationCenter.default().removeObserver(self)
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
     }
 
     // MARK: - Input Source Change Handling
@@ -63,8 +77,27 @@ final class InputSourceMonitor: NSObject {
         // Auto-revert after a short delay.
         NSLog("Lexime: unexpected ABC switch detected, auto-reverting in %.1fs", Self.autoRevertDelay)
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.autoRevertDelay) { [weak self] in
+            self?.revertFromAbcWithRetry()
+        }
+    }
+
+    // MARK: - Wake Handling
+
+    /// After sleep/wake, macOS often ends up on ABC without firing a
+    /// TISNotifySelectedKeyboardInputSourceChanged we can act on in time,
+    /// so re-check explicitly once the system has settled.
+    @objc private func didWake() {
+        NSLog("Lexime: wake detected, rechecking input source in %.1fs", Self.wakeRecheckDelay)
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.wakeRecheckDelay) { [weak self] in
             guard let self else { return }
-            self.selectLeximeRoman()
+            guard self.isCurrentInputSourceAbc() else { return }
+            if IsSecureEventInputEnabled() {
+                NSLog("Lexime: wake on ABC during secure input, polling for release")
+                self.startSecureInputPolling()
+                return
+            }
+            NSLog("Lexime: wake on ABC, reverting to Lexime Roman")
+            self.revertFromAbcWithRetry()
         }
     }
 
@@ -81,7 +114,7 @@ final class InputSourceMonitor: NSObject {
                 timer.invalidate()
                 self.secureInputTimer = nil
                 NSLog("Lexime: Secure input released, switching back to Lexime")
-                self.selectLeximeRoman()
+                self.revertFromAbcWithRetry()
             } else if Date() >= deadline {
                 timer.invalidate()
                 self.secureInputTimer = nil
@@ -98,6 +131,25 @@ final class InputSourceMonitor: NSObject {
                 as? [TISInputSource],
               let source = list.first else { return }
         TISSelectInputSource(source)
+    }
+
+    private func isCurrentInputSourceAbc() -> Bool {
+        guard let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return false }
+        guard let idRef = TISGetInputSourceProperty(current, kTISPropertyInputSourceID) else { return false }
+        let id = Unmanaged<CFString>.fromOpaque(idRef).takeUnretainedValue() as String
+        return id == Self.abcSourceID
+    }
+
+    /// TISSelectInputSource can silently fail during wake or other input source
+    /// transitions. Verify the switch took effect and retry if still on ABC.
+    private func revertFromAbcWithRetry(attempt: Int = 0) {
+        selectLeximeRoman()
+        guard attempt + 1 < Self.revertRetryMaxAttempts else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.revertRetryInterval) { [weak self] in
+            guard let self else { return }
+            guard self.isCurrentInputSourceAbc() else { return }
+            self.revertFromAbcWithRetry(attempt: attempt + 1)
+        }
     }
 
 }

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -279,29 +279,12 @@ class LeximeInputController: IMKInputController {
         guard attempt < maxAttempts else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
             guard let self else { return }
-            if self.isCurrentInputSourceStandardABC() {
-                self.selectLeximeJapanese()
+            if InputSource.isCurrentStandardABC() {
+                InputSource.select(id: LeximeInputSourceID.japanese)
             } else {
                 self.revertToLeximeWithRetry(attempt: attempt + 1)
             }
         }
-    }
-
-    private func isCurrentInputSourceStandardABC() -> Bool {
-        guard let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return false }
-        guard let idRef = TISGetInputSourceProperty(current, kTISPropertyInputSourceID) else { return false }
-        let id = Unmanaged<CFString>.fromOpaque(idRef).takeUnretainedValue() as String
-        return id == "com.apple.keylayout.ABC"
-    }
-
-    private func selectLeximeJapanese() {
-        let conditions = [
-            kTISPropertyInputSourceID as String: LeximeInputSourceID.japanese
-        ] as CFDictionary
-        guard let list = TISCreateInputSourceList(conditions, false)?.takeRetainedValue()
-                as? [TISInputSource],
-              let source = list.first else { return }
-        TISSelectInputSource(source)
     }
 
     override func activateServer(_ sender: Any!) {

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -274,6 +274,9 @@ class LeximeInputController: IMKInputController {
 
     /// Check up to 5 times (at 50ms intervals) whether macOS switched to
     /// standard ABC after ESC, and revert to Lexime Japanese if so.
+    /// The IMKit ABC race fires asynchronously so we keep checking each tick;
+    /// we also re-select on subsequent ticks if still ABC, to recover from a
+    /// silent TISSelectInputSource failure.
     private func revertToLeximeWithRetry(attempt: Int = 0) {
         let maxAttempts = 5
         guard attempt < maxAttempts else { return }
@@ -281,9 +284,8 @@ class LeximeInputController: IMKInputController {
             guard let self else { return }
             if InputSource.isCurrentStandardABC() {
                 InputSource.select(id: LeximeInputSourceID.japanese)
-            } else {
-                self.revertToLeximeWithRetry(attempt: attempt + 1)
             }
+            self.revertToLeximeWithRetry(attempt: attempt + 1)
         }
     }
 


### PR DESCRIPTION
## Summary
- sleep/wake 後に入力ソースが標準 ABC のまま固まる症状を修正。`NSWorkspace.didWakeNotification` を観測し、wake 1s 後に ABC ならば Lexime Roman に戻す（secure input 中は通知経路と同じく release 待ち polling）。
- `TISSelectInputSource` が wake 直下などで silent fail したとき救えるよう、revert 後に現在の入力ソースを確認して ABC のままなら 50ms × 最大 5 回リトライ（ESC 経路の既存挙動と揃えた）。
- 対症療法（Roman に固定で戻す）で、元が Kana/Japanese だった場合に Japanese に戻す責務は今のところ持たせていない。必要なら別 PR で対応。

## Test plan
- [ ] クリーンな状態で Lexime Japanese → sleep → wake を複数回試し、ABC に固まらないことを確認
- [ ] ログイン画面パスワード入力（secure input）直後の wake で、release 検出後に Roman に戻ることを確認
- [ ] 通常操作中に ESC → ABC 切替が発生しても従来どおり Japanese に戻ることを確認（`LeximeInputController.revertToLeximeWithRetry` 経路）
- [ ] `log show --predicate 'eventMessage CONTAINS "Lexime:"'` で `wake detected` / `Secure input released, switching back to Lexime` のログが期待どおり出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)