### PR TITLE
refactor: introduce Service protocol layer between Views and engine

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -89,6 +89,21 @@ final class AppContext {
         try config.reloadSnippets()
     }
 
+    // MARK: - Service factories
+
+    func makeUserDictionaryService() -> UserDictionaryService {
+        DefaultUserDictionaryService(
+            container: engineContainer, userDictPath: config.userDictPath)
+    }
+
+    func makeSnippetService() -> SnippetService {
+        DefaultSnippetService(config: config)
+    }
+
+    func makeEngineControlService() -> EngineControlService {
+        DefaultEngineControlService(container: engineContainer)
+    }
+
     // MARK: - Bootstrap
 
     static func bootstrap() -> AppContext {

--- a/Sources/Services/EngineControlService.swift
+++ b/Sources/Services/EngineControlService.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Engine-wide control operations exposed to the UI layer.
+protocol EngineControlService {
+    func clearHistory() throws
+}
+
+enum EngineControlServiceError: Error, LocalizedError {
+    case engineUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .engineUnavailable:
+            return "エンジンが利用できません"
+        }
+    }
+}
+
+final class DefaultEngineControlService: EngineControlService {
+    private let container: EngineContainer
+
+    init(container: EngineContainer) {
+        self.container = container
+    }
+
+    func clearHistory() throws {
+        guard let engine = container.engine else {
+            throw EngineControlServiceError.engineUnavailable
+        }
+        try engine.clearHistory()
+    }
+}

--- a/Sources/Services/SnippetService.swift
+++ b/Sources/Services/SnippetService.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Snippet file load/save operations exposed to the UI layer.
+protocol SnippetService {
+    func load() throws -> [LexSnippetEntry]
+    func save(_ entries: [LexSnippetEntry]) throws
+    func reload() throws
+}
+
+final class DefaultSnippetService: SnippetService {
+    private let config: ConfigStore
+
+    init(config: ConfigStore) {
+        self.config = config
+    }
+
+    func load() throws -> [LexSnippetEntry] {
+        let path = config.snippetPath
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return []
+        }
+        return try snippetsParse(content: content)
+    }
+
+    func save(_ entries: [LexSnippetEntry]) throws {
+        let toml = snippetsSerialize(entries: entries)
+        try FileManager.default.createDirectory(
+            atPath: config.supportDir, withIntermediateDirectories: true)
+        try toml.write(toFile: config.snippetPath, atomically: true, encoding: .utf8)
+    }
+
+    func reload() throws {
+        try config.reloadSnippets()
+    }
+}

