### PR TITLE
test: add Swift controller-layer coverage (CandidateManager, ModeController, SessionCoordinator)

### DIFF
--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -1,4 +1,3 @@
-import Carbon
 import Foundation
 
 // MARK: - UserDefaults Keys

--- a/Sources/AppContext.swift
+++ b/Sources/AppContext.swift
@@ -1,42 +1,6 @@
 import Carbon
 import Foundation
 
-// MARK: - Input Source IDs
-
-/// Runtime input source IDs for TIS API lookups (TISCreateInputSourceList etc).
-/// macOS prefixes the bundle identifier to the Info.plist tsInputModeListKey
-/// mode IDs, so "sh.send.inputmethod.Lexime.Japanese" in Info.plist becomes
-/// "sh.send.inputmethod.Lexime.Lexime.Japanese" at runtime. These IDs are
-/// derived from Bundle.main.bundleIdentifier to stay in sync automatically.
-enum LeximeInputSourceID {
-    private static let bundleID = Bundle.main.bundleIdentifier ?? "sh.send.inputmethod.Lexime"
-    static let japanese = bundleID + ".Japanese"
-    static let roman = bundleID + ".Roman"
-    static let standardABC = "com.apple.keylayout.ABC"
-}
-
-// MARK: - TIS helpers
-
-enum InputSource {
-    static func currentID() -> String? {
-        guard let src = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return nil }
-        guard let ref = TISGetInputSourceProperty(src, kTISPropertyInputSourceID) else { return nil }
-        return Unmanaged<CFString>.fromOpaque(ref).takeUnretainedValue() as String
-    }
-
-    static func isCurrentStandardABC() -> Bool {
-        currentID() == LeximeInputSourceID.standardABC
-    }
-
-    static func select(id: String) {
-        let conditions = [kTISPropertyInputSourceID as String: id] as CFDictionary
-        guard let list = TISCreateInputSourceList(conditions, false)?.takeRetainedValue()
-                as? [TISInputSource],
-              let source = list.first else { return }
-        TISSelectInputSource(source)
-    }
-}
-
 // MARK: - UserDefaults Keys
 
 enum DefaultsKey {

--- a/Sources/CandidateManager.swift
+++ b/Sources/CandidateManager.swift
@@ -1,6 +1,16 @@
 import Cocoa
 import InputMethodKit
 
+/// Minimal surface CandidateManager needs from the candidate panel. Allows
+/// tests to inject a fake panel without touching NSPanel (which cannot be
+/// exercised in a headless swiftc-driven test binary).
+protocol CandidatePanelDisplaying: AnyObject {
+    var isVisible: Bool { get }
+    func show(candidates: [String], selectedIndex: Int, globalIndex: Int, totalCount: Int,
+              cursorRect: NSRect?)
+    func hide()
+}
+
 class CandidateManager {
 
     private(set) var candidates: [String] = []
@@ -11,6 +21,12 @@ class CandidateManager {
 
     /// Set when commit_text moves the cursor; forces panel to recalculate position on next show.
     private var needsReposition = false
+
+    private let panel: CandidatePanelDisplaying
+
+    init(panel: CandidatePanelDisplaying) {
+        self.panel = panel
+    }
 
     static let maxDisplay = 9
 
@@ -54,7 +70,7 @@ class CandidateManager {
         let pageCandidates = Array(candidates[pageStart..<pageEnd])
         let pageSelectedIndex = clampedIndex - pageStart
 
-        let panel = AppContext.shared.candidatePanel
+        let panel = self.panel
         let totalCount = candidates.count
 
         // Mozc style: don't recalculate position while panel is visible (prevents jitter)
@@ -80,7 +96,7 @@ class CandidateManager {
     }
 
     func hide() {
-        AppContext.shared.candidatePanel.hide()
+        panel.hide()
     }
 
     // MARK: - Cursor Rect

--- a/Sources/CandidatePanel.swift
+++ b/Sources/CandidatePanel.swift
@@ -163,3 +163,7 @@ class CandidatePanel: NSPanel {
         )
     }
 }
+
+// NSPanel already provides `isVisible`; conformance just documents the seam
+// used by CandidateManager for dependency injection.
+extension CandidatePanel: CandidatePanelDisplaying {}

--- a/Sources/Controller/SessionCoordinator.swift
+++ b/Sources/Controller/SessionCoordinator.swift
@@ -7,7 +7,9 @@ import InputMethodKit
 /// callback, dispatched onto the main thread.
 final class SessionCoordinator {
 
-    private let session: LexSession
+    // Held as the UniFFI-generated protocol so tests can inject a fake session
+    // without crossing the FFI boundary.
+    private let session: LexSessionProtocol
     private let candidateManager: CandidateManager
     private let onSwitchToAbc: () -> Void
 
@@ -18,7 +20,7 @@ final class SessionCoordinator {
     /// arrives between keystrokes and we need an IMKTextInput to apply events against.
     private weak var lastClient: IMKTextInput?
 
-    init(factory: (LexSessionEvents) -> LexSession,
+    init(factory: (LexSessionEvents) -> LexSessionProtocol,
          candidateManager: CandidateManager,
          onSwitchToAbc: @escaping () -> Void) {
         self.candidateManager = candidateManager

--- a/Sources/InputSource.swift
+++ b/Sources/InputSource.swift
@@ -4,10 +4,10 @@ import Foundation
 // MARK: - Input Source IDs
 
 /// Runtime input source IDs for TIS API lookups (TISCreateInputSourceList etc).
-/// macOS prefixes the bundle identifier to the Info.plist tsInputModeListKey
-/// mode IDs, so "sh.send.inputmethod.Lexime.Japanese" in Info.plist becomes
-/// "sh.send.inputmethod.Lexime.Lexime.Japanese" at runtime. These IDs are
-/// derived from Bundle.main.bundleIdentifier to stay in sync automatically.
+/// These match the fully-qualified mode IDs declared in Info.plist's
+/// tsInputModeListKey (e.g. "sh.send.inputmethod.Lexime.Japanese"). Derived
+/// from Bundle.main.bundleIdentifier + suffix so they stay in sync
+/// automatically if the bundle ID changes.
 enum LeximeInputSourceID {
     private static let bundleID = Bundle.main.bundleIdentifier ?? "sh.send.inputmethod.Lexime"
     static let japanese = bundleID + ".Japanese"

--- a/Sources/InputSource.swift
+++ b/Sources/InputSource.swift
@@ -1,0 +1,38 @@
+import Carbon
+import Foundation
+
+// MARK: - Input Source IDs
+
+/// Runtime input source IDs for TIS API lookups (TISCreateInputSourceList etc).
+/// macOS prefixes the bundle identifier to the Info.plist tsInputModeListKey
+/// mode IDs, so "sh.send.inputmethod.Lexime.Japanese" in Info.plist becomes
+/// "sh.send.inputmethod.Lexime.Lexime.Japanese" at runtime. These IDs are
+/// derived from Bundle.main.bundleIdentifier to stay in sync automatically.
+enum LeximeInputSourceID {
+    private static let bundleID = Bundle.main.bundleIdentifier ?? "sh.send.inputmethod.Lexime"
+    static let japanese = bundleID + ".Japanese"
+    static let roman = bundleID + ".Roman"
+    static let standardABC = "com.apple.keylayout.ABC"
+}
+
+// MARK: - TIS helpers
+
+enum InputSource {
+    static func currentID() -> String? {
+        guard let src = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return nil }
+        guard let ref = TISGetInputSourceProperty(src, kTISPropertyInputSourceID) else { return nil }
+        return Unmanaged<CFString>.fromOpaque(ref).takeUnretainedValue() as String
+    }
+
+    static func isCurrentStandardABC() -> Bool {
+        currentID() == LeximeInputSourceID.standardABC
+    }
+
+    static func select(id: String) {
+        let conditions = [kTISPropertyInputSourceID as String: id] as CFDictionary
+        guard let list = TISCreateInputSourceList(conditions, false)?.takeRetainedValue()
+                as? [TISInputSource],
+              let source = list.first else { return }
+        TISSelectInputSource(source)
+    }
+}

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -7,7 +7,7 @@ class LeximeInputController: IMKInputController {
 
     // MARK: - State
 
-    private let candidateManager = CandidateManager()
+    private let candidateManager = CandidateManager(panel: AppContext.shared.candidatePanel)
     private let modeController = ModeController()
     private var coordinator: SessionCoordinator?
 

--- a/Tests/TestCandidateManager.swift
+++ b/Tests/TestCandidateManager.swift
@@ -1,0 +1,130 @@
+import Cocoa
+import Foundation
+import InputMethodKit
+
+func testCandidateManager() {
+    print("--- CandidateManager Tests ---")
+
+    // invalidate() bumps generation monotonically
+    do {
+        let m = CandidateManager(panel: FakePanel())
+        let g0 = m.generation
+        m.invalidate()
+        let g1 = m.generation
+        m.invalidate()
+        let g2 = m.generation
+        assertTrue(g1 == g0 &+ 1, "generation +1 after invalidate")
+        assertTrue(g2 == g1 &+ 1, "generation +1 after second invalidate")
+    }
+
+    // update() records surfaces + selected
+    do {
+        let m = CandidateManager(panel: FakePanel())
+        m.update(surfaces: ["あ", "い", "う"], selected: 1)
+        assertEqual(m.candidates, ["あ", "い", "う"], "candidates stored")
+        assertEqual(m.selectedIndex, 1, "selectedIndex stored")
+    }
+
+    // reset() clears candidates, preserves generation
+    do {
+        let m = CandidateManager(panel: FakePanel())
+        m.update(surfaces: ["x"], selected: 0)
+        m.invalidate()
+        let gen = m.generation
+        m.reset()
+        assertEqual(m.candidates, [], "reset clears candidates")
+        assertEqual(m.selectedIndex, 0, "reset clears selectedIndex")
+        assertEqual(m.generation, gen, "reset preserves generation")
+    }
+
+    // deactivate() invalidates + hides
+    do {
+        let panel = FakePanel()
+        panel.visible = false
+        let m = CandidateManager(panel: panel)
+        let g0 = m.generation
+        m.deactivate()
+        assertTrue(m.generation == g0 &+ 1, "deactivate invalidates")
+        assertEqual(panel.hideCalls, 1, "deactivate hides panel")
+    }
+
+    // hide() forwards to panel
+    do {
+        let panel = FakePanel()
+        panel.visible = false
+        let m = CandidateManager(panel: panel)
+        m.hide()
+        assertEqual(panel.hideCalls, 1, "hide forwards to panel")
+    }
+
+    // show() with empty candidates → hide, not show
+    do {
+        let panel = FakePanel()
+        panel.visible = false
+        let m = CandidateManager(panel: panel)
+        // Do not call update (candidates stays empty).
+        m.show(client: FakeIMKClient(), currentDisplay: nil)
+        assertEqual(panel.showCalls.count, 0, "empty candidates: no show")
+        assertEqual(panel.hideCalls, 1, "empty candidates: hide instead")
+    }
+
+    // show() with visible panel short-circuits (no deferred dispatch, no rect capture)
+    do {
+        let panel = FakePanel()
+        panel.visible = true
+        let m = CandidateManager(panel: panel)
+        m.update(surfaces: ["一", "二"], selected: 0)
+        m.show(client: FakeIMKClient(), currentDisplay: "いち")
+        assertEqual(panel.showCalls.count, 1, "visible path calls show immediately")
+        assertEqual(panel.showCalls[0].candidates, ["一", "二"], "visible: candidates page")
+        assertEqual(panel.showCalls[0].hasCursorRect, false, "visible: no cursor rect recomputed")
+    }
+
+    // flagReposition forces full path even when already visible
+    do {
+        let panel = FakePanel()
+        panel.visible = true
+        let m = CandidateManager(panel: panel)
+        m.update(surfaces: ["a"], selected: 0)
+        m.flagReposition()
+        m.show(client: FakeIMKClient(), currentDisplay: nil)
+        // Deferred path schedules to runloop; drain once so the async block fires.
+        runLoopSpin()
+        assertTrue(panel.showCalls.count >= 1, "flagReposition triggers full path show")
+        assertTrue(panel.showCalls.last?.hasCursorRect == true,
+                   "flagReposition: cursor rect recomputed")
+    }
+
+    // Generation bump between show() scheduling and runloop drain cancels the deferred show
+    do {
+        let panel = FakePanel()
+        panel.visible = false  // forces deferred path
+        let m = CandidateManager(panel: panel)
+        m.update(surfaces: ["x"], selected: 0)
+        m.show(client: FakeIMKClient(), currentDisplay: nil)
+        m.invalidate()  // bumps generation before deferred block runs
+        runLoopSpin()
+        assertEqual(panel.showCalls.count, 0, "generation mismatch cancels deferred show")
+    }
+
+    // Pagination: selected index past page boundary slices the correct page
+    do {
+        let panel = FakePanel()
+        panel.visible = true  // synchronous path for determinism
+        let m = CandidateManager(panel: panel)
+        let surfaces = (0..<20).map { "c\($0)" }
+        m.update(surfaces: surfaces, selected: 10)  // page 1 (of size 9)
+        m.show(client: FakeIMKClient(), currentDisplay: nil)
+        let call = panel.showCalls[0]
+        // page 1 = indices 9..<18
+        assertEqual(call.candidates, Array(surfaces[9..<18]), "page 1 candidates")
+        assertEqual(call.selectedIndex, 1, "selected within page")
+        assertEqual(call.globalIndex, 10, "global index preserved")
+        assertEqual(call.totalCount, 20, "total count preserved")
+    }
+}
+
+/// Pump the main run loop briefly so DispatchQueue.main.async blocks execute.
+private func runLoopSpin() {
+    RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+}

--- a/Tests/TestFakes.swift
+++ b/Tests/TestFakes.swift
@@ -1,0 +1,148 @@
+import Carbon
+import Cocoa
+import Foundation
+import InputMethodKit
+
+/// Full stub of the `IMKTextInput` protocol. Records the interactions the
+/// controller layer uses (`insertText`, `setMarkedText`) and returns inert
+/// defaults for every other method so we satisfy protocol requirements.
+final class FakeIMKClient: NSObject, IMKTextInput {
+    struct InsertCall: Equatable {
+        let text: String
+        let replacementRange: NSRange
+    }
+    struct MarkedCall: Equatable {
+        let text: String
+        let selectionRange: NSRange
+        let replacementRange: NSRange
+    }
+
+    var insertCalls: [InsertCall] = []
+    var markedCalls: [MarkedCall] = []
+
+    /// Optional rect returned from `attributes(forCharacterIndex:...)` so
+    /// CandidateManager has a non-zero cursor position to work with.
+    var attributesRect: NSRect = .zero
+
+    // MARK: IMKTextInput
+
+    func insertText(_ string: Any!, replacementRange: NSRange) {
+        let text = (string as? String) ?? (string as? NSAttributedString)?.string ?? ""
+        insertCalls.append(InsertCall(text: text, replacementRange: replacementRange))
+    }
+
+    func setMarkedText(_ string: Any!, selectionRange: NSRange, replacementRange: NSRange) {
+        let text = (string as? String) ?? (string as? NSAttributedString)?.string ?? ""
+        markedCalls.append(MarkedCall(
+            text: text,
+            selectionRange: selectionRange,
+            replacementRange: replacementRange))
+    }
+
+    func selectedRange() -> NSRange { NSRange(location: NSNotFound, length: 0) }
+    func markedRange() -> NSRange { NSRange(location: NSNotFound, length: 0) }
+    func attributedSubstring(from range: NSRange) -> NSAttributedString! { NSAttributedString(string: "") }
+    func length() -> Int { 0 }
+
+    func characterIndex(for point: NSPoint,
+                        tracking mappingMode: IMKLocationToOffsetMappingMode,
+                        inMarkedRange: UnsafeMutablePointer<ObjCBool>!) -> Int { 0 }
+
+    func attributes(forCharacterIndex index: Int,
+                    lineHeightRectangle lineRect: UnsafeMutablePointer<NSRect>!) -> [AnyHashable: Any]! {
+        lineRect?.pointee = attributesRect
+        return [:]
+    }
+
+    func validAttributesForMarkedText() -> [Any]! { [] }
+    func overrideKeyboard(withKeyboardNamed keyboardUniqueName: String!) {}
+    func selectMode(_ modeIdentifier: String!) {}
+    func supportsUnicode() -> Bool { true }
+    func bundleIdentifier() -> String! { "test.client" }
+    func windowLevel() -> CGWindowLevel { 0 }
+    func supportsProperty(_ property: TSMDocumentPropertyTag) -> Bool { false }
+    func uniqueClientIdentifierString() -> String! { "fake-client" }
+
+    func string(from range: NSRange, actualRange: NSRangePointer!) -> String! { "" }
+    func firstRect(forCharacterRange aRange: NSRange, actualRange: NSRangePointer!) -> NSRect { .zero }
+}
+
+/// Records the panel operations the tests care about. Default `visible = true`
+/// routes `CandidateManager.show` through the synchronous fast path; individual
+/// tests flip it to `false` to exercise the deferred path.
+final class FakePanel: CandidatePanelDisplaying {
+    struct ShowCall: Equatable {
+        let candidates: [String]
+        let selectedIndex: Int
+        let globalIndex: Int
+        let totalCount: Int
+        let hasCursorRect: Bool
+    }
+
+    var visible: Bool = true
+    var showCalls: [ShowCall] = []
+    var hideCalls: Int = 0
+
+    var showCount: Int { showCalls.count }
+    var hideCount: Int { hideCalls }
+    var lastCandidates: [String] { showCalls.last?.candidates ?? [] }
+    var lastSelectedIndex: Int { showCalls.last?.selectedIndex ?? 0 }
+
+    var isVisible: Bool { visible }
+
+    func show(candidates: [String], selectedIndex: Int, globalIndex: Int, totalCount: Int,
+              cursorRect: NSRect?) {
+        showCalls.append(ShowCall(
+            candidates: candidates,
+            selectedIndex: selectedIndex,
+            globalIndex: globalIndex,
+            totalCount: totalCount,
+            hasCursorRect: cursorRect != nil))
+        visible = true
+    }
+
+    func hide() {
+        hideCalls += 1
+        visible = false
+    }
+}
+
+/// In-memory fake of `LexSessionProtocol`. Tests queue responses to be returned
+/// by `handleKey` / `commit` and inspect recorded calls afterwards.
+final class FakeLexSession: LexSessionProtocol, @unchecked Sendable {
+    var handleKeyResponses: [LexKeyResponse] = []
+    var commitResponses: [LexKeyResponse] = []
+
+    var handleKeyCalls: [LexKeyEvent] = []
+    var commitCalls: Int = 0
+    var shutdownCalls: Int = 0
+    var isComposingValue: Bool = false
+
+    var setSnippetStoreCalls: Int = 0
+    var setAbcPassthroughCalls: [Bool] = []
+    var setConversionModeCalls: [LexConversionMode] = []
+    var setDeferCandidatesCalls: [Bool] = []
+
+    func handleKey(event: LexKeyEvent) -> LexKeyResponse {
+        handleKeyCalls.append(event)
+        if handleKeyResponses.isEmpty {
+            return LexKeyResponse(consumed: false, events: [])
+        }
+        return handleKeyResponses.removeFirst()
+    }
+
+    func commit() -> LexKeyResponse {
+        commitCalls += 1
+        if commitResponses.isEmpty {
+            return LexKeyResponse(consumed: false, events: [])
+        }
+        return commitResponses.removeFirst()
+    }
+
+    func isComposing() -> Bool { isComposingValue }
+    func setAbcPassthrough(enabled: Bool) { setAbcPassthroughCalls.append(enabled) }
+    func setConversionMode(mode: LexConversionMode) { setConversionModeCalls.append(mode) }
+    func setDeferCandidates(enabled: Bool) { setDeferCandidatesCalls.append(enabled) }
+    func setSnippetStore(store: LexSnippetStore?) { setSnippetStoreCalls += 1 }
+    func shutdown() { shutdownCalls += 1 }
+}

--- a/Tests/TestModeController.swift
+++ b/Tests/TestModeController.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+func testModeController() {
+    print("--- ModeController Tests ---")
+
+    // takePendingEscapeCommit: default is false
+    do {
+        let mc = ModeController()
+        assertTrue(!mc.takePendingEscapeCommit(),
+                   "default escape-commit flag is false")
+    }
+
+    // noteEscapeDuringCompose sets the flag; takePendingEscapeCommit consumes once
+    do {
+        let mc = ModeController()
+        mc.noteEscapeDuringCompose()
+        assertTrue(mc.takePendingEscapeCommit(), "flag set after note")
+        assertTrue(!mc.takePendingEscapeCommit(),
+                   "flag is one-shot: cleared after take")
+    }
+
+    // Repeated note + take: still one-shot each time
+    do {
+        let mc = ModeController()
+        mc.noteEscapeDuringCompose()
+        mc.noteEscapeDuringCompose()  // idempotent
+        assertTrue(mc.takePendingEscapeCommit(), "flag set after repeated notes")
+        assertTrue(!mc.takePendingEscapeCommit(), "cleared after take")
+        mc.noteEscapeDuringCompose()
+        assertTrue(mc.takePendingEscapeCommit(), "re-armable after clear")
+    }
+
+    // revertToLeximeIfEscapeRaced with attempt >= max exits immediately
+    // (no asyncAfter scheduled, so this is safe to invoke in a headless test).
+    // We can't observe the guard directly, but we can assert the call doesn't
+    // throw / crash and returns synchronously.
+    do {
+        let mc = ModeController()
+        // attempt == max: guard fails, returns without scheduling.
+        mc.revertToLeximeIfEscapeRaced(attempt: 100)
+        assertTrue(true, "revert guard returns without scheduling when attempt saturated")
+    }
+
+    // NOTE: The live retry path of `revertToLeximeIfEscapeRaced(attempt: 0)`
+    // calls TIS APIs and spawns DispatchQueue.main.asyncAfter work. Exercising
+    // it in a CLI test process would mutate the user's real input source and
+    // leak timers past test teardown, so we cover only the input-independent
+    // escape-flag state machine here. A full integration test would need a TIS
+    // fake layer, which is out of scope for this PR.
+}

--- a/Tests/TestModeController.swift
+++ b/Tests/TestModeController.swift
@@ -30,15 +30,13 @@ func testModeController() {
         assertTrue(mc.takePendingEscapeCommit(), "re-armable after clear")
     }
 
-    // revertToLeximeIfEscapeRaced with attempt >= max exits immediately
-    // (no asyncAfter scheduled, so this is safe to invoke in a headless test).
-    // We can't observe the guard directly, but we can assert the call doesn't
-    // throw / crash and returns synchronously.
+    // revertToLeximeIfEscapeRaced with attempt >= max exits immediately:
+    // no asyncAfter is scheduled, so calling it is safe in a headless test.
+    // We cannot observe the guard directly (no scheduler injection here), so
+    // this is a smoke check that the call returns synchronously without crashing.
     do {
         let mc = ModeController()
-        // attempt == max: guard fails, returns without scheduling.
         mc.revertToLeximeIfEscapeRaced(attempt: 100)
-        assertTrue(true, "revert guard returns without scheduling when attempt saturated")
     }
 
     // NOTE: The live retry path of `revertToLeximeIfEscapeRaced(attempt: 0)`

--- a/Tests/TestRunner.swift
+++ b/Tests/TestRunner.swift
@@ -34,6 +34,9 @@ struct TestMain {
         testDictFFI()
         testSessionFFI()
         testSnippetTOML()
+        testCandidateManager()
+        testModeController()
+        testSessionCoordinator()
 
         print("\nResults: \(testsPassed) passed, \(testsFailed) failed")
         exit(testsFailed > 0 ? 1 : 0)

--- a/Tests/TestSessionCoordinator.swift
+++ b/Tests/TestSessionCoordinator.swift
@@ -1,0 +1,194 @@
+import Cocoa
+import Foundation
+import InputMethodKit
+
+/// Build a coordinator wired to a FakeLexSession. The factory receives the
+/// listener the coordinator would normally hand to Rust; tests ignore it since
+/// nothing drives async responses here.
+private func makeCoordinator(
+    session: FakeLexSession,
+    panel: FakePanel = FakePanel(),
+    onSwitchToAbc: @escaping () -> Void = {}
+) -> (SessionCoordinator, CandidateManager) {
+    let manager = CandidateManager(panel: panel)
+    let coordinator = SessionCoordinator(
+        factory: { _ in session },
+        candidateManager: manager,
+        onSwitchToAbc: onSwitchToAbc)
+    return (coordinator, manager)
+}
+
+func testSessionCoordinator() {
+    print("--- SessionCoordinator Tests ---")
+
+    // handleKey: forwards key event to session + returns consumed flag
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [LexKeyResponse(consumed: true, events: [])]
+        let (coordinator, _) = makeCoordinator(session: session)
+
+        let client = FakeIMKClient()
+        let consumed = coordinator.handleKey(.space, client: client)
+        assertTrue(consumed, "handleKey returns response.consumed")
+        assertEqual(session.handleKeyCalls.count, 1, "session.handleKey called once")
+        assertEqual(session.handleKeyCalls[0], LexKeyEvent.space, "forwarded event matches")
+    }
+
+    // handleKey: bumps candidate generation (invalidates stale async work)
+    do {
+        let session = FakeLexSession()
+        let (coordinator, manager) = makeCoordinator(session: session)
+        let before = manager.generation
+        _ = coordinator.handleKey(.space, client: FakeIMKClient())
+        assertTrue(manager.generation == before &+ 1,
+                   "handleKey invalidates candidate generation")
+    }
+
+    // .commit event → client.insertText + currentDisplay cleared
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [.commit(text: "漢字")])
+        ]
+        let (coordinator, _) = makeCoordinator(session: session)
+        let client = FakeIMKClient()
+        _ = coordinator.handleKey(.enter, client: client)
+        assertEqual(client.insertCalls.count, 1, "commit → one insertText")
+        assertEqual(client.insertCalls[0].text, "漢字", "commit text passed through")
+        // Match the live NSRange(location: NSNotFound, length: 0) literal.
+        assertEqual(client.insertCalls[0].replacementRange.location, NSNotFound,
+                    "commit uses replacementRange at NSNotFound")
+        assertTrue(coordinator.currentDisplay == nil, "commit clears currentDisplay")
+    }
+
+    // .setMarkedText event (non-empty) → client.setMarkedText + currentDisplay updated
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [.setMarkedText(text: "あ")])
+        ]
+        let (coordinator, _) = makeCoordinator(session: session)
+        let client = FakeIMKClient()
+        _ = coordinator.handleKey(.text(text: "a", shift: false), client: client)
+        assertEqual(client.markedCalls.count, 1, "setMarkedText called")
+        assertEqual(client.markedCalls[0].text, "あ", "marked text passed through")
+        assertEqual(coordinator.currentDisplay, "あ", "currentDisplay tracks marked text")
+    }
+
+    // .setMarkedText with empty string clears currentDisplay (nil, not "")
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [
+                .setMarkedText(text: "あ"),
+                .setMarkedText(text: ""),
+            ])
+        ]
+        let (coordinator, _) = makeCoordinator(session: session)
+        _ = coordinator.handleKey(.backspace, client: FakeIMKClient())
+        assertTrue(coordinator.currentDisplay == nil,
+                   "empty marked text → currentDisplay nil")
+    }
+
+    // .showCandidates → CandidateManager populated + panel.show called
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [
+                .showCandidates(surfaces: ["一", "二"], selected: 0)
+            ])
+        ]
+        let panel = FakePanel()
+        panel.visible = true
+        let (coordinator, manager) = makeCoordinator(session: session, panel: panel)
+        _ = coordinator.handleKey(.space, client: FakeIMKClient())
+        assertEqual(manager.candidates, ["一", "二"], "candidates applied")
+        assertEqual(manager.selectedIndex, 0, "selected applied")
+        assertTrue(panel.showCount >= 1, "panel.show called for candidates")
+    }
+
+    // .hideCandidates → panel.hide
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [.hideCandidates])
+        ]
+        let panel = FakePanel()
+        let (coordinator, _) = makeCoordinator(session: session, panel: panel)
+        _ = coordinator.handleKey(.escape, client: FakeIMKClient())
+        assertTrue(panel.hideCount >= 1, "hideCandidates → panel.hide")
+    }
+
+    // .switchToAbc → onSwitchToAbc closure fired
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [.switchToAbc])
+        ]
+        var switched = 0
+        let (coordinator, _) = makeCoordinator(session: session, onSwitchToAbc: {
+            switched += 1
+        })
+        _ = coordinator.handleKey(.switchToDirectInput, client: FakeIMKClient())
+        assertEqual(switched, 1, "switchToAbc event triggers closure")
+    }
+
+    // commit(client:) forwards to session.commit + applies events
+    do {
+        let session = FakeLexSession()
+        session.commitResponses = [
+            LexKeyResponse(consumed: true, events: [.commit(text: "あ")])
+        ]
+        let (coordinator, _) = makeCoordinator(session: session)
+        let client = FakeIMKClient()
+        coordinator.commit(client: client)
+        assertEqual(session.commitCalls, 1, "session.commit called")
+        assertEqual(client.insertCalls.count, 1, "commit response events applied")
+        assertEqual(client.insertCalls[0].text, "あ", "committed text")
+    }
+
+    // Session passthroughs
+    do {
+        let session = FakeLexSession()
+        let (coordinator, _) = makeCoordinator(session: session)
+        session.isComposingValue = true
+        assertTrue(coordinator.isComposing, "isComposing forwarded")
+
+        coordinator.setSnippetStore(nil)
+        assertEqual(session.setSnippetStoreCalls, 1, "setSnippetStore forwarded")
+
+        coordinator.setAbcPassthrough(enabled: true)
+        assertEqual(session.setAbcPassthroughCalls, [true],
+                    "setAbcPassthrough forwarded")
+    }
+
+    // resetDisplay clears currentDisplay without side effects
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [.setMarkedText(text: "x")])
+        ]
+        let (coordinator, _) = makeCoordinator(session: session)
+        _ = coordinator.handleKey(.text(text: "x", shift: false), client: FakeIMKClient())
+        assertEqual(coordinator.currentDisplay, "x", "precondition: display set")
+        coordinator.resetDisplay()
+        assertTrue(coordinator.currentDisplay == nil, "resetDisplay clears display")
+    }
+
+    // deactivate: invalidates candidates, hides panel, clears display
+    do {
+        let session = FakeLexSession()
+        session.handleKeyResponses = [
+            LexKeyResponse(consumed: true, events: [.setMarkedText(text: "y")])
+        ]
+        let panel = FakePanel()
+        let (coordinator, manager) = makeCoordinator(session: session, panel: panel)
+        _ = coordinator.handleKey(.text(text: "y", shift: false), client: FakeIMKClient())
+        let genBefore = manager.generation
+        coordinator.deactivate()
+        assertTrue(manager.generation == genBefore &+ 1,
+                   "deactivate invalidates generation")
+        assertTrue(panel.hideCount >= 1, "deactivate hides panel")
+        assertTrue(coordinator.currentDisplay == nil, "deactivate clears display")
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -225,7 +225,8 @@ depends = ["uniffi-gen"]
 # NOTE: Test files are listed explicitly because swiftc compiles all sources
 # into one binary. If you add a new test file under Tests/, add it here too.
 # Source files required by tests are also listed explicitly (SnippetTOML for
-# TestSnippetTOML).
+# TestSnippetTOML; CandidateManager/SessionCoordinator/ModeController/InputSource
+# for the controller tests).
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
@@ -234,7 +235,12 @@ swiftc -Xcc -fmodule-map-file=generated/lex_engineFFI.modulemap \
   -Lbuild -llex_engine \
   generated/lex_engine.swift \
   Sources/Services/SnippetTOML.swift \
+  Sources/InputSource.swift \
+  Sources/CandidateManager.swift \
+  Sources/Controller/SessionCoordinator.swift \
+  Sources/Controller/ModeController.swift \
   Tests/TestRunner.swift Tests/TestRomajiFFI.swift Tests/TestDictFFI.swift Tests/TestSessionFFI.swift Tests/TestSnippetTOML.swift \
+  Tests/TestFakes.swift Tests/TestCandidateManager.swift Tests/TestModeController.swift Tests/TestSessionCoordinator.swift \
   -o build/test-runner && build/test-runner
 """
 


### PR DESCRIPTION
## Summary

PR #10 of the architecture refresh: extend the existing swiftc-driven custom
runner with coverage for the three controller-layer modules that previously
had no automated tests.

### Tests added (all under `Tests/`)

| File | Suites | Covers |
| --- | --- | --- |
| `TestCandidateManager.swift` | 1 function, 9 blocks | `invalidate()` generation bump, `update` / `reset` / `deactivate` / `hide`, empty-candidates → `hide`, synchronous (panel visible) show path, deferred (panel hidden) show path, generation-mismatch cancellation of deferred block, `flagReposition` forcing full path, pagination across 20 candidates |
| `TestModeController.swift` | 1 function, 4 blocks | default escape-commit flag, `noteEscapeDuringCompose` + `takePendingEscapeCommit` one-shot semantics, re-armability, `revertToLeximeIfEscapeRaced(attempt:)` guard path exits cleanly when attempts saturate |
| `TestSessionCoordinator.swift` | 1 function, 11 blocks | `handleKey` forwards events + returns `consumed`, `handleKey` bumps candidate generation, every `LexEvent` variant (`commit`, `setMarkedText`, empty `setMarkedText`, `showCandidates`, `hideCandidates`, `switchToAbc`), `commit(client:)` applies response events, `isComposing` / `setSnippetStore` / `setAbcPassthrough` passthroughs, `resetDisplay` / `deactivate` lifecycle |
| `TestFakes.swift` | (shared helpers) | `FakeIMKClient` (full `IMKTextInput` stub), `FakePanel` (`CandidatePanelDisplaying`), `FakeLexSession` (`LexSessionProtocol`) |

`TestRunner.main()` now calls `testCandidateManager()`, `testModeController()`,
`testSessionCoordinator()` in addition to the existing FFI / snippet suites.

### Source changes to unlock testing

Minimal seams only; no production logic changes.

- `Sources/CandidateManager.swift`: added `CandidatePanelDisplaying` protocol,
  injected via a required `panel:` init parameter (previously reached into
  `AppContext.shared.candidatePanel` at use sites).
- `Sources/CandidatePanel.swift`: declared `CandidatePanel` conformance to
  `CandidatePanelDisplaying` (empty extension — NSPanel already satisfies the
  surface).
- `Sources/Controller/SessionCoordinator.swift`: held the session as
  `LexSessionProtocol` (UniFFI-generated) instead of the concrete `LexSession`
  class; factory signature updated. Call site in `LeximeInputController` still
  passes `engine.createSession(...)` which returns a conforming value.
- `Sources/LeximeInputController.swift`: now constructs
  `CandidateManager(panel: AppContext.shared.candidatePanel)` explicitly.
- `Sources/InputSource.swift` (new): extracted `LeximeInputSourceID` +
  `InputSource` from `AppContext.swift`. The test binary needs `InputSource`
  (via `ModeController`) but cannot pull in all of `AppContext` without
  dragging in the full bootstrap graph.

### mise.toml diff

The `[tasks.test-swift]` block adds the new source + test files (see commit
`test: add controller-layer coverage for Swift frontend`):

```
  Sources/Services/SnippetTOML.swift \
+ Sources/InputSource.swift \
+ Sources/CandidateManager.swift \
+ Sources/Controller/SessionCoordinator.swift \
+ Sources/Controller/ModeController.swift \
  Tests/TestRunner.swift Tests/TestRomajiFFI.swift Tests/TestDictFFI.swift Tests/TestSessionFFI.swift Tests/TestSnippetTOML.swift \
+ Tests/TestFakes.swift Tests/TestCandidateManager.swift Tests/TestModeController.swift Tests/TestSessionCoordinator.swift \
```

### Skipped / out of scope

- The live retry path of `ModeController.revertToLeximeIfEscapeRaced(attempt: 0)`
  calls `TISSelectInputSource` and `DispatchQueue.main.asyncAfter`. Exercising
  it in a CLI test would mutate the user's real input source and leak timers
  past teardown; a real integration test would need a TIS fake layer, which is
  untestable without SPM migration and explicitly out of scope.
- `SessionCoordinator.applyAsyncResponse(_:)` (the `LexSessionEvents` async
  callback) is covered indirectly by `handleKey` applying identical event
  streams through `applyEvents`; driving a real async listener requires a live
  Rust worker and is out of scope.

## Test plan

- [x] `cd engine && cargo fmt --all --check` — clean
- [x] `cd engine && cargo test --workspace --all-features` — all pass
- [x] `mise run build` — main app builds (universal binary)
- [x] `mise run test-swift` — **97 passed, 0 failed** (new suites run after the existing ones)

No `mise run install` / `mise run reload` per instructions. No merge.

Generated with [Claude Code](https://claude.com/claude-code)