### PR TITLE
refactor: share Lattice via Arc and unify convert_from_lattice pipelines

### DIFF
--- a/engine/crates/lex-core/src/converter/mod.rs
+++ b/engine/crates/lex-core/src/converter/mod.rs
@@ -58,24 +58,13 @@ impl ConversionContext<'_> {
 
     /// 1-best conversion from a pre-built lattice.
     pub fn convert_from_lattice(&self, lattice: &Lattice) -> Vec<ConvertedSegment> {
-        if lattice.input.is_empty() {
-            return Vec::new();
-        }
-        let cost_fn = DefaultCostFunction::new(self.conn);
+        // 1-best uses a larger oversample floor than the N-best formula to give
+        // the reranker/history boost enough candidates to work with.
         let oversample = if self.history.is_some() { 30 } else { 10 };
-        let mut paths = viterbi_nbest(lattice, &cost_fn, oversample);
-        postprocess(
-            &mut paths,
-            lattice,
-            self.conn,
-            Some(self.dict),
-            self.history,
-            &lattice.input,
-            1,
-        )
-        .into_iter()
-        .next()
-        .unwrap_or_default()
+        self.convert_lattice_impl(lattice, 1, oversample)
+            .into_iter()
+            .next()
+            .unwrap_or_default()
     }
 
     /// N-best conversion from a pre-built lattice.
