### PR TITLE
refactor: push async session events via UniFFI callback

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -135,7 +135,6 @@ UniFFI proc-macro で Swift バインディングを自動生成。`generated/le
 | `ShowCandidates { surfaces, selected }` | 候補パネル表示 |
 | `HideCandidates` | 候補パネル非表示 |
 | `SwitchToAbc` | システム ABC 入力ソースに切替 |
-| `SchedulePoll` | ポールタイマー開始要求 |
 
 **トップレベル関数**:
 
@@ -157,11 +156,17 @@ UniFFI proc-macro で Swift バインディングを自動生成。`generated/le
 |---|---|
 | `handle_key(event)` | キー入力処理（`LexKeyEvent`）→ `LexKeyResponse` |
 | `commit()` | 現在の入力を確定 → `LexKeyResponse` |
-| `poll()` | 非同期結果をチェック → `Option<LexKeyResponse>` |
 | `is_composing()` | 入力中かどうか |
 | `set_defer_candidates(enabled)` | 非同期候補生成の有効化 |
 | `set_conversion_mode(mode)` | 変換モード切替（LexConversionMode enum） |
 | `set_abc_passthrough(enabled)` | ABC パススルー設定 |
+| `shutdown()` | AsyncWorker スレッドを即時停止 |
+
+**LexSessionEvents** (foreign callback interface):
+
+| メソッド | 説明 |
+|---|---|
+| `on_async_response(response)` | 非同期候補結果を `LexKeyResponse` として受信（Worker スレッドから呼ばれる） |
 
 ## 入力モデル
 
@@ -333,15 +338,15 @@ english サブモードで入力された連続 ASCII セグメントは、1 文
 
 ## 非同期候補生成
 
-候補生成は Rust 側の `AsyncWorker` でバックグラウンド実行する。Swift はポーリングで結果を受け取る。
+候補生成は Rust 側の `AsyncWorker` でバックグラウンド実行し、完了時に `LexSessionEvents` コールバックで Swift に結果を push する。
 
 ### アーキテクチャ
 
 1. キー入力 → `LexSession::handle_key()` → セッションが `async_request` を返す
 2. `handle_key` 内で自動的に `AsyncWorker` にサブミット
-3. レスポンスに `SchedulePoll` イベントを含めて返す
-4. Swift 側の 50ms ポールタイマーが `LexSession::poll()` を呼び出し
-5. `poll()` が `AsyncWorker` のチャネルから結果を取得し、セッションに配信
+3. `AsyncWorker` のワーカースレッドが候補を生成
+4. 完了時に `LexSessionEvents::on_async_response` を呼び、セッションを更新した上で `LexKeyResponse` を Swift に渡す
+5. Swift 側は main thread に dispatch して IMKit / 候補パネルに反映
 6. 結果が stale（generation counter 不一致）なら破棄
 
 ### AsyncWorker
@@ -352,7 +357,8 @@ english サブモードで入力された連続 ASCII セグメントは、1 文
 
 - `AtomicU64` generation counter で staleness を管理
 - mpsc チャネルの drain-to-latest で最新リクエストのみ処理
-- ポールタイマーは 5 秒アイドルタイムアウトで自動停止
+- ワーカースレッドは `LexSession` Drop または `shutdown()` で join される
+- foreign callback 呼び出しは `catch_unwind` で保護
 
 ## 学習機能
 

--- a/Sources/Controller/SessionCoordinator.swift
+++ b/Sources/Controller/SessionCoordinator.swift
@@ -3,8 +3,8 @@ import InputMethodKit
 
 /// Owns the Rust LexSession and translates IMKit key events into session calls,
 /// applying the resulting LexEvent stream to the IMKTextInput client and the
