### PR TITLE
refactor: split LatticeCache out of Composition

### DIFF
--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -89,14 +89,16 @@ impl InputSession {
         // Remove committed reading from kana.
         // Safety: starts_with check above guarantees the byte offset is a valid
         // UTF-8 boundary, but we use char-based slicing for extra safety.
-        let c = self.comp();
-        let skip_chars = committed_reading_len;
-        c.kana = c.kana.chars().skip(skip_chars).collect();
-        c.cached_lattice = None; // kana truncated — invalidate
-        c.stability.reset();
+        let prefix_text = {
+            let c = self.comp();
+            let skip_chars = committed_reading_len;
+            c.kana = c.kana.chars().skip(skip_chars).collect();
+            c.stability.reset();
+            std::mem::take(&mut c.prefix.text)
+        };
+        self.lattice_cache.invalidate();
 
-        // Include prefix in the committed text, then clear it
-        let prefix_text = std::mem::take(&mut c.prefix.text);
+        // Include prefix in the committed text
         let committed_text = format!("{}{}", prefix_text, committed_surface);
 
         // Accumulate committed text for context

--- a/engine/crates/lex-session/src/candidate_gen.rs
+++ b/engine/crates/lex-session/src/candidate_gen.rs
@@ -46,13 +46,14 @@ impl InputSession {
         // Do NOT reset stability here. It accumulates across keystrokes.
         let reading = self.comp().kana.clone();
         if !reading.is_empty() {
+            let lattice = self.lattice_cache.get_or_build(&reading, &*self.dict);
+
             let h_guard = self.history.as_ref().and_then(|h| h.read().ok());
             let ctx = ConversionContext {
                 dict: &*self.dict,
                 conn: self.conn.as_deref(),
                 history: h_guard.as_deref(),
             };
-            let lattice = self.lattice_cache.get_or_build(&reading, &ctx);
             let segments = ctx.convert_from_lattice(&lattice);
             drop(h_guard);
 

--- a/engine/crates/lex-session/src/candidate_gen.rs
+++ b/engine/crates/lex-session/src/candidate_gen.rs
@@ -1,5 +1,5 @@
 use lex_core::candidates::CandidateResponse;
-use lex_core::converter::{build_lattice, ConversionContext, ConvertedSegment};
+use lex_core::converter::{ConversionContext, ConvertedSegment};
 
 use super::response::{build_marked_text, build_marked_text_and_candidates};
 use super::types::{AsyncCandidateRequest, KeyResponse, SessionState, MAX_CANDIDATES};
@@ -46,38 +46,29 @@ impl InputSession {
         // Do NOT reset stability here. It accumulates across keystrokes.
         let reading = self.comp().kana.clone();
         if !reading.is_empty() {
-            // Reuse cached lattice: extend if kana grew, or keep as-is
-            // if unchanged. Fall back to full rebuild otherwise.
-            let lattice = match self.comp().cached_lattice.take() {
-                Some(mut cached) if reading.starts_with(&cached.input) => {
-                    cached.extend(&*self.dict, &reading); // no-op if reading == input
-                    cached
-                }
-                _ => build_lattice(&*self.dict, &reading),
+            let h_guard = self.history.as_ref().and_then(|h| h.read().ok());
+            let ctx = ConversionContext {
+                dict: &*self.dict,
+                conn: self.conn.as_deref(),
+                history: h_guard.as_deref(),
             };
+            let lattice = self.lattice_cache.get_or_build(&reading, &ctx);
+            let segments = ctx.convert_from_lattice(&lattice);
+            drop(h_guard);
 
-            let segments = {
-                let h_guard = self.history.as_ref().and_then(|h| h.read().ok());
-                let ctx = ConversionContext {
-                    dict: &*self.dict,
-                    conn: self.conn.as_deref(),
-                    history: h_guard.as_deref(),
-                };
-                ctx.convert_from_lattice(&lattice)
-            };
             let surface: String = segments.iter().map(|s| s.surface.as_str()).collect();
             let c = self.comp();
             c.candidates.surfaces = vec![surface];
             c.candidates.paths = vec![segments];
             c.candidates.selected = 0;
-            // Cache for next keystroke's incremental extension
-            c.cached_lattice = Some(lattice.clone());
 
             let mut resp = build_marked_text(self.comp());
+            // AsyncCandidateRequest.lattice stays `Option<Lattice>` in this PR;
+            // PR #6 will switch it (and the worker) to `Arc<Lattice>`.
             resp.async_request = Some(AsyncCandidateRequest {
                 reading,
                 candidate_dispatch: self.config.conversion_mode.candidate_dispatch(),
-                lattice: Some(lattice),
+                lattice: Some((*lattice).clone()),
             });
             return resp;
         } else {

--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -78,5 +78,6 @@ impl InputSession {
 
     pub(super) fn reset_state(&mut self) {
         self.state = SessionState::Idle;
+        self.lattice_cache.invalidate();
     }
 }

--- a/engine/crates/lex-session/src/key_handlers.rs
+++ b/engine/crates/lex-session/src/key_handlers.rs
@@ -255,16 +255,23 @@ impl InputSession {
     }
 
     pub(super) fn handle_backspace(&mut self) -> KeyResponse {
-        {
+        let kana_shortened = {
             let c = self.comp();
             if !c.pending.is_empty() {
                 c.pending.pop();
+                false
             } else if !c.kana.is_empty() {
                 c.kana.pop();
-                c.cached_lattice = None; // kana shortened — invalidate
+                true
             } else if !c.prefix.is_empty() {
                 c.prefix.pop();
+                false
+            } else {
+                false
             }
+        };
+        if kana_shortened {
+            self.lattice_cache.invalidate();
         }
 
         let c = self.comp();

--- a/engine/crates/lex-session/src/lattice_cache.rs
+++ b/engine/crates/lex-session/src/lattice_cache.rs
@@ -1,0 +1,52 @@
+//! Incremental lattice cache used by `InputSession`.
+//!
+//! The cache keeps a single `Arc<Lattice>` keyed by the current reading so
+//! consecutive keystrokes can extend the existing lattice instead of rebuilding
+//! from scratch. When the reading no longer matches (backspace, auto-commit,
+//! prefix mismatch) the cache falls back to a fresh build.
+
+use std::sync::Arc;
+
+use lex_core::converter::{build_lattice, ConversionContext, Lattice};
+
+pub(crate) struct LatticeCache {
+    lattice: Option<Arc<Lattice>>,
+}
+
+impl LatticeCache {
+    pub(crate) fn new() -> Self {
+        Self { lattice: None }
+    }
+
+    /// Drop any cached lattice (called on backspace, auto-commit, etc.).
+    pub(crate) fn invalidate(&mut self) {
+        self.lattice = None;
+    }
+
+    /// Return a lattice for `reading`, extending the cached one when possible.
+    ///
+    /// Reuses the cached lattice unchanged when `reading` matches, extends it
+    /// when `reading` is a pure suffix append, and rebuilds otherwise.
+    pub(crate) fn get_or_build(
+        &mut self,
+        reading: &str,
+        ctx: &ConversionContext<'_>,
+    ) -> Arc<Lattice> {
+        if let Some(arc) = self.lattice.take() {
+            if reading == arc.input {
+                self.lattice = Some(Arc::clone(&arc));
+                return arc;
+            }
+            if reading.starts_with(&arc.input) {
+                let mut owned = Arc::try_unwrap(arc).unwrap_or_else(|shared| (*shared).clone());
+                owned.extend(ctx.dict, reading);
+                let arc = Arc::new(owned);
+                self.lattice = Some(Arc::clone(&arc));
+                return arc;
+            }
+        }
+        let arc = Arc::new(build_lattice(ctx.dict, reading));
+        self.lattice = Some(Arc::clone(&arc));
+        arc
+    }
+}

--- a/engine/crates/lex-session/src/lattice_cache.rs
+++ b/engine/crates/lex-session/src/lattice_cache.rs
@@ -7,7 +7,8 @@
 
 use std::sync::Arc;
 
-use lex_core::converter::{build_lattice, ConversionContext, Lattice};
+use lex_core::converter::{build_lattice, Lattice};
+use lex_core::dict::Dictionary;
 
 pub(crate) struct LatticeCache {
     lattice: Option<Arc<Lattice>>,
@@ -27,11 +28,7 @@ impl LatticeCache {
     ///
     /// Reuses the cached lattice unchanged when `reading` matches, extends it
     /// when `reading` is a pure suffix append, and rebuilds otherwise.
-    pub(crate) fn get_or_build(
-        &mut self,
-        reading: &str,
-        ctx: &ConversionContext<'_>,
-    ) -> Arc<Lattice> {
+    pub(crate) fn get_or_build(&mut self, reading: &str, dict: &dyn Dictionary) -> Arc<Lattice> {
         if let Some(arc) = self.lattice.take() {
             if reading == arc.input {
                 self.lattice = Some(Arc::clone(&arc));
@@ -39,13 +36,13 @@ impl LatticeCache {
             }
             if reading.starts_with(&arc.input) {
                 let mut owned = Arc::try_unwrap(arc).unwrap_or_else(|shared| (*shared).clone());
-                owned.extend(ctx.dict, reading);
+                owned.extend(dict, reading);
                 let arc = Arc::new(owned);
                 self.lattice = Some(Arc::clone(&arc));
                 return arc;
             }
         }
-        let arc = Arc::new(build_lattice(ctx.dict, reading));
+        let arc = Arc::new(build_lattice(dict, reading));
         self.lattice = Some(Arc::clone(&arc));
         arc
     }

--- a/engine/crates/lex-session/src/lattice_cache.rs
+++ b/engine/crates/lex-session/src/lattice_cache.rs
@@ -47,3 +47,99 @@ impl LatticeCache {
         arc
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_core::dict::{DictEntry, TrieDictionary};
+
+    fn test_dict() -> TrieDictionary {
+        let entries = vec![
+            (
+                "きょう".to_string(),
+                vec![DictEntry {
+                    surface: "今日".to_string(),
+                    cost: 3000,
+                    left_id: 100,
+                    right_id: 100,
+                }],
+            ),
+            (
+                "は".to_string(),
+                vec![DictEntry {
+                    surface: "は".to_string(),
+                    cost: 2000,
+                    left_id: 200,
+                    right_id: 200,
+                }],
+            ),
+            (
+                "てんき".to_string(),
+                vec![DictEntry {
+                    surface: "天気".to_string(),
+                    cost: 4000,
+                    left_id: 400,
+                    right_id: 400,
+                }],
+            ),
+        ];
+        TrieDictionary::from_entries(entries)
+    }
+
+    #[test]
+    fn first_call_builds_fresh_lattice() {
+        let dict = test_dict();
+        let mut cache = LatticeCache::new();
+        let lattice = cache.get_or_build("きょう", &dict);
+        assert_eq!(lattice.input, "きょう");
+    }
+
+    #[test]
+    fn same_reading_returns_identical_arc() {
+        let dict = test_dict();
+        let mut cache = LatticeCache::new();
+        let a = cache.get_or_build("きょう", &dict);
+        let b = cache.get_or_build("きょう", &dict);
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "expected cached Arc reuse when reading matches exactly"
+        );
+    }
+
+    #[test]
+    fn suffix_append_extends_cached_lattice() {
+        let dict = test_dict();
+        let mut cache = LatticeCache::new();
+        let before = cache.get_or_build("きょう", &dict);
+        drop(before);
+        let extended = cache.get_or_build("きょうは", &dict);
+        assert_eq!(extended.input, "きょうは");
+    }
+
+    #[test]
+    fn prefix_mismatch_rebuilds_from_scratch() {
+        let dict = test_dict();
+        let mut cache = LatticeCache::new();
+        let first = cache.get_or_build("きょう", &dict);
+        let rebuilt = cache.get_or_build("てんき", &dict);
+        assert_eq!(rebuilt.input, "てんき");
+        assert!(
+            !Arc::ptr_eq(&first, &rebuilt),
+            "prefix mismatch should produce a fresh Arc, not reuse the old one"
+        );
+    }
+
+    #[test]
+    fn invalidate_forces_rebuild_on_same_reading() {
+        let dict = test_dict();
+        let mut cache = LatticeCache::new();
+        let before = cache.get_or_build("きょう", &dict);
+        cache.invalidate();
+        let after = cache.get_or_build("きょう", &dict);
+        assert_eq!(after.input, "きょう");
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "invalidate() followed by get_or_build should produce a fresh Arc"
+        );
+    }
+}

--- a/engine/crates/lex-session/src/lib.rs
+++ b/engine/crates/lex-session/src/lib.rs
@@ -10,6 +10,7 @@ mod candidate_gen;
 mod commit;
 mod composing;
 mod key_handlers;
+mod lattice_cache;
 mod response;
 mod snippet_handler;
 
@@ -28,6 +29,7 @@ pub use types::{
     KeyResponse, LearningRecord, MarkedText, SideEffects,
 };
 
+use lattice_cache::LatticeCache;
 use types::{Composition, SessionConfig, SessionState};
 
 /// Stateful IME session encapsulating all input processing logic.
@@ -39,6 +41,9 @@ pub struct InputSession {
     state: SessionState,
 
     config: SessionConfig,
+
+    /// Incremental Viterbi-input cache, independent of the UI `Composition`.
+    pub(crate) lattice_cache: LatticeCache,
 
     // History recording buffer
     history_records: Vec<LearningRecord>,
@@ -67,6 +72,7 @@ impl InputSession {
                 defer_candidates: false,
                 conversion_mode: ConversionMode::Standard,
             },
+            lattice_cache: LatticeCache::new(),
             history_records: Vec::new(),
             abc_passthrough: false,
             committed_context: String::new(),

--- a/engine/crates/lex-session/src/types/composition.rs
+++ b/engine/crates/lex-session/src/types/composition.rs
@@ -64,9 +64,6 @@ pub(crate) struct Composition {
     pub(crate) prefix: FrozenPrefix,
     pub(crate) candidates: CandidateState,
     pub(crate) stability: StabilityTracker,
-    /// Cached lattice for incremental extension on character append.
-    /// Cleared on backspace, auto-commit, or other destructive kana changes.
-    pub(crate) cached_lattice: Option<lex_core::converter::Lattice>,
 }
 
 impl Composition {
@@ -77,7 +74,6 @@ impl Composition {
             prefix: FrozenPrefix::new(),
             candidates: CandidateState::new(),
             stability: StabilityTracker::new(),
-            cached_lattice: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Extracts the incremental Viterbi lattice (introduced in #215) out of `Composition` and into a dedicated `LatticeCache` owned by `InputSession`.
- `Composition` is now a pure UI-display struct again; its lifetime no longer needs to thread a Viterbi-input cache through every backspace / auto-commit path.
- Invalidation is explicit at the session level: `handle_backspace`, `try_auto_commit`, and `reset_state` all call `lattice_cache.invalidate()`.

### Design notes

- `LatticeCache` holds `Option<Arc<Lattice>>`. `get_or_build` uses `Arc::try_unwrap` so the common "only owner" case extends the existing lattice in place; prefix mismatches fall back to a full rebuild.
- `AsyncCandidateRequest.lattice` stays `Option<Lattice>` for this PR. `async_worker::CandidateWork` will be migrated to `Arc<Lattice>` in the follow-up PR #6, together with the `convert_*_from_lattice` Arc plumbing.
- Cache is also invalidated on `reset_state` so a fresh composition never inherits a stale lattice from a previous session.

## Test plan

- [x] `cd engine && cargo fmt --all --check`
- [x] `cd engine && cargo clippy --workspace --all-features -- -D warnings`
- [x] `cd engine && cargo test --workspace --all-features` (all passing, 339 + 69 + 11 + 10)
- [x] `mise run accuracy` — unchanged: **64/64 pass, 2 skip** (same skip cases as before)
- [x] `mise run accuracy-history` — unchanged: **6/6 pass, 0 skip**

### accuracy (before / after)

Before:
```
=== Summary ===
  Total:     66
  Pass:       64
  Fail:        0
  Skip:        2
  Pass rate: 100.0% (64/64)
```

After:
```
=== Summary ===
  Total:     66
  Pass:       64
  Fail:        0
  Skip:        2
  Pass rate: 100.0% (64/64)
```

Skip cases are identical (`さんぜんえん`, `きのうともだちとえいがをみた`).

### accuracy-history (before / after)

Before:
```
=== Summary ===
  Total:     6
  Pass:        6
  Fail:        0
  Skip:        0
  Pass rate: 100.0% (6/6)
```

After:
```
=== Summary ===
  Total:     6
  Pass:        6
  Fail:        0
  Skip:        0
  Pass rate: 100.0% (6/6)
```