### PR TITLE
feat: curated domain extras dict (IT / food / geography)

### DIFF
--- a/engine/crates/lex-cli/src/dict_source/extras.rs
+++ b/engine/crates/lex-cli/src/dict_source/extras.rs
@@ -43,7 +43,12 @@ impl DictSource for ExtrasSource {
         parse_dict_files(
             dir,
             "extras *.tsv",
-            |name| name.ends_with(".tsv"),
+            // Only parse files that are still registered in DOMAINS. This
+            // prevents stale TSVs (e.g. a renamed/removed domain whose old
+            // file lingers in the gitignored extras-raw/ dir) from silently
+            // leaking entries into the merged dict and making builds
+            // non-deterministic. Mirrors symbols.rs's exact-name match.
+            |name| DOMAINS.iter().any(|(n, _)| *n == name),
             '\t',
             |fields| {
                 if fields.len() < 2 {
@@ -144,8 +149,10 @@ mod tests {
         let dir = std::env::temp_dir().join("lexime_test_extras_invalid");
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
+        // Use a real registered domain name so the strict file-name filter
+        // accepts it; the test still validates per-line filtering.
         fs::write(
-            dir.join("bad.tsv"),
+            dir.join("food.tsv"),
             "Tanjao\t藤椒\n\
              たんじゃお\t藤椒\n",
         )
@@ -163,11 +170,37 @@ mod tests {
         let dir = std::env::temp_dir().join("lexime_test_extras_cost");
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("custom.tsv"), "あさかい\t朝会\t3000\n").unwrap();
+        fs::write(dir.join("it.tsv"), "あさかい\t朝会\t3000\n").unwrap();
 
         let entries = ExtrasSource.parse_dir(&dir).unwrap();
         let asakai = entries.get("あさかい").unwrap();
         assert_eq!(asakai[0].cost, 3000);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ignores_unregistered_tsv_files() {
+        // A stale TSV left over from a renamed/removed domain (or any file
+        // that's not in DOMAINS) must NOT contribute entries — that would
+        // make builds non-deterministic.
+        let dir = std::env::temp_dir().join("lexime_test_extras_stale");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        // Pretend a 'cooking-chinese.tsv' (no longer registered) lingers
+        // alongside a registered domain file.
+        fs::write(dir.join("cooking-chinese.tsv"), "ぱくちー\t香菜\n").unwrap();
+        fs::write(dir.join("it.tsv"), "べきとう\t冪等\n").unwrap();
+
+        let entries = ExtrasSource.parse_dir(&dir).unwrap();
+        assert!(
+            entries.contains_key("べきとう"),
+            "registered file's entries must be picked up"
+        );
+        assert!(
+            !entries.contains_key("ぱくちー"),
+            "unregistered file must be ignored, not silently merged"
+        );
 
         fs::remove_dir_all(&dir).ok();
     }
@@ -181,7 +214,7 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
         fs::write(
-            dir.join("bad.tsv"),
+            dir.join("it.tsv"),
             "あさかい\t朝会\t40000\n\
              べきとう\t冪等\tabc\n\
              しかかり\t仕掛\n",

--- a/engine/crates/lex-cli/src/dict_source/extras.rs
+++ b/engine/crates/lex-cli/src/dict_source/extras.rs
@@ -57,12 +57,15 @@ impl DictSource for ExtrasSource {
                 if !is_hiragana(reading) {
                     return None;
                 }
-                let cost = fields
-                    .get(2)
-                    .map(|s| s.trim())
-                    .filter(|s| !s.is_empty())
-                    .and_then(|s| s.parse::<i16>().ok())
-                    .unwrap_or(DEFAULT_COST);
+                // Cost is optional — empty / missing falls back to DEFAULT_COST,
+                // but a present-but-malformed value (typo, out-of-i16-range)
+                // skips the line so authoring mistakes don't silently demote
+                // the entry to default ranking. Mirrors parse_id_cost's
+                // strictness for the other sources.
+                let cost = match fields.get(2).map(|s| s.trim()) {
+                    None | Some("") => DEFAULT_COST,
+                    Some(s) => s.parse::<i16>().ok()?,
+                };
                 Some(ParsedLine {
                     reading: reading.to_string(),
                     surface: surface.to_string(),
@@ -165,6 +168,35 @@ mod tests {
         let entries = ExtrasSource.parse_dir(&dir).unwrap();
         let asakai = entries.get("あさかい").unwrap();
         assert_eq!(asakai[0].cost, 3000);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn skips_line_on_unparsable_cost() {
+        // Out-of-i16-range value (40000 > i16::MAX = 32767) and a non-numeric
+        // typo must skip the line, not fall back to default. Empty / missing
+        // cost stays as default-cost behavior (covered by bundled_tsvs_parse).
+        let dir = std::env::temp_dir().join("lexime_test_extras_bad_cost");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("bad.tsv"),
+            "あさかい\t朝会\t40000\n\
+             べきとう\t冪等\tabc\n\
+             しかかり\t仕掛\n",
+        )
+        .unwrap();
+
+        let entries = ExtrasSource.parse_dir(&dir).unwrap();
+        // Out-of-range and non-numeric lines are dropped.
+        assert!(!entries.contains_key("あさかい"));
+        assert!(!entries.contains_key("べきとう"));
+        // Missing-cost line still produces an entry with default cost.
+        let shikakari = entries
+            .get("しかかり")
+            .expect("missing-cost line keeps entry");
+        assert_eq!(shikakari[0].cost, DEFAULT_COST);
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/engine/crates/lex-cli/src/dict_source/extras.rs
+++ b/engine/crates/lex-cli/src/dict_source/extras.rs
@@ -1,0 +1,171 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use super::{is_hiragana, parse_dict_files, DictSource, DictSourceError, ParsedLine};
+use lex_core::dict::DictEntry;
+
+/// Curated domain-specific vocabulary not covered by Mozc UT.
+///
+/// Each domain TSV under `extras/<domain>.tsv` is bundled into the binary via
+/// `include_str!`. `fetch` materializes them to disk so the existing `compile`
+/// pipeline (which reads from a directory) can consume them without
+/// special-casing — same approach as `symbols.rs`.
+///
+/// Domains intentionally cover broad areas (`food`, `it`, `geography`) rather
+/// than narrow categories like `cooking-chinese`: a vocabulary item like
+/// 一保堂(いっぽどう, 京都の日本茶ブランド) sits naturally in `food` but has
+/// nowhere clean to go under a stricter taxonomy.
+///
+/// File format:
+///   reading[TAB]surface[TAB]cost(optional, default 5000)
+/// Comment lines (starting with `#`) and blank lines are skipped.
+const DOMAINS: &[(&str, &str)] = &[
+    ("it.tsv", include_str!("extras/it.tsv")),
+    ("food.tsv", include_str!("extras/food.tsv")),
+    ("geography.tsv", include_str!("extras/geography.tsv")),
+];
+
+/// Default cost for entries that don't specify one. Mid-range so curated
+/// entries are plausible candidates without dominating Mozc's better-tuned
+/// homophones unless we explicitly want them to.
+const DEFAULT_COST: i16 = 5000;
+
+/// Default POS: 名詞,一般 (Mozc id 1852). Works for content nouns and
+/// brand-name proper nouns alike. Per-domain POS tuning is deferred — cost
+/// adjustment is sufficient for the MVP.
+const DEFAULT_POS: u16 = 1852;
+
+pub struct ExtrasSource;
+
+impl DictSource for ExtrasSource {
+    fn parse_dir(&self, dir: &Path) -> Result<HashMap<String, Vec<DictEntry>>, DictSourceError> {
+        parse_dict_files(
+            dir,
+            "extras *.tsv",
+            |name| name.ends_with(".tsv"),
+            '\t',
+            |fields| {
+                if fields.len() < 2 {
+                    return None;
+                }
+                let reading = fields[0].trim();
+                let surface = fields[1].trim();
+                if reading.is_empty() || surface.is_empty() {
+                    return None;
+                }
+                if !is_hiragana(reading) {
+                    return None;
+                }
+                let cost = fields
+                    .get(2)
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| s.parse::<i16>().ok())
+                    .unwrap_or(DEFAULT_COST);
+                Some(ParsedLine {
+                    reading: reading.to_string(),
+                    surface: surface.to_string(),
+                    left_id: DEFAULT_POS,
+                    right_id: DEFAULT_POS,
+                    cost,
+                })
+            },
+        )
+    }
+
+    fn fetch(&self, dest: &Path) -> Result<(), DictSourceError> {
+        fs::create_dir_all(dest).map_err(DictSourceError::Io)?;
+        for (name, content) in DOMAINS {
+            fs::write(dest.join(name), content).map_err(DictSourceError::Io)?;
+            eprintln!("  {name} ({} bytes)", content.len());
+        }
+        fs::write(dest.join(".stamp"), "").map_err(DictSourceError::Io)?;
+        eprintln!(
+            "Wrote {} bundled extras TSV(s) to {}",
+            DOMAINS.len(),
+            dest.display()
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_tsvs_parse() {
+        let dir = std::env::temp_dir().join("lexime_test_extras");
+        let _ = fs::remove_dir_all(&dir);
+
+        let source = ExtrasSource;
+        source.fetch(&dir).unwrap();
+        let entries = source.parse_dir(&dir).unwrap();
+
+        // IT domain
+        let bekitou = entries.get("べきとう").expect("べきとう must map to 冪等");
+        assert!(bekitou.iter().any(|e| e.surface == "冪等"));
+        let asakai = entries.get("あさかい").expect("あさかい must map to 朝会");
+        assert!(asakai.iter().any(|e| e.surface == "朝会"));
+
+        // food domain
+        let tanjao = entries
+            .get("たんじゃお")
+            .expect("たんじゃお must map to 藤椒");
+        assert!(tanjao.iter().any(|e| e.surface == "藤椒"));
+        let ippodo = entries
+            .get("いっぽどう")
+            .expect("いっぽどう must map to 一保堂");
+        assert!(ippodo.iter().any(|e| e.surface == "一保堂"));
+
+        // geography domain
+        let kirarazaka = entries
+            .get("きららざか")
+            .expect("きららざか must map to 雲母坂");
+        assert!(kirarazaka.iter().any(|e| e.surface == "雲母坂"));
+
+        // All entries use the default POS id.
+        for entries in entries.values() {
+            for entry in entries {
+                assert_eq!(entry.left_id, DEFAULT_POS);
+                assert_eq!(entry.right_id, DEFAULT_POS);
+            }
+        }
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn skips_non_hiragana_reading() {
+        let dir = std::env::temp_dir().join("lexime_test_extras_invalid");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("bad.tsv"),
+            "Tanjao\t藤椒\n\
+             たんじゃお\t藤椒\n",
+        )
+        .unwrap();
+
+        let entries = ExtrasSource.parse_dir(&dir).unwrap();
+        assert_eq!(entries.len(), 1, "non-hiragana reading must be skipped");
+        assert!(entries.contains_key("たんじゃお"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn explicit_cost_overrides_default() {
+        let dir = std::env::temp_dir().join("lexime_test_extras_cost");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("custom.tsv"), "あさかい\t朝会\t3000\n").unwrap();
+
+        let entries = ExtrasSource.parse_dir(&dir).unwrap();
+        let asakai = entries.get("あさかい").unwrap();
+        assert_eq!(asakai[0].cost, 3000);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/engine/crates/lex-cli/src/dict_source/extras.rs
+++ b/engine/crates/lex-cli/src/dict_source/extras.rs
@@ -134,8 +134,8 @@ mod tests {
         assert!(kirarazaka.iter().any(|e| e.surface == "雲母坂"));
 
         // All entries use the default POS id.
-        for entries in entries.values() {
-            for entry in entries {
+        for entry_list in entries.values() {
+            for entry in entry_list {
                 assert_eq!(entry.left_id, DEFAULT_POS);
                 assert_eq!(entry.right_id, DEFAULT_POS);
             }

--- a/engine/crates/lex-cli/src/dict_source/extras/food.tsv
+++ b/engine/crates/lex-cli/src/dict_source/extras/food.tsv
@@ -1,0 +1,12 @@
+# Lexime curated extras: food & drink vocabulary (ingredients, brands,
+# culinary terms across cuisines) not covered by Mozc UT.
+#
+# Format: reading[TAB]surface[TAB]cost(optional)
+# Comment lines start with '#'. See it.tsv for full format spec.
+
+# --- 中華料理 (調味料・スパイス) ---
+たんじゃお	藤椒
+ほわじゃお	花椒
+
+# --- 日本茶ブランド ---
+いっぽどう	一保堂

--- a/engine/crates/lex-cli/src/dict_source/extras/geography.tsv
+++ b/engine/crates/lex-cli/src/dict_source/extras/geography.tsv
@@ -1,0 +1,8 @@
+# Lexime curated extras: place names & geography vocabulary (regional
+# place readings, cartographic terms) not covered by Mozc UT.
+#
+# Format: reading[TAB]surface[TAB]cost(optional)
+# Comment lines start with '#'. See it.tsv for full format spec.
+
+# --- 京都の地名 ---
+きららざか	雲母坂

--- a/engine/crates/lex-cli/src/dict_source/extras/it.tsv
+++ b/engine/crates/lex-cli/src/dict_source/extras/it.tsv
@@ -1,0 +1,17 @@
+# Lexime curated extras: IT / business vocabulary not covered by Mozc UT.
+#
+# Format: reading[TAB]surface[TAB]cost(optional)
+#   - reading: hiragana
+#   - cost: i16. Default 5000 (mid). Lower = higher rank.
+# Comment lines start with '#'. Blank lines are ignored.
+#
+# All entries use POS id 1852 (名詞,一般). When that's wrong (e.g. proper
+# nouns), tune via cost rather than POS for now — POS overrides are out of
+# scope for the curated layer.
+
+# --- 数学 / CS ---
+べきとう	冪等
+
+# --- 業務 / スクラム ---
+あさかい	朝会
+しかかり	仕掛

--- a/engine/crates/lex-cli/src/dict_source/mod.rs
+++ b/engine/crates/lex-cli/src/dict_source/mod.rs
@@ -1,3 +1,4 @@
+mod extras;
 mod mozc;
 pub mod pos_map;
 mod symbols;
@@ -17,6 +18,7 @@ type SourceCtor = fn() -> Box<dyn DictSource>;
 const SOURCES: &[(&str, SourceCtor)] = &[
     ("mozc", || Box::new(mozc::MozcSource)),
     ("symbols", || Box::new(symbols::SymbolsSource)),
+    ("extras", || Box::new(extras::ExtrasSource)),
 ];
 
 /// Comma-separated list of source names recognized by [`from_name`]. Shown in

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -412,6 +412,56 @@ category = "numeric"
 tags = ["counter", "large"]
 
 # ═══════════════════════════════════════════════════════════════════
+# Curated domain extras (engine/data/extras-raw)
+# ═══════════════════════════════════════════════════════════════════
+# These come from the curated `extras` dict source, not Mozc UT.
+# When this category fails, check engine/crates/lex-cli/src/dict_source/extras/
+# for the corresponding TSV.
+
+[[cases]]
+reading = "べきとう"
+expected = "冪等"
+category = "extras"
+tags = ["it"]
+
+[[cases]]
+reading = "あさかい"
+expected = "朝会"
+category = "extras"
+tags = ["it", "domain-reading"]
+note = "Mozc は ちょうかい→朝会 のみ。あさかい はスクラム慣用読み"
+
+[[cases]]
+reading = "しかかり"
+expected = "仕掛"
+category = "extras"
+tags = ["it", "business"]
+
+[[cases]]
+reading = "たんじゃお"
+expected = "藤椒"
+category = "extras"
+tags = ["food", "domain-reading"]
+
+[[cases]]
+reading = "ほわじゃお"
+expected = "花椒"
+category = "extras"
+tags = ["food", "domain-reading"]
+
+[[cases]]
+reading = "いっぽどう"
+expected = "一保堂"
+category = "extras"
+tags = ["food", "brand"]
+
+[[cases]]
+reading = "きららざか"
+expected = "雲母坂"
+category = "extras"
+tags = ["geography", "domain-reading"]
+
+# ═══════════════════════════════════════════════════════════════════
 # Compound nouns (segmentation + POS)
 # ═══════════════════════════════════════════════════════════════════
 

--- a/mise.toml
+++ b/mise.toml
@@ -105,14 +105,27 @@ sources = [
 outputs = ["engine/data/symbols-raw/.stamp"]
 run = "cd engine && cargo run -p lex-cli --bin dictool -- fetch --source symbols data/symbols-raw"
 
+[tasks.fetch-dict-extras]
+description = "Materialize bundled curated domain TSVs (IT, food, geography, ...)"
+sources = [
+  "engine/crates/lex-cli/src/bin/dictool.rs",
+  "engine/crates/lex-cli/src/dict_source/mod.rs",
+  "engine/crates/lex-cli/src/dict_source/extras.rs",
+  "engine/crates/lex-cli/src/dict_source/extras/*.tsv",
+]
+outputs = ["engine/data/extras-raw/.stamp"]
+run = "cd engine && cargo run -p lex-cli --bin dictool -- fetch --source extras data/extras-raw"
+
 [tasks.dict]
-description = "Build merged dictionary (Mozc + bundled symbols)"
-depends = ["fetch-dict-mozc", "fetch-dict-symbols"]
+description = "Build merged dictionary (Mozc + bundled symbols + curated extras)"
+depends = ["fetch-dict-mozc", "fetch-dict-symbols", "fetch-dict-extras"]
 sources = [
   "engine/data/mozc-raw/.stamp",
   "engine/data/mozc-raw/id.def",
   "engine/data/symbols-raw/.stamp",
+  "engine/data/extras-raw/.stamp",
   "engine/crates/lex-cli/src/dict_source/symbols.tsv",
+  "engine/crates/lex-cli/src/dict_source/extras/*.tsv",
   "engine/crates/**/*.rs",
   "engine/crates/**/*.toml",
   "engine/Cargo.toml",
@@ -128,6 +141,7 @@ target/release/dictool compile \
   --source mozc \
   --id-def data/mozc-raw/id.def \
   --extra-source symbols:data/symbols-raw \
+  --extra-source extras:data/extras-raw \
   data/mozc-raw data/lexime.dict
 """
 


### PR DESCRIPTION
## Summary

Adds a curated `extras` dict source for domain-specific vocabulary not covered by Mozc UT. Three domains seeded: **IT / 業務**, **food (飲食)**, **geography (地名/地図)**.

```
engine/crates/lex-cli/src/dict_source/extras.rs       # source impl
engine/crates/lex-cli/src/dict_source/extras/<dom>.tsv # per-domain TSV
```

## Design

Format (TSV):
\`\`\`
reading[TAB]surface[TAB]cost(optional, default 5000)
\`\`\`
- POS は固定 (`1852` = 名詞,一般)。一保堂のようなブランドも 1852 で動く
- 各 domain ファイルは `include_str!` で binary 内に bundling
- 新 domain = `<name>.tsv` 追加 + `extras.rs::DOMAINS` に 1 行追加で済む

Domain 粒度は **広め** に。一保堂 (日本茶ブランド) のような境界例が `cooking-chinese` だと行き場をなくすため。

## 過去の Sudachi 全マージとの差別化

PR #156 (2026-02-20) で SudachiDict bulk merge を**意図的に削除済**。理由 (e20e31a):
> "Mozc dictionary is better calibrated for IME use and produces less noisy candidates."

今回は **真逆のアプローチ**: 大量取り込みではなく、ユーザ報告ベースの厳選 curated 語彙のみ。

| | 過去 (Sudachi 全マージ) | 今回 (curated extras) |
|---|---|---|
| 規模 | 全部 (~700K 語) | 7 entries 初期、PR で漸増 |
| ノイズ | 多 → top-1 品質悪化 | 各エントリ手レビュー |
| ライセンス | Apache-2.0 (集約源は混在) | 独自 (リポジトリ MIT) |
| 制御性 | 不能 | domain 単位 PR |

## Seed (7 entries, ユーザ user_dict ベース)

| reading | surface | domain | Mozc 状況 |
|---|---|---|---|
| べきとう | 冪等 | it | 無し |
| あさかい | 朝会 | it | ちょうかい→朝会 のみ |
| しかかり | 仕掛 | it | しかけ→仕掛 のみ |
| たんじゃお | 藤椒 | food | 無し (ふじしょう→藤生人名のみ) |
| ほわじゃお | 花椒 | food | 無し (ホアジャオ カナのみ) |
| いっぽどう | 一保堂 | food | 無し |
| きららざか | 雲母坂 | geography | 無し |

## Before / After

\`\`\`
mise run accuracy:    68/68+1skip → 75/75+1skip (+7 extras 全 pass)
mise run accuracy-history: 6/6 維持
\`\`\`

\`lextool explain\` 全 7 ケース top-1 確認済:
\`\`\`
さんぜんえん → 三千円 (regression なし)
べきとう → 冪等 (final_cost=10426)
あさかい → 朝会 (final_cost=10426)
しかかり → 仕掛 (final_cost=10426)
たんじゃお → 藤椒 (final_cost=10426)
ほわじゃお → 花椒 (final_cost=10426)
いっぽどう → 一保堂 (final_cost=10426)
きららざか → 雲母坂 (final_cost=10426)
\`\`\`

## 今後の運用

- 語彙追加は domain TSV への PR で受ける形
- ユーザ user_dict を seed 源として活用 (個人で困った語彙 = 候補)
- 新 domain (medical, legal, finance, music...) は necessity 駆動で追加

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-features -- -D warnings\`
- [x] \`cargo test --workspace --all-features\` (全 444 tests pass、新規 +3)
- [x] \`mise run accuracy\` (75/75 pass)
- [x] \`mise run accuracy-history\` (6/6 pass)
- [x] \`mise run build && install && reload\` で実機展開
- [ ] 実機 IME での 7 ケース変換確認 (ユーザ実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)