### PR TITLE
refactor: move snippet TOML parsing to Swift

### DIFF
--- a/Sources/ConfigStore.swift
+++ b/Sources/ConfigStore.swift
@@ -4,7 +4,7 @@ struct SnippetLoadError: LocalizedError {
     let path: String
     let underlying: any Error
     var errorDescription: String? {
-        "snippets at \(path): \(underlying.localizedDescription)"
+        "snippets at \(path): \(String(describing: underlying))"
     }
 }
 

--- a/Sources/ConfigStore.swift
+++ b/Sources/ConfigStore.swift
@@ -17,7 +17,9 @@ final class ConfigStore {
     /// On success or missing file, updates `snippetStore` and posts notification.
     func reloadSnippets() throws {
         if FileManager.default.fileExists(atPath: snippetPath) {
-            let store = try snippetsLoad(path: snippetPath)
+            let content = try String(contentsOfFile: snippetPath, encoding: .utf8)
+            let entries = try SnippetTOML.parse(content)
+            let store = try snippetsBuildStore(entries: entries)
             NSLog("Lexime: Snippets reloaded from %@", snippetPath)
             self.snippetStore = store
         } else {

--- a/Sources/ConfigStore.swift
+++ b/Sources/ConfigStore.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+struct SnippetLoadError: LocalizedError {
+    let path: String
+    let underlying: any Error
+    var errorDescription: String? {
+        "snippets at \(path): \(underlying.localizedDescription)"
+    }
+}
+
 final class ConfigStore {
     let supportDir: String
     let userDictPath: String
@@ -17,11 +25,15 @@ final class ConfigStore {
     /// On success or missing file, updates `snippetStore` and posts notification.
     func reloadSnippets() throws {
         if FileManager.default.fileExists(atPath: snippetPath) {
-            let content = try String(contentsOfFile: snippetPath, encoding: .utf8)
-            let entries = try SnippetTOML.parse(content)
-            let store = try snippetsBuildStore(entries: entries)
-            NSLog("Lexime: Snippets reloaded from %@", snippetPath)
-            self.snippetStore = store
+            do {
+                let content = try String(contentsOfFile: snippetPath, encoding: .utf8)
+                let entries = try SnippetTOML.parse(content)
+                let store = try snippetsBuildStore(entries: entries)
+                NSLog("Lexime: Snippets reloaded from %@", snippetPath)
+                self.snippetStore = store
+            } catch {
+                throw SnippetLoadError(path: snippetPath, underlying: error)
+            }
         } else {
             self.snippetStore = nil
         }

--- a/Sources/Services/SnippetService.swift
+++ b/Sources/Services/SnippetService.swift
@@ -19,11 +19,11 @@ final class DefaultSnippetService: SnippetService {
         guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
             return []
         }
-        return try snippetsParse(content: content)
+        return try SnippetTOML.parse(content)
     }
 
     func save(_ entries: [LexSnippetEntry]) throws {
-        let toml = snippetsSerialize(entries: entries)
+        let toml = SnippetTOML.serialize(entries)
         try FileManager.default.createDirectory(
             atPath: config.supportDir, withIntermediateDirectories: true)
         try toml.write(toFile: config.snippetPath, atomically: true, encoding: .utf8)

--- a/Sources/Services/SnippetTOML.swift
+++ b/Sources/Services/SnippetTOML.swift
@@ -48,9 +48,10 @@ enum SnippetTOML {
             skipInlineWhitespace(trimmed, cursor: &cursor)
 
             if cursor < trimmed.endIndex, trimmed[cursor] != "#" {
+                let column = trimmed.distance(from: trimmed.startIndex, to: cursor) + 1
                 throw ParseError(
                     line: lineNumber,
-                    message: "unexpected trailing content: \(String(trimmed[cursor...]))")
+                    message: "unexpected trailing content after value at column \(column)")
             }
 
             if seenKeys.contains(key) {
@@ -166,7 +167,6 @@ enum SnippetTOML {
                 case "r": out.append("\r")
                 case "b": out.append("\u{08}")
                 case "f": out.append("\u{0C}")
-                case "/": out.append("/")
                 case "u":
                     cursor = line.index(after: cursor)
                     out.append(try readHexUnicode(line, cursor: &cursor, digits: 4, line: lineNumber))

--- a/Sources/Services/SnippetTOML.swift
+++ b/Sources/Services/SnippetTOML.swift
@@ -1,0 +1,305 @@
+import Foundation
+
+/// Minimal TOML parser and serializer for the snippets file format.
+///
+/// Only the subset actually emitted by the Lexime engine is supported:
+///   - Flat `key = "value"` pairs (no tables, no arrays)
+///   - Bare keys `[A-Za-z0-9_-]+` or quoted basic/literal string keys
+///   - Basic strings `"..."` with standard escapes (`\"`, `\\`, `\n`, `\t`,
+///     `\r`, `\b`, `\f`, `\uXXXX`, `\UXXXXXXXX`)
+///   - Literal strings `'...'` with no escape handling
+///   - `#` line comments and blank lines
+///
+/// Multi-line strings, integers, floats, dates, arrays, and inline tables are
+/// intentionally unsupported — snippets.toml never contains them. If a user
+/// hand-edits their file with unsupported syntax, parsing will throw a clear
+/// error and the UI will surface it.
+enum SnippetTOML {
+
+    struct ParseError: Error, CustomStringConvertible {
+        let line: Int
+        let message: String
+        var description: String { "line \(line): \(message)" }
+    }
+
+    /// Parse flat `key = "value"` TOML into snippet entries sorted by key.
+    static func parse(_ source: String) throws -> [LexSnippetEntry] {
+        var entries: [(String, String)] = []
+        var seenKeys: Set<String> = []
+
+        let lines = source.split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\n" })
+        for (index, rawLine) in lines.enumerated() {
+            let lineNumber = index + 1
+            let line = stripTrailingCR(rawLine)
+            let trimmed = trimLeadingWhitespace(line)
+            if trimmed.isEmpty || trimmed.first == "#" {
+                continue
+            }
+
+            var cursor = trimmed.startIndex
+            let key = try parseKey(trimmed, cursor: &cursor, line: lineNumber)
+            skipInlineWhitespace(trimmed, cursor: &cursor)
+            guard cursor < trimmed.endIndex, trimmed[cursor] == "=" else {
+                throw ParseError(line: lineNumber, message: "expected '=' after key")
+            }
+            cursor = trimmed.index(after: cursor)
+            skipInlineWhitespace(trimmed, cursor: &cursor)
+            let value = try parseString(trimmed, cursor: &cursor, line: lineNumber)
+            skipInlineWhitespace(trimmed, cursor: &cursor)
+
+            if cursor < trimmed.endIndex, trimmed[cursor] != "#" {
+                throw ParseError(
+                    line: lineNumber,
+                    message: "unexpected trailing content: \(String(trimmed[cursor...]))")
+            }
+
+            if seenKeys.contains(key) {
+                throw ParseError(line: lineNumber, message: "duplicate key '\(key)'")
+            }
+            seenKeys.insert(key)
+            entries.append((key, value))
+        }
+
+        entries.sort { $0.0 < $1.0 }
+        return entries.map { LexSnippetEntry(key: $0.0, body: $0.1) }
+    }
+
+    /// Serialize entries to `key = "value"` lines, sorted by key, trailing
+    /// newline after each entry. Round-trips with `parse`.
+    static func serialize(_ entries: [LexSnippetEntry]) -> String {
+        let sorted = entries.sorted { $0.key < $1.key }
+        var out = ""
+        for entry in sorted {
+            out += formatKey(entry.key)
+            out += " = "
+            out += formatBasicString(entry.body)
+            out += "\n"
+        }
+        return out
+    }
+
+    // MARK: - Key parsing
+
+    private static func parseKey(
+        _ line: Substring, cursor: inout Substring.Index, line lineNumber: Int
+    ) throws -> String {
+        guard cursor < line.endIndex else {
+            throw ParseError(line: lineNumber, message: "expected key")
+        }
+        let ch = line[cursor]
+        if ch == "\"" {
+            return try parseBasicString(line, cursor: &cursor, line: lineNumber)
+        }
+        if ch == "'" {
+            return try parseLiteralString(line, cursor: &cursor, line: lineNumber)
+        }
+        return try parseBareKey(line, cursor: &cursor, line: lineNumber)
+    }
+
+    private static func parseBareKey(
+        _ line: Substring, cursor: inout Substring.Index, line lineNumber: Int
+    ) throws -> String {
+        let start = cursor
+        while cursor < line.endIndex, isBareKeyChar(line[cursor]) {
+            cursor = line.index(after: cursor)
+        }
+        let key = String(line[start..<cursor])
+        if key.isEmpty {
+            throw ParseError(line: lineNumber, message: "invalid key")
+        }
+        return key
+    }
+
+    private static func isBareKeyChar(_ ch: Character) -> Bool {
+        guard let scalar = ch.unicodeScalars.first, ch.unicodeScalars.count == 1 else {
+            return false
+        }
+        return (scalar >= "A" && scalar <= "Z")
+            || (scalar >= "a" && scalar <= "z")
+            || (scalar >= "0" && scalar <= "9")
+            || scalar == "_" || scalar == "-"
+    }
+
+    // MARK: - String parsing
+
+    private static func parseString(
+        _ line: Substring, cursor: inout Substring.Index, line lineNumber: Int
+    ) throws -> String {
+        guard cursor < line.endIndex else {
+            throw ParseError(line: lineNumber, message: "expected string value")
+        }
+        let ch = line[cursor]
+        if ch == "\"" {
+            return try parseBasicString(line, cursor: &cursor, line: lineNumber)
+        }
+        if ch == "'" {
+            return try parseLiteralString(line, cursor: &cursor, line: lineNumber)
+        }
+        throw ParseError(
+            line: lineNumber,
+            message: "value must be a quoted string (found '\(ch)')")
+    }
+
+    private static func parseBasicString(
+        _ line: Substring, cursor: inout Substring.Index, line lineNumber: Int
+    ) throws -> String {
+        // cursor is at opening "
+        cursor = line.index(after: cursor)
+        var out = ""
+        while cursor < line.endIndex {
+            let ch = line[cursor]
+            if ch == "\"" {
+                cursor = line.index(after: cursor)
+                return out
+            }
+            if ch == "\\" {
+                cursor = line.index(after: cursor)
+                guard cursor < line.endIndex else {
+                    throw ParseError(line: lineNumber, message: "unterminated escape sequence")
+                }
+                let esc = line[cursor]
+                switch esc {
+                case "\"": out.append("\"")
+                case "\\": out.append("\\")
+                case "n": out.append("\n")
+                case "t": out.append("\t")
+                case "r": out.append("\r")
+                case "b": out.append("\u{08}")
+                case "f": out.append("\u{0C}")
+                case "/": out.append("/")
+                case "u":
+                    cursor = line.index(after: cursor)
+                    out.append(try readHexUnicode(line, cursor: &cursor, digits: 4, line: lineNumber))
+                    continue
+                case "U":
+                    cursor = line.index(after: cursor)
+                    out.append(try readHexUnicode(line, cursor: &cursor, digits: 8, line: lineNumber))
+                    continue
+                default:
+                    throw ParseError(
+                        line: lineNumber,
+                        message: "invalid escape sequence '\\\(esc)'")
+                }
+                cursor = line.index(after: cursor)
+                continue
+            }
+            out.append(ch)
+            cursor = line.index(after: cursor)
+        }
+        throw ParseError(line: lineNumber, message: "unterminated basic string")
+    }
+
+    private static func parseLiteralString(
+        _ line: Substring, cursor: inout Substring.Index, line lineNumber: Int
+    ) throws -> String {
+        // cursor is at opening '
+        cursor = line.index(after: cursor)
+        let start = cursor
+        while cursor < line.endIndex {
+            if line[cursor] == "'" {
+                let value = String(line[start..<cursor])
+                cursor = line.index(after: cursor)
+                return value
+            }
+            cursor = line.index(after: cursor)
+        }
+        throw ParseError(line: lineNumber, message: "unterminated literal string")
+    }
+
+    private static func readHexUnicode(
+        _ line: Substring, cursor: inout Substring.Index, digits: Int, line lineNumber: Int
+    ) throws -> Character {
+        var hex = ""
+        for _ in 0..<digits {
+            guard cursor < line.endIndex else {
+                throw ParseError(
+                    line: lineNumber,
+                    message: "expected \(digits) hex digits in unicode escape")
+            }
+            let ch = line[cursor]
+            if !ch.isHexDigit {
+                throw ParseError(
+                    line: lineNumber,
+                    message: "invalid hex digit '\(ch)' in unicode escape")
+            }
+            hex.append(ch)
+            cursor = line.index(after: cursor)
+        }
+        guard let code = UInt32(hex, radix: 16), let scalar = Unicode.Scalar(code) else {
+            throw ParseError(
+                line: lineNumber,
+                message: "invalid unicode scalar \\u\(hex)")
+        }
+        return Character(scalar)
+    }
+
+    // MARK: - Whitespace helpers
+
+    private static func skipInlineWhitespace(_ line: Substring, cursor: inout Substring.Index) {
+        while cursor < line.endIndex {
+            let ch = line[cursor]
+            if ch == " " || ch == "\t" {
+                cursor = line.index(after: cursor)
+            } else {
+                return
+            }
+        }
+    }
+
+    private static func trimLeadingWhitespace(_ line: Substring) -> Substring {
+        var idx = line.startIndex
+        while idx < line.endIndex, line[idx] == " " || line[idx] == "\t" {
+            idx = line.index(after: idx)
+        }
+        return line[idx...]
+    }
+
+    private static func stripTrailingCR(_ line: Substring) -> Substring {
+        if line.last == "\r" {
+            return line.dropLast()
+        }
+        return line
+    }
+
+    // MARK: - Serialization helpers
+
+    private static func isBareKey(_ key: String) -> Bool {
+        guard !key.isEmpty else { return false }
+        return key.unicodeScalars.allSatisfy { s in
+            (s >= "A" && s <= "Z") || (s >= "a" && s <= "z")
+                || (s >= "0" && s <= "9") || s == "_" || s == "-"
+        }
+    }
+
+    private static func formatKey(_ key: String) -> String {
+        if isBareKey(key) {
+            return key
+        }
+        return formatBasicString(key)
+    }
+
+    /// Serialize as a TOML basic string. Matches Rust `toml::Value::String`
+    /// output: escapes `"`, `\`, and control chars; leaves non-ASCII as-is.
+    private static func formatBasicString(_ value: String) -> String {
+        var out = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            case "\u{08}": out += "\\b"
+            case "\u{0C}": out += "\\f"
+            default:
+                if scalar.value < 0x20 || scalar.value == 0x7F {
+                    out += String(format: "\\u%04X", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        out += "\""
+        return out
+    }
+}

--- a/Sources/Services/SnippetTOML.swift
+++ b/Sources/Services/SnippetTOML.swift
@@ -16,10 +16,11 @@ import Foundation
 /// error and the UI will surface it.
 enum SnippetTOML {
 
-    struct ParseError: Error, CustomStringConvertible {
+    struct ParseError: Error, CustomStringConvertible, LocalizedError {
         let line: Int
         let message: String
         var description: String { "line \(line): \(message)" }
+        var errorDescription: String? { description }
     }
 
     /// Parse flat `key = "value"` TOML into snippet entries sorted by key.

--- a/Tests/TestRunner.swift
+++ b/Tests/TestRunner.swift
@@ -33,6 +33,7 @@ struct TestMain {
         testRomajiFFI()
         testDictFFI()
         testSessionFFI()
+        testSnippetTOML()
 
         print("\nResults: \(testsPassed) passed, \(testsFailed) failed")
         exit(testsFailed > 0 ? 1 : 0)

--- a/Tests/TestSnippetTOML.swift
+++ b/Tests/TestSnippetTOML.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+func testSnippetTOML() {
+    print("--- Snippet TOML Tests ---")
+
+    // Round-trip the real user's default layout
+    do {
+        let source = """
+            gh = "https://github.com/"
+            gmail = "kaz.july.7@gmail.com"
+            now = "$datetime"
+            today = "$date"
+            wareki = "$wareki"
+
+            """
+        let entries = try SnippetTOML.parse(source)
+        assertEqual(entries.count, 5, "5 entries")
+        assertEqual(entries[0].key, "gh", "sorted: gh first")
+        assertEqual(entries[0].body, "https://github.com/", "gh body")
+        assertEqual(entries[2].key, "now", "now key")
+        assertEqual(entries[2].body, "$datetime", "now body preserves $var")
+
+        let serialized = SnippetTOML.serialize(entries)
+        assertEqual(serialized, source, "round-trip exact match")
+    } catch {
+        testsFailed += 1
+        print("FAIL (basic round-trip): \(error)")
+    }
+
+    // Comments and blank lines are tolerated on parse
+    do {
+        let source = """
+            # header comment
+            a = "alpha"
+
+            # middle comment
+            b = "beta"  # inline comment
+            """
+        let entries = try SnippetTOML.parse(source)
+        assertEqual(entries.count, 2, "comments stripped")
+        assertEqual(entries[0].key, "a", "a key")
+        assertEqual(entries[0].body, "alpha", "a body")
+        assertEqual(entries[1].body, "beta", "b body (inline comment ignored)")
+    } catch {
+        testsFailed += 1
+        print("FAIL (comments): \(error)")
+    }
+
+    // Escape sequences: \n, \t, \", \\
+    do {
+        let source = #"""
+            multiline = "line1\nline2"
+            tabbed = "a\tb"
+            quoted = "say \"hi\""
+            slashes = "\\path"
+            """#
+        let entries = try SnippetTOML.parse(source)
+        let map = Dictionary(uniqueKeysWithValues: entries.map { ($0.key, $0.body) })
+        assertEqual(map["multiline"], "line1\nline2", "\\n escape")
+        assertEqual(map["tabbed"], "a\tb", "\\t escape")
+        assertEqual(map["quoted"], "say \"hi\"", "\\\" escape")
+        assertEqual(map["slashes"], "\\path", "\\\\ escape")
+
+        // Round-trip through serializer
+        let serialized = SnippetTOML.serialize(entries)
+        let reparsed = try SnippetTOML.parse(serialized)
+        let remap = Dictionary(uniqueKeysWithValues: reparsed.map { ($0.key, $0.body) })
+        assertEqual(remap["multiline"], "line1\nline2", "round-trip \\n")
+        assertEqual(remap["quoted"], "say \"hi\"", "round-trip \\\"")
+    } catch {
+        testsFailed += 1
+        print("FAIL (escapes): \(error)")
+    }
+
+    // Non-ASCII passes through without escaping
+    do {
+        let entries = [LexSnippetEntry(key: "hi", body: "こんにちは")]
+        let serialized = SnippetTOML.serialize(entries)
+        assertEqual(serialized, "hi = \"こんにちは\"\n", "japanese body preserved")
+        let reparsed = try SnippetTOML.parse(serialized)
+        assertEqual(reparsed[0].body, "こんにちは", "japanese round-trip")
+    } catch {
+        testsFailed += 1
+        print("FAIL (unicode): \(error)")
+    }
+
+    // Literal strings (single-quoted) — hand-edits should work
+    do {
+        let source = "k = 'raw \\n value'\n"
+        let entries = try SnippetTOML.parse(source)
+        assertEqual(entries.count, 1, "literal string parsed")
+        assertEqual(entries[0].body, "raw \\n value", "literal string preserves backslash")
+    } catch {
+        testsFailed += 1
+        print("FAIL (literal string): \(error)")
+    }
+
+    // Quoted keys with special chars
+    do {
+        let source = "\"key with space\" = \"v\"\n"
+        let entries = try SnippetTOML.parse(source)
+        assertEqual(entries.count, 1, "quoted key parsed")
+        assertEqual(entries[0].key, "key with space", "quoted key value")
+
+        // Serializer quotes non-bare keys
+        let serialized = SnippetTOML.serialize(entries)
+        assertEqual(serialized, "\"key with space\" = \"v\"\n", "non-bare key serialized quoted")
+    } catch {
+        testsFailed += 1
+        print("FAIL (quoted key): \(error)")
+    }
+
+    // Unicode escape \u00A9
+    do {
+        let source = "c = \"\\u00A9\"\n"
+        let entries = try SnippetTOML.parse(source)
+        assertEqual(entries[0].body, "©", "unicode escape decoded")
+    } catch {
+        testsFailed += 1
+        print("FAIL (unicode escape): \(error)")
+    }
+
+    // Errors: unterminated string
+    do {
+        _ = try SnippetTOML.parse("k = \"unclosed\n")
+        testsFailed += 1
+        print("FAIL: expected parse error for unterminated string")
+    } catch {
+        testsPassed += 1
+    }
+
+    // Errors: missing equals
+    do {
+        _ = try SnippetTOML.parse("k \"value\"\n")
+        testsFailed += 1
+        print("FAIL: expected parse error for missing '='")
+    } catch {
+        testsPassed += 1
+    }
+
+    // Errors: duplicate key
+    do {
+        _ = try SnippetTOML.parse("a = \"1\"\na = \"2\"\n")
+        testsFailed += 1
+        print("FAIL: expected parse error for duplicate key")
+    } catch {
+        testsPassed += 1
+    }
+
+    // Empty input produces empty list
+    do {
+        let entries = try SnippetTOML.parse("")
+        assertEqual(entries.count, 0, "empty input")
+        assertEqual(SnippetTOML.serialize([]), "", "empty serialize")
+    } catch {
+        testsFailed += 1
+        print("FAIL (empty): \(error)")
+    }
+}

--- a/Tests/TestSnippetTOML.swift
+++ b/Tests/TestSnippetTOML.swift
@@ -7,7 +7,7 @@ func testSnippetTOML() {
     do {
         let source = """
             gh = "https://github.com/"
-            gmail = "kaz.july.7@gmail.com"
+            gmail = "user@example.com"
             now = "$datetime"
             today = "$date"
             wareki = "$wareki"

--- a/engine/crates/lex-core/src/snippets/config.rs
+++ b/engine/crates/lex-core/src/snippets/config.rs
@@ -8,17 +8,17 @@ pub enum SnippetConfigError {
     UndefinedVariable { key: String, name: String },
 }
 
-/// Parse a snippets.toml file (flat key = "body" format).
-/// Validates that all variable references in bodies refer to known variables.
-pub fn parse_snippets_toml(
-    toml_str: &str,
+/// Validate that every `$name`/`${name}` reference in the snippet bodies
+/// resolves against the provided known variable list.
+///
+/// TOML parsing now lives in the Swift FFI boundary; this function accepts
+/// already-parsed entries so it can be shared by tests and by the
+/// `snippets_build_store` FFI call.
+pub fn validate_snippet_entries(
+    entries: &HashMap<String, String>,
     known_variables: &[String],
-) -> Result<HashMap<String, String>, SnippetConfigError> {
-    let table: HashMap<String, String> =
-        toml::from_str(toml_str).map_err(|e| SnippetConfigError::Parse(e.to_string()))?;
-
-    // Validate variable references in all bodies
-    for (key, body) in &table {
+) -> Result<(), SnippetConfigError> {
+    for (key, body) in entries {
         for var_name in extract_variable_names(body) {
             if !known_variables.contains(&var_name) {
                 return Err(SnippetConfigError::UndefinedVariable {
@@ -28,7 +28,19 @@ pub fn parse_snippets_toml(
             }
         }
     }
+    Ok(())
+}
 
+/// Parse a snippets.toml file (flat `key = "body"` format) and validate
+/// variable references.  Kept for unit tests and any non-FFI callers; the
+/// Swift layer no longer routes through this.
+pub fn parse_snippets_toml(
+    toml_str: &str,
+    known_variables: &[String],
+) -> Result<HashMap<String, String>, SnippetConfigError> {
+    let table: HashMap<String, String> =
+        toml::from_str(toml_str).map_err(|e| SnippetConfigError::Parse(e.to_string()))?;
+    validate_snippet_entries(&table, known_variables)?;
     Ok(table)
 }
 
@@ -149,5 +161,20 @@ greeting = "Today: ${date}"
         let known = vec!["date".to_string()];
         let result = parse_snippets_toml(toml, &known).unwrap();
         assert_eq!(result["greeting"], "Today: ${date}");
+    }
+
+    #[test]
+    fn test_validate_entries_undefined() {
+        let mut entries = HashMap::new();
+        entries.insert("k".to_string(), "hello $nope".to_string());
+        let err = validate_snippet_entries(&entries, &[]).unwrap_err();
+        assert!(matches!(err, SnippetConfigError::UndefinedVariable { .. }));
+    }
+
+    #[test]
+    fn test_validate_entries_ok() {
+        let mut entries = HashMap::new();
+        entries.insert("k".to_string(), "hello $name".to_string());
+        validate_snippet_entries(&entries, &["name".to_string()]).unwrap();
     }
 }

--- a/engine/crates/lex-core/src/snippets/mod.rs
+++ b/engine/crates/lex-core/src/snippets/mod.rs
@@ -2,6 +2,6 @@ mod config;
 mod store;
 mod variables;
 
-pub use config::{parse_snippets_toml, SnippetConfigError};
+pub use config::{parse_snippets_toml, validate_snippet_entries, SnippetConfigError};
 pub use store::SnippetStore;
 pub use variables::{SnippetVariable, VariableResolver};

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -124,11 +124,19 @@ fn snippets_build_store(
 
     let mut map: std::collections::HashMap<String, String> =
         std::collections::HashMap::with_capacity(entries.len());
-    for entry in entries {
-        if map.insert(entry.key.clone(), entry.body).is_some() {
-            return Err(LexError::InvalidData {
-                msg: format!("duplicate snippet key: \"{}\"", entry.key.escape_default()),
-            });
+    for LexSnippetEntry { key, body } in entries {
+        match map.entry(key) {
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                vacant.insert(body);
+            }
+            std::collections::hash_map::Entry::Occupied(occupied) => {
+                return Err(LexError::InvalidData {
+                    msg: format!(
+                        "duplicate snippet key: \"{}\"",
+                        occupied.key().escape_default()
+                    ),
+                });
+            }
         }
     }
     validate_snippet_entries(&map, &known)

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -107,65 +107,26 @@ fn snippet_trigger_key() -> Option<LexTriggerKey> {
         })
 }
 
-/// Parse snippets.toml into a flat list for UI display.
+/// Build a `LexSnippetStore` from entries parsed by the Swift layer.
 ///
-/// This intentionally performs only TOML syntax parsing without variable
-/// validation.  Variable references are validated at load time by
-/// `snippets_load()`, which is called on save via `reloadSnippets()`.
-/// Keeping this function lightweight lets the settings UI display raw
-/// entries (including those with invalid variable references) so users
-/// can see and fix them.
+/// Swift now owns snippets.toml I/O and TOML parsing; Rust only validates
+/// variable references against settings-defined variables and wraps the
+/// entries in a resolver-equipped store.
 #[uniffi::export]
-fn snippets_parse(content: String) -> Result<Vec<LexSnippetEntry>, LexError> {
-    let table: std::collections::HashMap<String, String> =
-        toml::from_str(&content).map_err(|e| LexError::InvalidData { msg: e.to_string() })?;
-    let mut entries: Vec<LexSnippetEntry> = table
-        .into_iter()
-        .map(|(key, body)| LexSnippetEntry { key, body })
-        .collect();
-    entries.sort_by(|a, b| a.key.cmp(&b.key));
-    Ok(entries)
-}
-
-#[uniffi::export]
-fn snippets_serialize(entries: Vec<LexSnippetEntry>) -> String {
-    let mut sorted = entries;
-    sorted.sort_by(|a, b| a.key.cmp(&b.key));
-    let mut out = String::new();
-    for entry in &sorted {
-        let key = if entry
-            .key
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-            && !entry.key.is_empty()
-        {
-            entry.key.clone()
-        } else {
-            format!("{}", toml::Value::String(entry.key.clone()))
-        };
-        out.push_str(&format!(
-            "{} = {}\n",
-            key,
-            toml::Value::String(entry.body.clone())
-        ));
-    }
-    out
-}
-
-#[uniffi::export]
-fn snippets_load(path: String) -> Result<std::sync::Arc<LexSnippetStore>, LexError> {
-    use lex_core::snippets::{parse_snippets_toml, SnippetStore, VariableResolver};
-
-    let content = std::fs::read_to_string(&path).map_err(|e| LexError::Io {
-        msg: format!("{path}: {e}"),
-    })?;
+fn snippets_build_store(
+    entries: Vec<LexSnippetEntry>,
+) -> Result<std::sync::Arc<LexSnippetStore>, LexError> {
+    use lex_core::snippets::{validate_snippet_entries, SnippetStore, VariableResolver};
 
     let settings = crate::settings::settings();
     let resolver = VariableResolver::new(settings.snippets.variables.clone());
     let known = resolver.known_names();
-    let entries = parse_snippets_toml(&content, &known)
+
+    let map: std::collections::HashMap<String, String> =
+        entries.into_iter().map(|e| (e.key, e.body)).collect();
+    validate_snippet_entries(&map, &known)
         .map_err(|e| LexError::InvalidData { msg: e.to_string() })?;
 
-    let store = SnippetStore::new(entries, resolver);
+    let store = SnippetStore::new(map, resolver);
     Ok(LexSnippetStore::new(std::sync::Arc::new(store)))
 }

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -122,8 +122,15 @@ fn snippets_build_store(
     let resolver = VariableResolver::new(settings.snippets.variables.clone());
     let known = resolver.known_names();
 
-    let map: std::collections::HashMap<String, String> =
-        entries.into_iter().map(|e| (e.key, e.body)).collect();
+    let mut map: std::collections::HashMap<String, String> =
+        std::collections::HashMap::with_capacity(entries.len());
+    for entry in entries {
+        if map.insert(entry.key.clone(), entry.body).is_some() {
+            return Err(LexError::InvalidData {
+                msg: format!("duplicate snippet key: {}", entry.key),
+            });
+        }
+    }
     validate_snippet_entries(&map, &known)
         .map_err(|e| LexError::InvalidData { msg: e.to_string() })?;
 

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -127,7 +127,7 @@ fn snippets_build_store(
     for entry in entries {
         if map.insert(entry.key.clone(), entry.body).is_some() {
             return Err(LexError::InvalidData {
-                msg: format!("duplicate snippet key: {}", entry.key),
+                msg: format!("duplicate snippet key: \"{}\"", entry.key.escape_default()),
             });
         }
     }

--- a/mise.toml
+++ b/mise.toml
@@ -224,6 +224,8 @@ description = "Run Swift unit tests (UniFFI round-trip)"
 depends = ["uniffi-gen"]
 # NOTE: Test files are listed explicitly because swiftc compiles all sources
 # into one binary. If you add a new test file under Tests/, add it here too.
+# Source files required by tests are also listed explicitly (SnippetTOML for
+# TestSnippetTOML).
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
@@ -231,7 +233,8 @@ mkdir -p build
 swiftc -Xcc -fmodule-map-file=generated/lex_engineFFI.modulemap \
   -Lbuild -llex_engine \
   generated/lex_engine.swift \
-  Tests/TestRunner.swift Tests/TestRomajiFFI.swift Tests/TestDictFFI.swift Tests/TestSessionFFI.swift \
+  Sources/Services/SnippetTOML.swift \
+  Tests/TestRunner.swift Tests/TestRomajiFFI.swift Tests/TestDictFFI.swift Tests/TestSessionFFI.swift Tests/TestSnippetTOML.swift \
   -o build/test-runner && build/test-runner
 """
 


### PR DESCRIPTION
## Summary

- Remove `snippets_parse`, `snippets_serialize`, and `snippets_load` from the UniFFI surface; replace them with a single `snippets_build_store(entries)` call that validates variable references and wraps entries in a `SnippetStore`.
- Add a small, hand-rolled Swift TOML parser/serializer (`Sources/Services/SnippetTOML.swift`) scoped to the flat `key = "value"` format snippets.toml uses. Supports basic strings with standard escapes, literal strings, bare and quoted keys, comments, and blank lines.
- `DefaultSnippetService` and `ConfigStore.reloadSnippets()` now do file I/O plus TOML parsing in Swift and only cross the FFI to build the store.

## TOML parser choice

Hand-rolled, ~200 LOC of actual logic. Snippets.toml only ever contains flat `key = "value"` pairs, so a full TOML library would be overkill. The parser rejects anything it doesn't recognize with a line-numbered error, and the serializer emits byte-for-byte the same format as `toml::Value::String` for the subset we care about — verified by round-tripping the real snippet file layout (5 entries including `\$datetime` / `\$date` / `\$wareki` variable references) with exact equality.

## Test plan

- [x] `cd engine && cargo fmt --all --check`
- [x] `cd engine && cargo clippy --workspace --all-features -- -D warnings`
- [x] `cd engine && cargo test --workspace --all-features` — all pass
- [x] `mise run build` — succeeds, UniFFI regenerates with only `snippetsBuildStore` (no parse/serialize/load)
- [x] `mise run test-swift` — 40/40 pass, including the new `TestSnippetTOML` round-trip and edge-case suite
- [x] `mise run accuracy` — same baseline as main: 1 pre-existing fail (`したほうがいい`, #229) plus the 2 skip cases, all other 63 pass
- [x] Round-trip of the real user snippets.toml layout via a standalone harness: exact byte equality

## Compatibility

The serializer preserves the engine's current output format exactly (tested on the real user file: `gh = "…"`, `now = "\$datetime"`, etc.). Existing snippets.toml files load unchanged — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)