### PR TITLE
refactor: split AppContext into EngineContainer / UIServices / ConfigStore

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -48,56 +48,49 @@ extension Notification.Name {
     static let snippetsDidReload = Notification.Name("LeximeSnippetsDidReload")
 }
 
-class AppContext {
-    static let shared = AppContext()
+/// Composite facade over `EngineContainer`, `UIServices`, and `ConfigStore`.
+/// Retained for backwards compatibility; prefer the underlying containers in new code.
+final class AppContext {
+    /// Process-wide shared instance, assigned by `main.swift` at startup.
+    static var shared: AppContext!
 
-    let engine: LexEngine?
-    private(set) var snippetStore: LexSnippetStore?
-    let userDictPath: String
-    let supportDir: String
-    let candidatePanel = CandidatePanel()
-    let inputSourceMonitor = InputSourceMonitor()
+    let engineContainer: EngineContainer
+    let ui: UIServices
+    let config: ConfigStore
 
-    private init() {
+    init(engineContainer: EngineContainer, ui: UIServices, config: ConfigStore) {
+        self.engineContainer = engineContainer
+        self.ui = ui
+        self.config = config
+    }
+
+    // MARK: - Forwarded properties (backwards-compatible surface)
+
+    var engine: LexEngine? { engineContainer.engine }
+    var snippetStore: LexSnippetStore? { config.snippetStore }
+    var userDictPath: String { config.userDictPath }
+    var supportDir: String { config.supportDir }
+    var candidatePanel: CandidatePanel { ui.candidatePanel }
+    var inputSourceMonitor: InputSourceMonitor { ui.inputSourceMonitor }
+
+    func reloadSnippets() throws {
+        try config.reloadSnippets()
+    }
+
+    // MARK: - Bootstrap
+
+    static func bootstrap() -> AppContext {
         guard let resourcePath = Bundle.main.resourcePath else {
             fatalError("Lexime: Bundle.main.resourcePath is nil")
         }
 
-        // Load dictionary
-        let dictPath = (resourcePath as NSString).appendingPathComponent("lexime.dict")
-        var dict: LexDictionary?
-        do {
-            let d = try LexDictionary.open(path: dictPath)
-            NSLog("Lexime: Dictionary loaded from %@", dictPath)
-            let entries = d.lookup(reading: "かんじ")
-            NSLog("Lexime: Sample lookup 'かんじ' → %d candidates", entries.count)
-            dict = d
-        } catch {
-            NSLog("Lexime: Failed to load dictionary at %@: %@", dictPath, "\(error)")
-            dict = nil
-        }
-
-        // Load connection matrix (optional — falls back to unigram if not found)
-        let connPath = (resourcePath as NSString).appendingPathComponent("lexime.conn")
-        let conn: LexConnection?
-        do {
-            let c = try LexConnection.open(path: connPath)
-            NSLog("Lexime: Connection matrix loaded from %@", connPath)
-            conn = c
-        } catch {
-            NSLog("Lexime: Connection matrix not found at %@ (using unigram fallback)", connPath)
-            conn = nil
-        }
-
-        // Load user history (learning data)
         guard let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask).first else {
             fatalError("Lexime: Cannot find Application Support directory")
         }
         let leximeDir = appSupport.appendingPathComponent("Lexime").path
-        self.supportDir = leximeDir
-        let historyPath = (leximeDir as NSString).appendingPathComponent("user_history.lxud")
-        self.userDictPath = (leximeDir as NSString).appendingPathComponent("user_dict.lxuw")
+
+        let config = ConfigStore(supportDir: leximeDir)
 
         // Initialize tracing (no-op unless built with --features trace)
         let libraryDir = NSSearchPathForDirectoriesInDomains(
@@ -108,9 +101,7 @@ class AppContext {
             atPath: logDir, withIntermediateDirectories: true)
         traceInit(logDir: logDir)
 
-        // Load custom settings if present
-        let settingsPath = appSupport
-            .appendingPathComponent("Lexime/settings.toml").path
+        let settingsPath = (leximeDir as NSString).appendingPathComponent("settings.toml")
         if FileManager.default.fileExists(atPath: settingsPath) {
             do {
                 try settingsLoadConfig(path: settingsPath)
@@ -118,13 +109,10 @@ class AppContext {
             } catch {
                 NSLog("Lexime: settings config error at %@: %@",
                       settingsPath, "\(error)")
-                // Embedded defaults will be used
             }
         }
 
-        // Load custom romaji config if present
-        let romajiPath = appSupport
-            .appendingPathComponent("Lexime/romaji.toml").path
+        let romajiPath = (leximeDir as NSString).appendingPathComponent("romaji.toml")
         if FileManager.default.fileExists(atPath: romajiPath) {
             do {
                 try romajiLoadConfig(path: romajiPath)
@@ -132,77 +120,27 @@ class AppContext {
             } catch {
                 NSLog("Lexime: romaji config error at %@: %@",
                       romajiPath, "\(error)")
-                // Embedded default will be used
             }
         }
 
-        // Load user dictionary (optional — for custom word registration)
-        let userDict: LexUserDictionary?
+        let historyPath = (leximeDir as NSString).appendingPathComponent("user_history.lxud")
+        let engineContainer = EngineContainer.load(
+            resourcePath: resourcePath,
+            userDictPath: config.userDictPath,
+            historyPath: historyPath)
+
+        let ui = UIServices()
+
+        let ctx = AppContext(engineContainer: engineContainer, ui: ui, config: config)
+
         do {
-            let ud = try LexUserDictionary.open(path: self.userDictPath)
-            NSLog("Lexime: User dictionary loaded from %@", self.userDictPath)
-            userDict = ud
-        } catch {
-            NSLog("Lexime: Failed to open user dictionary at %@: %@",
-                  self.userDictPath, "\(error)")
-            userDict = nil
-        }
-
-        // Reload dict with user dictionary layer if available
-        if userDict != nil, dict != nil {
-            do {
-                let composite = try LexDictionary.openWithUserDict(
-                    path: dictPath, userDict: userDict)
-                NSLog("Lexime: Composite dictionary created (system + user)")
-                dict = composite
-            } catch {
-                NSLog("Lexime: Failed to create composite dictionary: %@", "\(error)")
-                // Fall back to system-only dict (already set)
-            }
-        }
-
-        let history: LexUserHistory?
-        do {
-            let h = try LexUserHistory.open(path: historyPath)
-            NSLog("Lexime: User history loaded from %@", historyPath)
-            history = h
-        } catch {
-            NSLog("Lexime: Failed to open user history at %@: %@", historyPath, "\(error)")
-            history = nil
-        }
-
-        // Assemble engine (requires at least a dictionary)
-        if let dict {
-            self.engine = LexEngine(
-                dict: dict, conn: conn, history: history,
-                userDict: userDict)
-        } else {
-            self.engine = nil
-        }
-
-        // Load snippets (optional)
-        self.snippetStore = nil
-        do {
-            try reloadSnippets()
+            try config.reloadSnippets()
         } catch {
             NSLog("Lexime: snippets load error: %@", "\(error)")
         }
 
-        // Start monitoring for unexpected ABC input source switches
-        inputSourceMonitor.startMonitoring()
-    }
+        ui.startMonitoring()
 
-    /// Reload snippets from disk. Throws if the file exists but fails to load.
-    /// On success or missing file, updates `snippetStore` and posts notification.
-    func reloadSnippets() throws {
-        let snippetsPath = (supportDir as NSString).appendingPathComponent("snippets.toml")
-        if FileManager.default.fileExists(atPath: snippetsPath) {
-            let store = try snippetsLoad(path: snippetsPath)
-            NSLog("Lexime: Snippets reloaded from %@", snippetsPath)
-            self.snippetStore = store
-        } else {
-            self.snippetStore = nil
-        }
-        NotificationCenter.default.post(name: .snippetsDidReload, object: nil)
+        return ctx
     }
 }

--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -51,8 +51,20 @@ extension Notification.Name {
 /// Composite facade over `EngineContainer`, `UIServices`, and `ConfigStore`.
 /// Retained for backwards compatibility; prefer the underlying containers in new code.
 final class AppContext {
-    /// Process-wide shared instance, assigned by `main.swift` at startup.
-    static var shared: AppContext!
+    private static var _shared: AppContext?
+
+    /// Process-wide shared instance, assigned once at startup via `installShared(_:)`.
+    static var shared: AppContext {
+        guard let shared = _shared else {
+            fatalError("AppContext.shared accessed before initialization. Call AppContext.installShared(_:) during startup.")
+        }
+        return shared
+    }
+
+    static func installShared(_ context: AppContext) {
+        precondition(_shared == nil, "AppContext.shared may only be installed once.")
+        _shared = context
+    }
 
     let engineContainer: EngineContainer
     let ui: UIServices

--- a/Sources/ConfigStore.swift
+++ b/Sources/ConfigStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+final class ConfigStore {
+    let supportDir: String
+    let userDictPath: String
+    let snippetPath: String
+    private(set) var snippetStore: LexSnippetStore?
+
+    init(supportDir: String) {
+        self.supportDir = supportDir
+        self.userDictPath = (supportDir as NSString).appendingPathComponent("user_dict.lxuw")
+        self.snippetPath = (supportDir as NSString).appendingPathComponent("snippets.toml")
+        self.snippetStore = nil
+    }
+
+    /// Reload snippets from disk. Throws if the file exists but fails to load.
+    /// On success or missing file, updates `snippetStore` and posts notification.
+    func reloadSnippets() throws {
+        if FileManager.default.fileExists(atPath: snippetPath) {
+            let store = try snippetsLoad(path: snippetPath)
+            NSLog("Lexime: Snippets reloaded from %@", snippetPath)
+            self.snippetStore = store
+        } else {
+            self.snippetStore = nil
+        }
+        NotificationCenter.default.post(name: .snippetsDidReload, object: nil)
+    }
+}

--- a/Sources/EngineContainer.swift
+++ b/Sources/EngineContainer.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+final class EngineContainer {
+    let engine: LexEngine?
+    let dictionary: LexDictionary?
+    let history: LexUserHistory?
+    let userDict: LexUserDictionary?
+
+    init(
+        engine: LexEngine?,
+        dictionary: LexDictionary?,
+        history: LexUserHistory?,
+        userDict: LexUserDictionary?
+    ) {
+        self.engine = engine
+        self.dictionary = dictionary
+        self.history = history
+        self.userDict = userDict
+    }
+
+    static func load(resourcePath: String, userDictPath: String, historyPath: String) -> EngineContainer {
+        let dictPath = (resourcePath as NSString).appendingPathComponent("lexime.dict")
+        var dict: LexDictionary?
+        do {
+            let d = try LexDictionary.open(path: dictPath)
+            NSLog("Lexime: Dictionary loaded from %@", dictPath)
+            let entries = d.lookup(reading: "かんじ")
+            NSLog("Lexime: Sample lookup 'かんじ' → %d candidates", entries.count)
+            dict = d
+        } catch {
+            NSLog("Lexime: Failed to load dictionary at %@: %@", dictPath, "\(error)")
+            dict = nil
+        }
+
+        let connPath = (resourcePath as NSString).appendingPathComponent("lexime.conn")
+        let conn: LexConnection?
+        do {
+            let c = try LexConnection.open(path: connPath)
+            NSLog("Lexime: Connection matrix loaded from %@", connPath)
+            conn = c
+        } catch {
+            NSLog("Lexime: Connection matrix not found at %@ (using unigram fallback)", connPath)
+            conn = nil
+        }
+
+        let userDict: LexUserDictionary?
+        do {
+            let ud = try LexUserDictionary.open(path: userDictPath)
+            NSLog("Lexime: User dictionary loaded from %@", userDictPath)
+            userDict = ud
+        } catch {
+            NSLog("Lexime: Failed to open user dictionary at %@: %@", userDictPath, "\(error)")
+            userDict = nil
+        }
+
+        if userDict != nil, dict != nil {
+            do {
+                let composite = try LexDictionary.openWithUserDict(
+                    path: dictPath, userDict: userDict)
+                NSLog("Lexime: Composite dictionary created (system + user)")
+                dict = composite
+            } catch {
+                NSLog("Lexime: Failed to create composite dictionary: %@", "\(error)")
+            }
+        }
+
+        let history: LexUserHistory?
+        do {
+            let h = try LexUserHistory.open(path: historyPath)
+            NSLog("Lexime: User history loaded from %@", historyPath)
+            history = h
+        } catch {
+            NSLog("Lexime: Failed to open user history at %@: %@", historyPath, "\(error)")
+            history = nil
+        }
+
+        let engine: LexEngine?
+        if let dict {
+            engine = LexEngine(dict: dict, conn: conn, history: history, userDict: userDict)
+        } else {
+            engine = nil
+        }
+
+        return EngineContainer(
+            engine: engine, dictionary: dict, history: history, userDict: userDict)
+    }
+}

--- a/Sources/EngineContainer.swift
+++ b/Sources/EngineContainer.swift
@@ -25,7 +25,7 @@ final class EngineContainer {
             let d = try LexDictionary.open(path: dictPath)
             NSLog("Lexime: Dictionary loaded from %@", dictPath)
             let entries = d.lookup(reading: "かんじ")
-            NSLog("Lexime: Sample lookup 'かんじ' → %d candidates", entries.count)
+            NSLog("Lexime: Sample lookup 'かんじ' → %ld candidates", entries.count)
             dict = d
         } catch {
             NSLog("Lexime: Failed to load dictionary at %@: %@", dictPath, "\(error)")

--- a/Sources/UIServices.swift
+++ b/Sources/UIServices.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+final class UIServices {
+    let candidatePanel: CandidatePanel
+    let inputSourceMonitor: InputSourceMonitor
+
+    init(candidatePanel: CandidatePanel = CandidatePanel(),
+         inputSourceMonitor: InputSourceMonitor = InputSourceMonitor()) {
+        self.candidatePanel = candidatePanel
+        self.inputSourceMonitor = inputSourceMonitor
+    }
+
+    func startMonitoring() {
+        inputSourceMonitor.startMonitoring()
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -4,7 +4,7 @@ import InputMethodKit
 let kConnectionName = "sh.send.inputmethod.Lexime_Connection"
 
 // Initialize shared app context (loads dictionary, connection matrix, user history)
-AppContext.shared = AppContext.bootstrap()
+AppContext.installShared(AppContext.bootstrap())
 
 guard let bundleId = Bundle.main.bundleIdentifier else {
     NSLog("Lexime: Bundle.main.bundleIdentifier is nil")

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -4,7 +4,7 @@ import InputMethodKit
 let kConnectionName = "sh.send.inputmethod.Lexime_Connection"
 
 // Initialize shared app context (loads dictionary, connection matrix, user history)
-_ = AppContext.shared
+AppContext.shared = AppContext.bootstrap()
 
 guard let bundleId = Bundle.main.bundleIdentifier else {
     NSLog("Lexime: Bundle.main.bundleIdentifier is nil")


### PR DESCRIPTION
## Summary

PR #1 of the Swift frontend refactor. Decomposes the 208-line `AppContext.swift` god object into three focused containers while preserving the `AppContext.shared.xxx` call surface for existing callers.

- `EngineContainer` — `engine`, `dictionary`, `history`, `userDict` (and the multi-step load / composite-dict wiring previously inlined in `AppContext.init`)
- `UIServices` — `candidatePanel`, `inputSourceMonitor`
- `ConfigStore` — `supportDir`, `userDictPath`, `snippetPath`, `snippetStore` + `reloadSnippets()`
- `AppContext` is now a thin composite facade that holds the three and forwards the legacy surface (`engine`, `snippetStore`, `userDictPath`, `supportDir`, `candidatePanel`, `inputSourceMonitor`, `reloadSnippets()`). Bootstrap moved from a private `init` to an explicit `AppContext.bootstrap()` call invoked from `main.swift`.

No call-site changes. `LeximeInputController`, `CandidateManager`, and all views continue to use `AppContext.shared.xxx` unchanged.

### Design notes

- `AppContext.shared` is backed by a private optional (`_shared`) and exposed via a read-only getter that `fatalError`s on pre-install access, plus a single-shot `installShared(_:)` guarded by `precondition` (tightened after Copilot review round 1).
- The three containers expose only the minimum surface needed to keep the existing `AppContext` facade intact.
- Behaviour is preserved except for one intentional correctness fix from Copilot review round 1: the sample-lookup log format changed from `%d` to `%ld` because `entries.count` is `Int` (64-bit on macOS) and the previous `%d` was a varargs type/width mismatch. All other log messages, fallback order, and snippet-reload semantics are unchanged.

### Out of scope (future PRs)

- `LeximeInputController` decomposition (PR #2)
- Removing direct `engine` access from views (PR #8)
- Moving snippet TOML logic (PR #9)

## Test plan

- [x] `swiftc` compiles all of `Sources/*.swift` together for both `arm64-apple-macosx13.0` and `x86_64-apple-macosx13.0` against existing UniFFI bindings — no errors, no warnings from the touched files.
- [x] Full `mise run build` end-to-end passes (Lexime.app builds successfully with the Round 1 fixes applied).
- [ ] Manual verification by user needed: launch the rebuilt IME and confirm conversion, candidate panel, user-dict editing, snippet reload, and input-source monitoring all still work.