--- a/Sources/Services/UserDictionaryService.swift
+++ b/Sources/Services/UserDictionaryService.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// User-dictionary operations exposed to the UI layer.
+protocol UserDictionaryService {
+    func list() -> [LexUserWord]
+    func register(reading: String, surface: String) throws
+    func unregister(reading: String, surface: String) throws
+    func save() throws
+}
+
+enum UserDictionaryServiceError: Error, LocalizedError {
+    case engineUnavailable
+    case duplicate
+    case notFound
+
+    var errorDescription: String? {
+        switch self {
+        case .engineUnavailable:
+            return "エンジンが利用できません"
+        case .duplicate:
+            return "同じ読み・表層の単語が既に登録されています"
+        case .notFound:
+            return "指定された単語は登録されていません"
+        }
+    }
+}
+
+final class DefaultUserDictionaryService: UserDictionaryService {
+    private let container: EngineContainer
+    private let userDictPath: String
+
+    init(container: EngineContainer, userDictPath: String) {
+        self.container = container
+        self.userDictPath = userDictPath
+    }
+
+    func list() -> [LexUserWord] {
+        container.engine?.listUserWords() ?? []
+    }
+
+    func register(reading: String, surface: String) throws {
+        guard let engine = container.engine else {
+            throw UserDictionaryServiceError.engineUnavailable
+        }
+        let added = engine.registerWord(reading: reading, surface: surface)
+        if !added {
+            throw UserDictionaryServiceError.duplicate
+        }
+    }
+
+    func unregister(reading: String, surface: String) throws {
+        guard let engine = container.engine else {
+            throw UserDictionaryServiceError.engineUnavailable
+        }
+        let removed = engine.unregisterWord(reading: reading, surface: surface)
+        if !removed {
+            throw UserDictionaryServiceError.notFound
+        }
+    }
+
+    func save() throws {
+        guard let engine = container.engine else {
+            throw UserDictionaryServiceError.engineUnavailable
+        }
+        try engine.saveUserDict(path: userDictPath)
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -31,7 +31,13 @@ struct DeveloperSettingsView: View {
     @State private var needsRestart = false
     @State private var showResetConfirm = false
 
-    private let supportDir = AppContext.shared.supportDir
+    private let supportDir: String
+    private let engineControl: EngineControlService
+
+    init(engineControl: EngineControlService? = nil, supportDir: String? = nil) {
+        self.engineControl = engineControl ?? AppContext.shared.makeEngineControlService()
+        self.supportDir = supportDir ?? AppContext.shared.supportDir
+    }
 
     private let editorHeight: CGFloat = 150
 
@@ -149,15 +155,11 @@ struct DeveloperSettingsView: View {
         NSLog("Lexime: Resetting all settings and history")
 
         // 1. Clear learning history via engine (closes WAL handle + deletes files)
-        if let engine = AppContext.shared.engine {
-            do {
-                try engine.clearHistory()
-                NSLog("Lexime: History cleared")
-            } catch {
-                NSLog("Lexime: Failed to clear history: %@", "\(error)")
-            }
-        } else {
-            NSLog("Lexime: Engine not available; skipping history clear")
+        do {
+            try engineControl.clearHistory()
+            NSLog("Lexime: History cleared")
+        } catch {
+            NSLog("Lexime: Failed to clear history: %@", "\(error)")
         }
 
         // 2. Delete config files

--- a/Sources/SnippetView.swift
+++ b/Sources/SnippetView.swift
@@ -7,7 +7,11 @@ struct SnippetView: View {
     @State private var selectedKey: String?
     @State private var saveError: String?
 
-    private let supportDir = AppContext.shared.supportDir
+    private let service: SnippetService
+
+    init(service: SnippetService? = nil) {
+        self.service = service ?? AppContext.shared.makeSnippetService()
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -71,13 +75,8 @@ struct SnippetView: View {
     }
 
     private func refresh() {
-        let path = (supportDir as NSString).appendingPathComponent("snippets.toml")
-        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
-            entries = []
-            return
-        }
         do {
-            entries = try snippetsParse(content: content)
+            entries = try service.load()
         } catch {
             NSLog("Lexime: Failed to parse snippets.toml: %@", "\(error)")
             saveError = "スニペットの読み込みに失敗しました: \(error.localizedDescription)"
@@ -89,23 +88,19 @@ struct SnippetView: View {
         entries.removeAll { $0.key == key }
         entries.append(LexSnippetEntry(key: key, body: body))
         entries.sort { $0.key < $1.key }
-        save()
+        persist()
     }
 
     private func removeSelected() {
         guard let key = selectedKey else { return }
         entries.removeAll { $0.key == key }
         selectedKey = nil
-        save()
+        persist()
     }
 
-    private func save() {
-        let toml = snippetsSerialize(entries: entries)
-        let path = (supportDir as NSString).appendingPathComponent("snippets.toml")
+    private func persist() {
         do {
-            try FileManager.default.createDirectory(
-                atPath: supportDir, withIntermediateDirectories: true)
-            try toml.write(toFile: path, atomically: true, encoding: .utf8)
+            try service.save(entries)
             NSLog("Lexime: Saved snippets.toml")
         } catch {
             NSLog("Lexime: Failed to save snippets.toml: %@", "\(error)")
@@ -113,7 +108,7 @@ struct SnippetView: View {
             return
         }
         do {
-            try AppContext.shared.reloadSnippets()
+            try service.reload()
         } catch {
             NSLog("Lexime: Failed to reload snippets.toml: %@", "\(error)")
             saveError = "保存は成功しましたが、再読み込みに失敗しました: \(error.localizedDescription)"

--- a/Sources/UserDictionaryView.swift
+++ b/Sources/UserDictionaryView.swift
@@ -78,9 +78,16 @@ struct UserDictionaryView: View {
     private func addWord(reading: String, surface: String) {
         do {
             try service.register(reading: reading, surface: surface)
-            try service.save()
         } catch {
             NSLog("Lexime: Failed to register word: %@", "\(error)")
+            saveError = "単語の登録に失敗しました: \(error.localizedDescription)"
+            refresh()
+            return
+        }
+        do {
+            try service.save()
+        } catch {
+            NSLog("Lexime: Failed to save user dict after register: %@", "\(error)")
             saveError = "辞書の保存に失敗しました: \(error.localizedDescription)"
         }
         refresh()
@@ -91,9 +98,17 @@ struct UserDictionaryView: View {
         let word = words[index]
         do {
             try service.unregister(reading: word.reading, surface: word.surface)
-            try service.save()
         } catch {
             NSLog("Lexime: Failed to unregister word: %@", "\(error)")
+            saveError = "単語の削除に失敗しました: \(error.localizedDescription)"
+            selectedIndex = nil
+            refresh()
+            return
+        }
+        do {
+            try service.save()
+        } catch {
+            NSLog("Lexime: Failed to save user dict after unregister: %@", "\(error)")
             saveError = "辞書の保存に失敗しました: \(error.localizedDescription)"
         }
         selectedIndex = nil

--- a/Sources/UserDictionaryView.swift
+++ b/Sources/UserDictionaryView.swift
@@ -7,6 +7,12 @@ struct UserDictionaryView: View {
     @State private var selectedIndex: Int?
     @State private var saveError: String?
 
+    private let service: UserDictionaryService
+
+    init(service: UserDictionaryService? = nil) {
+        self.service = service ?? AppContext.shared.makeUserDictionaryService()
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if words.isEmpty {
@@ -66,34 +72,32 @@ struct UserDictionaryView: View {
     }
 
     private func refresh() {
-        words = AppContext.shared.engine?.listUserWords() ?? []
+        words = service.list()
     }
 
     private func addWord(reading: String, surface: String) {
-        guard let engine = AppContext.shared.engine else { return }
-        let added = engine.registerWord(reading: reading, surface: surface)
-        if added { saveUserDict() }
+        do {
+            try service.register(reading: reading, surface: surface)
+            try service.save()
+        } catch {
+            NSLog("Lexime: Failed to register word: %@", "\(error)")
+            saveError = "辞書の保存に失敗しました: \(error.localizedDescription)"
+        }
         refresh()
     }
 
     private func removeSelected() {
-        guard let engine = AppContext.shared.engine,
-              let index = selectedIndex, index < words.count else { return }
+        guard let index = selectedIndex, index < words.count else { return }
         let word = words[index]
-        _ = engine.unregisterWord(reading: word.reading, surface: word.surface)
-        saveUserDict()
-        selectedIndex = nil
-        refresh()
-    }
-
-    private func saveUserDict() {
-        guard let engine = AppContext.shared.engine else { return }
         do {
-            try engine.saveUserDict(path: AppContext.shared.userDictPath)
+            try service.unregister(reading: word.reading, surface: word.surface)
+            try service.save()
         } catch {
-            NSLog("Lexime: Failed to save user dict: %@", "\(error)")
+            NSLog("Lexime: Failed to unregister word: %@", "\(error)")
             saveError = "辞書の保存に失敗しました: \(error.localizedDescription)"
         }
+        selectedIndex = nil
+        refresh()
     }
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -144,6 +144,7 @@ description = "Build Lexime.app (universal binary)"
 depends = ["uniffi-gen", "dict", "conn"]
 sources = [
   "Sources/*.swift",
+  "Sources/Services/*.swift",
   "generated/lex_engine.swift",
   "generated/lex_engineFFI.h",
   "generated/lex_engineFFI.modulemap",
@@ -172,9 +173,9 @@ LINK_FLAGS="-Lbuild -llex_engine"
 
 mkdir -p "$MACOS" "$RES"
 swiftc $SWIFTC_FLAGS $LINK_FLAGS -target x86_64-apple-macosx$MACOS_MIN \
-  generated/lex_engine.swift Sources/*.swift -o "$MACOS/Lexime-x86_64"
+  generated/lex_engine.swift Sources/*.swift Sources/Services/*.swift -o "$MACOS/Lexime-x86_64"
 swiftc $SWIFTC_FLAGS $LINK_FLAGS -target arm64-apple-macosx$MACOS_MIN \
-  generated/lex_engine.swift Sources/*.swift -o "$MACOS/Lexime-arm64"
+  generated/lex_engine.swift Sources/*.swift Sources/Services/*.swift -o "$MACOS/Lexime-arm64"
 lipo -create "$MACOS/Lexime-x86_64" "$MACOS/Lexime-arm64" -output "$MACOS/Lexime"
 rm "$MACOS/Lexime-x86_64" "$MACOS/Lexime-arm64"
 cp Info.plist "$APP/Contents/Info.plist"


### PR DESCRIPTION
## Summary

- Add `Sources/Services/` with three protocols (`UserDictionaryService`, `SnippetService`, `EngineControlService`) plus default implementations that wrap `EngineContainer` / `ConfigStore`.
- Remove every `AppContext.shared.engine` / `snippetStore` / `reloadSnippets()` reference from `SettingsView`, `UserDictionaryView`, and `SnippetView`. Views take a protocol through an optional initializer for future DI/testing and fall back to `AppContext.make*Service()` factories so the existing `SettingsWindowController.showWindow()` site (`SettingsView()`) keeps compiling.
- TOML parse/serialize stays on the Rust side for PR #8; the `snippetsParse`/`snippetsSerialize`/`snippetsLoad` calls are now confined to `DefaultSnippetService` and `ConfigStore`. PR #9 will migrate TOML handling to Swift.
- Update `mise run build` so `Sources/Services/*.swift` are compiled alongside the top-level sources.

## Scope boundary

This PR intentionally does not touch `LeximeInputController.swift`, `AppContext`'s composition, or `EngineContainer` beyond adding factory methods on `AppContext`. `LeximeInputController` still uses `AppContext.shared.engine`/`snippetStore` directly (PR #2 territory).

## Acceptance check

```
$ rg -n 'LexEngine|LexSnippetStore' Sources/*View.swift
(no matches)
```

## Test plan

- [x] `mise run build` passes (universal binary produced).
- [x] Acceptance grep: no `LexEngine` / `LexSnippetStore` mentions remain in `Sources/*View.swift`.
- [ ] Manual verification by user needed: open 設定 → ユーザ辞書 (add / remove / reopen), スニペット (add / remove), 開発者 → 初期化, ensure behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)