@@ -84,15 +73,25 @@ impl ConversionContext<'_> {
         lattice: &Lattice,
         n: usize,
     ) -> Vec<Vec<ConvertedSegment>> {
-        if lattice.input.is_empty() || n == 0 {
-            return Vec::new();
-        }
-        let cost_fn = DefaultCostFunction::new(self.conn);
         let oversample = if self.history.is_some() {
             (n * 3).max(50)
         } else {
             n * 3
         };
+        self.convert_lattice_impl(lattice, n, oversample)
+    }
+
+    /// Shared Viterbi + postprocess pipeline used by the 1-best and N-best wrappers.
+    fn convert_lattice_impl(
+        &self,
+        lattice: &Lattice,
+        n: usize,
+        oversample: usize,
+    ) -> Vec<Vec<ConvertedSegment>> {
+        if lattice.input.is_empty() || n == 0 {
+            return Vec::new();
+        }
+        let cost_fn = DefaultCostFunction::new(self.conn);
         let mut paths = viterbi_nbest(lattice, &cost_fn, oversample);
         postprocess(
             &mut paths,

--- a/engine/crates/lex-session/src/candidate_gen.rs
+++ b/engine/crates/lex-session/src/candidate_gen.rs
@@ -64,12 +64,10 @@ impl InputSession {
             c.candidates.selected = 0;
 
             let mut resp = build_marked_text(self.comp());
-            // AsyncCandidateRequest.lattice stays `Option<Lattice>` in this PR;
-            // PR #6 will switch it (and the worker) to `Arc<Lattice>`.
             resp.async_request = Some(AsyncCandidateRequest {
                 reading,
                 candidate_dispatch: self.config.conversion_mode.candidate_dispatch(),
-                lattice: Some((*lattice).clone()),
+                lattice: Some(std::sync::Arc::clone(&lattice)),
             });
             return resp;
         } else {

--- a/engine/crates/lex-session/src/types/mod.rs
+++ b/engine/crates/lex-session/src/types/mod.rs
@@ -106,7 +106,9 @@ pub struct AsyncCandidateRequest {
     pub candidate_dispatch: CandidateDispatch,
     /// Pre-built lattice for reuse by the async worker.
     /// `None` when the lattice is unavailable (e.g. auto-commit with new kana).
-    pub lattice: Option<lex_core::converter::Lattice>,
+    /// Shared via `Arc` so hand-off to the worker stays cheap — the session's
+    /// cache and the worker both hold references to the same lattice.
+    pub lattice: Option<std::sync::Arc<lex_core::converter::Lattice>>,
 }
 
 /// Orthogonal side-effects that accompany a response.

--- a/engine/src/async_worker.rs
+++ b/engine/src/async_worker.rs
@@ -17,7 +17,7 @@ pub(crate) struct CandidateWork {
     pub reading: String,
     pub dispatch: CandidateDispatch,
     pub generation: u64,
-    pub lattice: Option<crate::converter::Lattice>,
+    pub lattice: Option<Arc<crate::converter::Lattice>>,
 }
 
 pub(crate) struct CandidateResult {
@@ -72,7 +72,7 @@ impl AsyncWorker {
         &self,
         reading: String,
         dispatch: CandidateDispatch,
-        lattice: Option<crate::converter::Lattice>,
+        lattice: Option<Arc<crate::converter::Lattice>>,
     ) {
         let gen = self.candidate_gen.fetch_add(1, Ordering::SeqCst) + 1;
         if let Some(ref tx) = self.candidate_tx {
@@ -180,7 +180,7 @@ fn candidate_worker(
         // Use lattice.input as the canonical reading when a lattice was provided,
         // so the stale-check in receive_candidates matches the actual conversion.
         let reading = match latest.lattice {
-            Some(lattice) => lattice.input,
+            Some(lattice) => lattice.input.clone(),
             None => latest.reading,
         };
         let _ = tx.send(CandidateResult { reading, response });


### PR DESCRIPTION
## Summary

- `AsyncCandidateRequest.lattice` と `CandidateWork.lattice` を `Option<Lattice>` から `Option<Arc<Lattice>>` に変更。`LatticeCache` 側はすでに `Arc<Lattice>` を保持しているので、session → async worker の受け渡しがディープクローンではなく refcount bump になった。
- `ConversionContext::convert_from_lattice` と `convert_nbest_from_lattice` で重複していた empty-input ガード / viterbi_nbest / postprocess のパイプラインを private helper `convert_lattice_impl(&self, &Lattice, n, oversample) -> Vec<Vec<ConvertedSegment>>` に集約。oversample 式だけ 2 つの wrapper に残す（1-best: `history? 30 : 10`、N-best: `history? max(n*3, 50) : n*3`）。
- 既存 public シグネチャ (`convert_from_lattice` / `convert_nbest_from_lattice`) は変更なし。accuracy 出力も維持。

## Files changed

- `engine/crates/lex-core/src/converter/mod.rs` — helper 抽出
- `engine/crates/lex-session/src/types/mod.rs` — `AsyncCandidateRequest.lattice` を `Arc` 化
- `engine/crates/lex-session/src/candidate_gen.rs` — `Some((*lattice).clone())` → `Some(Arc::clone(&lattice))`
- `engine/src/async_worker.rs` — `CandidateWork.lattice` と `submit_candidates` を `Arc` 化、ワーカー末尾で `lattice.input.clone()`

4 files changed, 27 insertions(+), 28 deletions(-)

## Accuracy before / after

どちらも同一結果（リファクタで出力不変を確認）。

### `mise run accuracy` — before (main) と after (このブランチ) で共通

```
=== Summary ===
  Total:     66
  Pass:       63
  Fail:        1
  Skip:        2
  Pass rate: 98.4% (63/64)
```

Fail は pre-existing の `したほうがいい → したほうが良い (got: 下ほうが良い)` のみ (#229)。Skip は `さんぜんえん` と `きのうともだちとえいがをみた`。

### `mise run accuracy-history` — before / after 共通

```
=== Summary ===
  Total:     6
  Pass:        6
  Fail:        0
  Skip:        0
  Pass rate: 100.0% (6/6)
```

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` — all passing (339 lex-core + 74 lex-session + 11 lex_engine + …)
- [x] `mise run accuracy` — regression fail は pre-existing (#229)、他は変わらず
- [x] `mise run accuracy-history` — 6/6 pass

## Notes for reviewers

- **PR #3 との conflict 予測**: `engine/src/async_worker.rs` に触れるが、変更箇所は `CandidateWork.lattice` フィールド型と `submit_candidates` シグネチャ、ワーカーループ内の `let reading = match latest.lattice { Some(lattice) => lattice.input.clone(), None => ... }` の 3 点のみ。PR #3 の channel → callback 置換は別レイヤで、rebase 時に両方の hunk を素直に当てればほぼ解決する想定。
- コミットは (1) convert 統合、(2) Arc 化 の 2 段に分かれており、bisect / revert 容易。