-/// candidate panel. Also owns the async poll timer that drains deferred
-/// session results between keystrokes.
+/// candidate panel. Async results are delivered via the `LexSessionEvents`
+/// callback, dispatched onto the main thread.
 final class SessionCoordinator {
 
     private let session: LexSession
@@ -14,19 +14,25 @@ final class SessionCoordinator {
     /// Tracks the currently displayed marked text so composedString stays in sync.
     private(set) var currentDisplay: String?
 
-    private var pollTimer: Timer?
-    private weak var pollClient: IMKTextInput?
+    /// Client captured by the most recent handleKey. Used when an async callback
+    /// arrives between keystrokes and we need an IMKTextInput to apply events against.
+    private weak var lastClient: IMKTextInput?
 
-    init(session: LexSession,
+    init(factory: (LexSessionEvents) -> LexSession,
          candidateManager: CandidateManager,
          onSwitchToAbc: @escaping () -> Void) {
-        self.session = session
         self.candidateManager = candidateManager
         self.onSwitchToAbc = onSwitchToAbc
+        // Build the listener first, then construct the session with it. The
+        // listener holds only a weak reference to `self`, breaking the retain
+        // cycle created by LexSession -> listener -> SessionCoordinator.
+        let listener = Listener()
+        self.session = factory(listener)
+        listener.coordinator = self
     }
 
     deinit {
-        pollTimer?.invalidate()
+        session.shutdown()
     }
 
     // MARK: - Session Passthrough
@@ -43,17 +49,8 @@ final class SessionCoordinator {
 
     // MARK: - Key Handling
 
-    /// Drain any pending async results before taking a new key event.
-    /// Safe to call on any incoming IMKit event; does not stop the poll loop,
-    /// so modifier-only events won't starve deferred candidate updates.
-    func drainPending(client: IMKTextInput) {
-        while let resp = session.poll() {
-            applyEvents(resp, client: client)
-        }
-    }
-
     func handleKey(_ keyEvent: LexKeyEvent, client: IMKTextInput) -> Bool {
-        cancelPollTimer()
+        lastClient = client
         candidateManager.invalidate()
         let resp = session.handleKey(event: keyEvent)
         applyEvents(resp, client: client)
@@ -61,6 +58,7 @@ final class SessionCoordinator {
     }
 
     func commit(client: IMKTextInput) {
+        lastClient = client
         let resp = session.commit()
         applyEvents(resp, client: client)
     }
@@ -72,12 +70,17 @@ final class SessionCoordinator {
     }
 
     func deactivate() {
-        cancelPollTimer()
         candidateManager.deactivate()
         currentDisplay = nil
+        lastClient = nil
     }
 
     // MARK: - Apply Events
+
+    fileprivate func applyAsyncResponse(_ resp: LexKeyResponse) {
+        guard let client = lastClient else { return }
+        applyEvents(resp, client: client)
+    }
 
     private func applyEvents(_ resp: LexKeyResponse, client: IMKTextInput) {
         for event in resp.events {
@@ -96,8 +99,6 @@ final class SessionCoordinator {
                 candidateManager.hide()
             case .switchToAbc:
                 onSwitchToAbc()
-            case .schedulePoll:
-                schedulePollTimer(client: client)
             }
         }
     }
@@ -113,37 +114,20 @@ final class SessionCoordinator {
                              selectionRange: NSRange(location: len, length: 0),
                              replacementRange: NSRange(location: NSNotFound, length: 0))
     }
+}
 
-    // MARK: - Poll Timer
+/// Bridge object passed to `LexEngine.createSession`. Holds a weak reference
+/// back to the coordinator so the Rust-held listener does not keep the
+/// coordinator alive (breaking the retain cycle `LexSession` -> listener ->
+/// `SessionCoordinator` -> `LexSession`).
+private final class Listener: LexSessionEvents, @unchecked Sendable {
+    weak var coordinator: SessionCoordinator?
 
-    private func schedulePollTimer(client: IMKTextInput) {
-        pollClient = client
-        guard pollTimer == nil else { return }
-        var idleTicks = 0
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
-            guard let self, let client = self.pollClient else {
-                self?.cancelPollTimer()
-                return
-            }
-            var hadResult = false
-            while let resp = self.session.poll() {
-                self.applyEvents(resp, client: client)
-                hadResult = true
-            }
-            if hadResult {
-                idleTicks = 0
-            } else {
-                idleTicks += 1
-                if idleTicks >= 100 {
-                    self.cancelPollTimer()
-                }
-            }
+    func onAsyncResponse(response: LexKeyResponse) {
+        // Invoked on the Rust AsyncWorker thread; bounce to the main thread
+        // where UI / IMKit calls are safe.
+        DispatchQueue.main.async { [weak self] in
+            self?.coordinator?.applyAsyncResponse(response)
         }
-    }
-
-    private func cancelPollTimer() {
-        pollTimer?.invalidate()
-        pollTimer = nil
-        pollClient = nil
     }
 }

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -28,17 +28,18 @@ class LeximeInputController: IMKInputController {
             return
         }
 
-        let session = engine.createSession()
-        session.setDeferCandidates(enabled: true)
-        session.setSnippetStore(store: AppContext.shared.snippetStore)
-        let convMode = UserDefaults.standard.integer(forKey: DefaultsKey.conversionMode)
-        if convMode == 1 {
-            session.setConversionMode(mode: .predictive)
-        }
-
         let modeController = self.modeController
+        let convMode = UserDefaults.standard.integer(forKey: DefaultsKey.conversionMode)
         coordinator = SessionCoordinator(
-            session: session,
+            factory: { listener in
+                let session = engine.createSession(listener: listener)
+                session.setDeferCandidates(enabled: true)
+                session.setSnippetStore(store: AppContext.shared.snippetStore)
+                if convMode == 1 {
+                    session.setConversionMode(mode: .predictive)
+                }
+                return session
+            },
             candidateManager: candidateManager,
             onSwitchToAbc: { modeController.selectStandardABC() })
 
@@ -66,8 +67,6 @@ class LeximeInputController: IMKInputController {
         guard let coordinator, let event, let client = sender as? IMKTextInput else {
             return false
         }
-
-        coordinator.drainPending(client: client)
 
         guard event.type == .keyDown else {
             // Consume modifier-only events while composing

--- a/engine/src/api/engine.rs
+++ b/engine/src/api/engine.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use super::session::LexSessionEvents;
 use super::{
     LexConnection, LexDictionary, LexError, LexSession, LexUserDictionary, LexUserHistory,
     LexUserWord,
@@ -30,11 +31,12 @@ impl LexEngine {
         })
     }
 
-    fn create_session(&self) -> Arc<LexSession> {
+    fn create_session(&self, listener: Arc<dyn LexSessionEvents>) -> Arc<LexSession> {
         LexSession::new(
             Arc::clone(&self.dict),
             self.conn.as_ref().map(Arc::clone),
             self.history.as_ref().map(Arc::clone),
+            listener,
         )
     }
 

--- a/engine/src/api/mapping.rs
+++ b/engine/src/api/mapping.rs
@@ -42,7 +42,7 @@ impl From<LexKeyEvent> for KeyEvent {
     }
 }
 
-pub(super) fn convert_to_events(resp: KeyResponse, has_pending_work: bool) -> LexKeyResponse {
+pub(super) fn convert_to_events(resp: KeyResponse) -> LexKeyResponse {
     let mut events = Vec::new();
 
     // 1. Commit
@@ -67,11 +67,6 @@ pub(super) fn convert_to_events(resp: KeyResponse, has_pending_work: bool) -> Le
     // 4. Side effects
     if resp.side_effects.switch_to_abc {
         events.push(LexEvent::SwitchToAbc);
-    }
-
-    // 5. Schedule poll
-    if has_pending_work {
-        events.push(LexEvent::SchedulePoll);
     }
 
     LexKeyResponse {
@@ -99,7 +94,7 @@ mod tests {
     #[test]
     fn test_convert_empty_response() {
         let resp = empty_response();
-        let result = convert_to_events(resp, false);
+        let result = convert_to_events(resp);
         assert!(!result.consumed);
         assert!(result.events.is_empty());
     }
@@ -109,7 +104,7 @@ mod tests {
         let mut resp = empty_response();
         resp.consumed = true;
         resp.commit = Some("テスト".to_string());
-        let result = convert_to_events(resp, false);
+        let result = convert_to_events(resp);
         assert!(result.consumed);
         assert_eq!(result.events.len(), 1);
         assert!(matches!(&result.events[0], LexEvent::Commit { text } if text == "テスト"));
@@ -122,7 +117,7 @@ mod tests {
         resp.marked = Some(MarkedText {
             text: "かな".to_string(),
         });
-        let result = convert_to_events(resp, false);
+        let result = convert_to_events(resp);
         assert_eq!(result.events.len(), 1);
         assert!(matches!(&result.events[0], LexEvent::SetMarkedText { text } if text == "かな"));
     }
@@ -134,7 +129,7 @@ mod tests {
         resp.marked = Some(MarkedText {
             text: String::new(),
         });
-        let result = convert_to_events(resp, false);
+        let result = convert_to_events(resp);
         // Empty marked text becomes SetMarkedText with empty string
         assert_eq!(result.events.len(), 1);
         assert!(matches!(&result.events[0], LexEvent::SetMarkedText { text } if text.is_empty()));
@@ -148,7 +143,7 @@ mod tests {
             surfaces: vec!["候補1".to_string(), "候補2".to_string()],
             selected: 0,
         };
-        let result = convert_to_events(resp, false);
+        let result = convert_to_events(resp);
         assert_eq!(result.events.len(), 1);
         assert!(matches!(
             &result.events[0],
@@ -162,17 +157,9 @@ mod tests {
         let mut resp = empty_response();
         resp.consumed = true;
         resp.candidates = CandidateAction::Hide;
-        let result = convert_to_events(resp, false);
+        let result = convert_to_events(resp);
         assert_eq!(result.events.len(), 1);
         assert!(matches!(&result.events[0], LexEvent::HideCandidates));
-    }
-
-    #[test]
-    fn test_convert_schedule_poll() {
-        let resp = empty_response();
-        let result = convert_to_events(resp, true);
-        assert_eq!(result.events.len(), 1);
-        assert!(matches!(&result.events[0], LexEvent::SchedulePoll));
     }
 
     #[test]
@@ -180,7 +167,7 @@ mod tests {
         let mut resp = empty_response();
         resp.consumed = true;
         resp.side_effects.switch_to_abc = true;
-        let result = convert_to_events(resp, false);
+        let result = convert_to_events(resp);
         assert_eq!(result.events.len(), 1);
         assert!(matches!(&result.events[0], LexEvent::SwitchToAbc));
     }
@@ -197,13 +184,12 @@ mod tests {
             surfaces: vec!["a".to_string()],
             selected: 0,
         };
-        let result = convert_to_events(resp, true);
+        let result = convert_to_events(resp);
         assert!(result.consumed);
-        // commit + marked + candidates + poll = 4
-        assert_eq!(result.events.len(), 4);
+        // commit + marked + candidates = 3
+        assert_eq!(result.events.len(), 3);
         assert!(matches!(&result.events[0], LexEvent::Commit { .. }));
         assert!(matches!(&result.events[1], LexEvent::SetMarkedText { .. }));
         assert!(matches!(&result.events[2], LexEvent::ShowCandidates { .. }));
-        assert!(matches!(&result.events[3], LexEvent::SchedulePoll));
     }
 }

--- a/engine/src/api/mod.rs
+++ b/engine/src/api/mod.rs
@@ -12,7 +12,7 @@ mod user_dict;
 
 pub use engine::LexEngine;
 pub use resources::{LexConnection, LexDictionary, LexUserHistory};
-pub use session::LexSession;
+pub use session::{LexSession, LexSessionEvents};
 pub use snippet_store::LexSnippetStore;
 pub use types::{
     LexConversionMode, LexDictEntry, LexError, LexEvent, LexKeyEvent, LexKeyResponse,

--- a/engine/src/api/session.rs
+++ b/engine/src/api/session.rs
@@ -159,8 +159,11 @@ impl LexSession {
     /// IMKInputController teardown to guarantee the worker is joined before
     /// the last Arc to `LexSession` is dropped.
     fn shutdown(&self) {
-        let mut slot = self.worker.lock().unwrap();
-        *slot = None;
+        let worker = {
+            let mut slot = self.worker.lock().unwrap();
+            slot.take()
+        };
+        drop(worker);
     }
 }
 

--- a/engine/src/api/session.rs
+++ b/engine/src/api/session.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use crate::async_worker::AsyncWorker;
+use crate::async_worker::{AsyncWorker, CandidateResult, CandidateSink};
 use crate::converter::ConvertedSegment;
 use crate::session::{InputSession, LearningRecord};
 
@@ -9,6 +9,40 @@ use super::resources::{LexConnection, LexDictionary, LexUserHistory};
 use super::snippet_store::LexSnippetStore;
 use super::types::LexConversionMode;
 use super::{LexKeyEvent, LexKeyResponse};
+
+/// Listener for async session events delivered from the Rust worker thread.
+///
+/// Implementations must be `Send + Sync` (UniFFI requirement). The callback is
+/// invoked on the AsyncWorker thread — foreign implementations are responsible
+/// for dispatching onto their UI thread if needed.
+#[uniffi::export(with_foreign)]
+pub trait LexSessionEvents: Send + Sync {
+    fn on_async_response(&self, response: LexKeyResponse);
+}
+
+/// Bridge from the internal `CandidateSink` trait to the foreign `LexSessionEvents`.
+/// Also holds a weak reference back to the `LexSession` so results can be merged
+/// into session state without creating a retain cycle with the worker thread.
+struct ListenerSink {
+    session: std::sync::Weak<LexSession>,
+    listener: Arc<dyn LexSessionEvents>,
+}
+
+impl CandidateSink for ListenerSink {
+    fn deliver(&self, result: CandidateResult) {
+        let Some(session) = self.session.upgrade() else {
+            return;
+        };
+        let Some(resp) = session.integrate_candidate_result(result) else {
+            return;
+        };
+        let listener = Arc::clone(&self.listener);
+        // Isolate foreign-code panics so the worker thread keeps running.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            listener.on_async_response(resp);
+        }));
+    }
+}
 
 /// IME session exposed to the Swift frontend via UniFFI.
 ///
@@ -22,7 +56,7 @@ use super::{LexKeyEvent, LexKeyResponse};
 pub struct LexSession {
     history: Option<Arc<LexUserHistory>>,
     session: Mutex<InputSession>,
-    worker: AsyncWorker,
+    worker: Mutex<Option<AsyncWorker>>,
 }
 
 #[uniffi::export]
@@ -32,42 +66,54 @@ impl LexSession {
         dict: Arc<LexDictionary>,
         conn: Option<Arc<LexConnection>>,
         history: Option<Arc<LexUserHistory>>,
+        listener: Arc<dyn LexSessionEvents>,
     ) -> Arc<Self> {
         let session = InputSession::new(
             Arc::clone(&dict.inner),
             conn.as_ref().map(|c| Arc::clone(&c.inner)),
             history.as_ref().map(|h| Arc::clone(&h.inner)),
         );
-        let worker = AsyncWorker::new(
-            Arc::clone(&dict.inner),
-            conn.as_ref().map(|c| Arc::clone(&c.inner)),
-            history.as_ref().map(|h| Arc::clone(&h.inner)),
-        );
-        Arc::new(Self {
-            history,
-            session: Mutex::new(session),
-            worker,
-        })
+
+        let arc = Arc::new_cyclic(|weak: &std::sync::Weak<LexSession>| {
+            let sink = ListenerSink {
+                session: weak.clone(),
+                listener,
+            };
+            let worker = AsyncWorker::new(
+                Arc::clone(&dict.inner),
+                conn.as_ref().map(|c| Arc::clone(&c.inner)),
+                history.as_ref().map(|h| Arc::clone(&h.inner)),
+                sink,
+            );
+            Self {
+                history,
+                session: Mutex::new(session),
+                worker: Mutex::new(Some(worker)),
+            }
+        });
+        arc
     }
 
     fn handle_key(&self, event: LexKeyEvent) -> LexKeyResponse {
         // Invalidate stale candidates from previous key events
-        self.worker.invalidate_candidates();
+        if let Some(worker) = self.worker.lock().unwrap().as_ref() {
+            worker.invalidate_candidates();
+        }
 
         let mut session = self.session.lock().unwrap();
         let mut resp = session.handle_key(event.into());
 
         // Submit async candidate work internally
-        let has_pending_work = resp.async_request.is_some();
         if let Some(req) = resp.async_request.take() {
-            self.worker
-                .submit_candidates(req.reading, req.candidate_dispatch, req.lattice);
+            if let Some(worker) = self.worker.lock().unwrap().as_ref() {
+                worker.submit_candidates(req.reading, req.candidate_dispatch, req.lattice);
+            }
         }
 
         let records = session.take_history_records();
         drop(session);
         self.record_history(&records);
-        convert_to_events(resp, has_pending_work)
+        convert_to_events(resp)
     }
 
     fn commit(&self) -> LexKeyResponse {
@@ -76,30 +122,7 @@ impl LexSession {
         let records = session.take_history_records();
         drop(session);
         self.record_history(&records);
-        convert_to_events(resp, false)
-    }
-
-    fn poll(&self) -> Option<LexKeyResponse> {
-        if let Some(result) = self.worker.try_recv_candidate() {
-            let surfaces = result.response.surfaces;
-            let paths: Vec<Vec<ConvertedSegment>> = result.response.paths;
-
-            let mut session = self.session.lock().unwrap();
-            if let Some(mut resp) = session.receive_candidates(&result.reading, surfaces, paths) {
-                // Chain: submit any new async requests from the response
-                let has_pending_work = resp.async_request.is_some();
-                if let Some(req) = resp.async_request.take() {
-                    self.worker
-                        .submit_candidates(req.reading, req.candidate_dispatch, req.lattice);
-                }
-                let records = session.take_history_records();
-                drop(session);
-                self.record_history(&records);
-                return Some(convert_to_events(resp, has_pending_work));
-            }
-        }
-
-        None
+        convert_to_events(resp)
     }
 
     fn is_composing(&self) -> bool {
@@ -131,9 +154,39 @@ impl LexSession {
             .unwrap()
             .set_snippet_store(store.map(|s| Arc::clone(&s.inner)));
     }
+
+    /// Stop the async worker thread eagerly. Called by the Swift side on
+    /// IMKInputController teardown to guarantee the worker is joined before
+    /// the last Arc to `LexSession` is dropped.
+    fn shutdown(&self) {
+        let mut slot = self.worker.lock().unwrap();
+        *slot = None;
+    }
 }
 
 impl LexSession {
+    /// Merge a candidate result returned by the worker into session state and
+    /// build the response that should be forwarded to the foreign listener.
+    /// Returns `None` if the result was stale.
+    fn integrate_candidate_result(&self, result: CandidateResult) -> Option<LexKeyResponse> {
+        let surfaces = result.response.surfaces;
+        let paths: Vec<Vec<ConvertedSegment>> = result.response.paths;
+
+        let mut session = self.session.lock().unwrap();
+        let mut resp = session.receive_candidates(&result.reading, surfaces, paths)?;
+
+        // Chain: submit any new async requests from the response
+        if let Some(req) = resp.async_request.take() {
+            if let Some(worker) = self.worker.lock().unwrap().as_ref() {
+                worker.submit_candidates(req.reading, req.candidate_dispatch, req.lattice);
+            }
+        }
+        let records = session.take_history_records();
+        drop(session);
+        self.record_history(&records);
+        Some(convert_to_events(resp))
+    }
+
     fn record_history(&self, records: &[LearningRecord]) {
         if records.is_empty() {
             return;

--- a/engine/src/api/session.rs
+++ b/engine/src/api/session.rs
@@ -38,9 +38,13 @@ impl CandidateSink for ListenerSink {
         };
         let listener = Arc::clone(&self.listener);
         // Isolate foreign-code panics so the worker thread keeps running.
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
             listener.on_async_response(resp);
-        }));
+        }))
+        .is_err()
+        {
+            tracing::error!("foreign LexSessionEvents.on_async_response panicked");
+        }
     }
 }
 

--- a/engine/src/api/types.rs
+++ b/engine/src/api/types.rs
@@ -54,7 +54,6 @@ pub enum LexEvent {
     },
     HideCandidates,
     SwitchToAbc,
-    SchedulePoll,
 }
 
 #[derive(uniffi::Enum)]

--- a/engine/src/async_worker.rs
+++ b/engine/src/async_worker.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{mpsc, Arc, Mutex, RwLock};
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 
 use crate::candidates::CandidateResponse;
@@ -25,28 +25,34 @@ pub(crate) struct CandidateResult {
     pub response: CandidateResponse,
 }
 
+/// Sink invoked by the worker thread when a candidate generation completes.
+/// Implementations must be cheap and non-blocking; heavy work should be
+/// dispatched to another thread from inside the sink.
+pub(crate) trait CandidateSink: Send + Sync + 'static {
+    fn deliver(&self, result: CandidateResult);
+}
+
 // ---------------------------------------------------------------------------
 // AsyncWorker
 // ---------------------------------------------------------------------------
 
 pub(crate) struct AsyncWorker {
     candidate_tx: Option<mpsc::Sender<CandidateWork>>,
-    candidate_rx: Mutex<mpsc::Receiver<CandidateResult>>,
     candidate_gen: Arc<AtomicU64>,
     thread_handle: Option<thread::JoinHandle<()>>,
 }
 
 impl AsyncWorker {
-    pub fn new(
+    pub fn new<S: CandidateSink>(
         dict: Arc<dyn Dictionary>,
         conn: Option<Arc<ConnectionMatrix>>,
         history: Option<Arc<RwLock<UserHistory>>>,
+        sink: S,
     ) -> Self {
         let candidate_gen = Arc::new(AtomicU64::new(0));
 
         // Candidate worker
         let (work_tx, work_rx) = mpsc::channel::<CandidateWork>();
-        let (result_tx, result_rx) = mpsc::channel::<CandidateResult>();
         let handle = {
             let dict = Arc::clone(&dict);
             let conn = conn.clone();
@@ -55,14 +61,13 @@ impl AsyncWorker {
             thread::Builder::new()
                 .name("lexime-candidates".into())
                 .spawn(move || {
-                    candidate_worker(work_rx, result_tx, gen, dict, conn, history);
+                    candidate_worker(work_rx, sink, gen, dict, conn, history);
                 })
                 .expect("failed to spawn candidate worker")
         };
 
         Self {
             candidate_tx: Some(work_tx),
-            candidate_rx: Mutex::new(result_rx),
             candidate_gen,
             thread_handle: Some(handle),
         }
@@ -88,11 +93,6 @@ impl AsyncWorker {
     pub fn invalidate_candidates(&self) {
         self.candidate_gen.fetch_add(1, Ordering::SeqCst);
     }
-
-    pub fn try_recv_candidate(&self) -> Option<CandidateResult> {
-        let rx = self.candidate_rx.lock().ok()?;
-        rx.try_recv().ok()
-    }
 }
 
 impl Drop for AsyncWorker {
@@ -109,9 +109,9 @@ impl Drop for AsyncWorker {
 // Worker threads
 // ---------------------------------------------------------------------------
 
-fn candidate_worker(
+fn candidate_worker<S: CandidateSink>(
     rx: mpsc::Receiver<CandidateWork>,
-    tx: mpsc::Sender<CandidateResult>,
+    sink: S,
     gen: Arc<AtomicU64>,
     dict: Arc<dyn Dictionary>,
     conn: Option<Arc<ConnectionMatrix>>,
@@ -183,7 +183,7 @@ fn candidate_worker(
             Some(lattice) => lattice.input,
             None => latest.reading,
         };
-        let _ = tx.send(CandidateResult { reading, response });
+        sink.deliver(CandidateResult { reading, response });
     }
 }
 

--- a/engine/src/async_worker.rs
+++ b/engine/src/async_worker.rs
@@ -183,7 +183,11 @@ fn candidate_worker<S: CandidateSink>(
             Some(lattice) => lattice.input.clone(),
             None => latest.reading,
         };
-        sink.deliver(CandidateResult { reading, response });
+        let result = CandidateResult { reading, response };
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sink.deliver(result))).is_err()
+        {
+            tracing::error!("candidate worker: CandidateSink::deliver panicked; dropping result");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the 50ms pull-loop (`LexSession::poll()` + Swift `Timer`) with a UniFFI foreign callback (`LexSessionEvents`). The `AsyncWorker` thread invokes the Swift listener directly; Swift bounces to the main thread before touching IMKit / the candidate panel.
- Delete `LexEvent::SchedulePoll`, `LexSession::poll`, `SessionCoordinator.pollTimer`, `drainPending`, and the mpsc result channel in `AsyncWorker`.
- `LexEngine::create_session(listener)` now takes an `Arc<dyn LexSessionEvents>`. `LexSession::shutdown()` joins the worker eagerly from Swift `deinit`.

## Design notes

- **Circular retain**: `LexSession` (Rust) -> worker -> sink -> `Arc<dyn LexSessionEvents>` -> Swift listener. On the Swift side, a small private `Listener` class implements the protocol and holds a **`weak` reference** back to `SessionCoordinator`. `SessionCoordinator` owns `LexSession` strongly. No cycle.
- **Panic safety**: `ListenerSink::deliver` wraps the foreign call in `std::panic::catch_unwind(AssertUnwindSafe(...))` so a Swift-side panic cannot poison the worker thread.
- **Session state race**: the sink holds a `Weak<LexSession>` and merges the candidate result into `InputSession` on the worker thread before invoking the listener. Merging happens under `self.session.lock()`, matching the previous behavior of `LexSession::poll`.
- **Generated Swift API**: UniFFI emits `public protocol LexSessionEvents: AnyObject, Sendable` with `func onAsyncResponse(response: LexKeyResponse)`.

## Test plan

- [x] `cd engine && cargo fmt --all --check`
- [x] `cd engine && cargo clippy --workspace --all-features -- -D warnings`
- [x] `cd engine && cargo test --workspace --all-features`
- [x] `mise run build` (Swift + UniFFI regeneration succeeds)
- [x] `mise run accuracy` — 63/64 pass (1 pre-existing regression `したほうがいい`, 2 skips), unchanged by this PR
- [x] `mise run accuracy-history` — 6/6 pass
- [ ] Manual verification by user needed: live IME behavior (incremental candidate updates, no drop on rapid typing, clean deinit on IMKInputController teardown)

## Known merge-conflict risks

- **PR #6 (Arc<Lattice>)**: both branches touch `engine/src/async_worker.rs`. This PR changes the result-delivery channel into a `CandidateSink` trait and adds a generic parameter to `candidate_worker`; `CandidateWork.lattice` is untouched. Conflict is likely textually adjacent but semantically orthogonal.
- **PR #9 (snippet TOML)**: both touch `engine/src/api/mod.rs`. This PR only adds `LexSessionEvents` to the `pub use` list; no overlap expected with snippet export removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)