### PR TITLE
fix(numeric): reject bare large-unit multipliers (まん/おく/ちょう)

### DIFF
--- a/engine/crates/lex-core/src/numeric.rs
+++ b/engine/crates/lex-core/src/numeric.rs
@@ -48,11 +48,17 @@ pub fn parse_japanese_number(kana: &str) -> Option<u64> {
             if pos != 0 {
                 return None;
             }
-            rest = &rest[unit_kana.len()..];
-            // If group is 0 before a large unit, it means the unit stands alone (e.g. まん = 10000)
+            // Require an explicit leading digit. Bare `まん` / `おく` /
+            // `ちょう` overwhelmingly mean something other than the bare
+            // numeric value (万年, 億劫, 兆候, 調査, ...) — accepting them
+            // as implicit-1 lets the number+counter rewriter generate
+            // spurious top-1 candidates like `ちょうさ → 一兆差` that
+            // outrank natural Viterbi top-1 like `調査`. Multiplier-only
+            // input remains a typing error if it ever reaches us.
             if group == 0 {
-                group = 1;
+                return None;
             }
+            rest = &rest[unit_kana.len()..];
             result += group * unit_val;
             group = parse_group(&mut rest);
         }
@@ -357,6 +363,20 @@ mod tests {
         assert_eq!(parse_japanese_number("いちおく"), Some(100_000_000));
         assert_eq!(parse_japanese_number("いっちょう"), None); // いっちょう not supported
         assert_eq!(parse_japanese_number("いちちょう"), Some(1_000_000_000_000));
+    }
+
+    #[test]
+    fn test_bare_large_units_rejected() {
+        // Bare large multipliers must NOT parse — otherwise the number+counter
+        // rewriter generates spurious top-1 like `ちょうさ → 一兆差` that
+        // outranks `調査` (real user bug).
+        assert_eq!(parse_japanese_number("まん"), None);
+        assert_eq!(parse_japanese_number("おく"), None);
+        assert_eq!(parse_japanese_number("ちょう"), None);
+        // Compound forms with a real leading group must still work.
+        assert_eq!(parse_japanese_number("ひゃくまん"), Some(1_000_000));
+        assert_eq!(parse_japanese_number("じゅうおく"), Some(1_000_000_000));
+        assert_eq!(parse_japanese_number("にちょう"), Some(2_000_000_000_000));
     }
 
     #[test]

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -411,6 +411,27 @@ expected = "一万円"
 category = "numeric"
 tags = ["counter", "large"]
 
+[[cases]]
+reading = "ちょうさ"
+expected = "調査"
+category = "regression"
+tags = ["numeric-rewriter", "bare-multiplier"]
+note = "NumericRewriter が `ちょう→1兆` + `さ→差` を合成し `一兆差` が top-1 になっていた (bare 多倍数 implicit-1 を削除して修正)"
+
+[[cases]]
+reading = "まんねん"
+expected = "万年"
+category = "regression"
+tags = ["numeric-rewriter", "bare-multiplier"]
+note = "同上 — `まん→1万` + `ねん→年` で `一万年` が top-1 になっていた"
+
+[[cases]]
+reading = "おくねん"
+expected = "憶念"
+category = "regression"
+tags = ["numeric-rewriter", "bare-multiplier"]
+note = "同上 — `おく→1億` + `ねん→年` で `一億年` が top-1 になっていた"
+
 # ═══════════════════════════════════════════════════════════════════
 # Curated domain extras (engine/data/extras-raw)
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

\`parse_japanese_number\` was accepting bare \`まん\`/\`おく\`/\`ちょう\` as \`10000\`/\`100_000_000\`/\`1_000_000_000_000\` via an implicit-1 prefix. This fed the number+counter rewriter (#239) spurious top-1 candidates that outranked the natural Viterbi top-1 for everyday vocabulary.

### User-reported bug

\`ちょうさ\` → \`一兆差\` (top-1, final_cost=8355) instead of \`調査\` (final_cost=8855).

\`lextool explain ちょうさ\` showed the rewriter emitting \`一兆差\` at \`best_cost - 500\`:
\`\`\`
  #1  一兆差  (final_cost=8355)
    seg[0]: 一兆差(ちょうさ) word=0   penalty=5000  script=-666   BOS->0
  #2  調査  (final_cost=8855)
    seg[0]: 調査(ちょうさ)   word=3226 penalty=5000 script=-666   BOS->1295
\`\`\`

Same pattern reproduced for:
- \`まんねん → 一万年\` (instead of \`万年\`)
- \`おくねん → 一億年\` (instead of \`憶念\`)

### Why this happened

\`差\` is POS-tagged as 助数詞 (counter — valid in contexts like \`1点差\`). The rewriter scans counter nodes ending at the reading's tail and pairs them with a parsed number prefix. \`parse_japanese_number(\"ちょう\")\` returned \`Some(1_000_000_000_000)\` via the implicit-1 fallback, so the rewriter generated \`一兆差\` with cost \`best_cost - 500\`, undercutting \`調査\`.

### Fix

Remove the implicit-1 fallback for bare \`まん\`/\`おく\`/\`ちょう\` in \`parse_japanese_number\`. Bare multipliers are virtually never how anyone writes these numbers (people type \`いちまん\` / \`いちちょう\` or \`1兆\` directly), so the fallback was a net negative.

Compound forms remain working: \`ひゃくまん\` (1,000,000), \`じゅうおく\` (1,000,000,000), \`にちょう\` (2兆), \`いちまんえん\` (10000円), etc. — verified by accuracy-corpus pass.

### After fix

\`\`\`
  #1  調査  (final_cost=8855)   ← restored as top-1
\`\`\`

## Test plan

- [x] New unit test \`test_bare_large_units_rejected\` covers all three bare forms + compound forms that must still work
- [x] 3 new accuracy regression cases (\`ちょうさ\` / \`まんねん\` / \`おくねん\`) under \`category = \"regression\"\`, tagged \`bare-multiplier\`
- [x] \`cargo fmt --all --check\` / \`cargo clippy --workspace --all-features -- -D warnings\` green
- [x] \`cargo test --workspace --all-features\` — 349 lex-core (was 348, +1 new) / 74 lex-engine / 32 lex-cli pass
- [x] \`mise run accuracy\`: 80/80 active pass (regression +3 cases)
- [x] \`mise run accuracy-history\`: 6/6 pass
- [x] \`mise run build && install && reload\` — verified \`ちょうさ→調査\` in live IME

🤖 Generated with [Claude Code](https://claude.com/claude-code)