### PR TITLE
fix(converter): stop post-history rewriters inheriting whole-path boost

### DIFF
--- a/engine/crates/lex-core/src/converter/reranker.rs
+++ b/engine/crates/lex-core/src/converter/reranker.rs
@@ -173,7 +173,13 @@ pub fn history_rerank_at(paths: &mut [ScoredPath], history: &UserHistory, now: u
     }
     for path in paths.iter_mut() {
         let breakdown = compute_history_boost(path, history, now);
-        path.viterbi_cost -= breakdown.applied(path.segments.len());
+        let applied = breakdown.applied(path.segments.len());
+        path.viterbi_cost -= applied;
+        // Remember the boost so candidate generators running after this step
+        // can recover the pre-boost cost (see `ScoredPath::pre_history_cost`)
+        // and avoid inheriting this path's whole-path boost into derived
+        // surfaces that were never actually confirmed.
+        path.history_boost = applied;
     }
     paths.sort_by_key(|p| p.viterbi_cost);
     debug!(best_cost = paths.first().map(|p| p.viterbi_cost));
@@ -207,6 +213,7 @@ mod tests {
         ScoredPath {
             segments,
             viterbi_cost: cost,
+            history_boost: 0,
         }
     }
 

--- a/engine/crates/lex-core/src/converter/resegment.rs
+++ b/engine/crates/lex-core/src/converter/resegment.rs
@@ -107,6 +107,7 @@ pub(super) fn resegment(
                     let candidate = ScoredPath {
                         segments: new_segs,
                         viterbi_cost: cost,
+                        history_boost: 0,
                     };
 
                     // Dedup against existing paths and already-generated candidates

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -29,9 +29,17 @@ pub(crate) trait Rewriter {
     fn generate(&self, paths: &[ScoredPath], reading: &str) -> Vec<ScoredPath>;
 }
 
-/// Worst (highest) Viterbi cost among paths, or 0 if empty.
+/// Worst (highest) pre-history Viterbi cost among paths, or 0 if empty.
+///
+/// Uses `pre_history_cost` so that rewriters running after `history_rerank`
+/// derive fallback costs from the intrinsic Viterbi cost, not from a
+/// history-boosted (possibly large-negative) cost.
 fn worst_cost(paths: &[ScoredPath]) -> i64 {
-    paths.iter().map(|p| p.viterbi_cost).max().unwrap_or(0)
+    paths
+        .iter()
+        .map(|p| p.pre_history_cost())
+        .max()
+        .unwrap_or(0)
 }
 
 /// Run all rewriters in sequence, deduplicating and inserting in cost order.
@@ -138,7 +146,8 @@ impl Rewriter for PartialHiraganaRewriter {
 
                 new_paths.push(ScoredPath {
                     segments: new_segments,
-                    viterbi_cost: path.viterbi_cost.saturating_add(2000),
+                    viterbi_cost: path.pre_history_cost().saturating_add(2000),
+                    history_boost: 0,
                 });
             }
         }
@@ -206,7 +215,7 @@ impl Rewriter for KanjiVariantRewriter<'_> {
                 && p.segments[0].surface == p.segments[0].reading
                 && p.segments[0].surface.chars().all(is_hiragana)
         }) {
-            self.kanji_variants_from_reading(reading, base.viterbi_cost, &mut new_paths);
+            self.kanji_variants_from_reading(reading, base.pre_history_cost(), &mut new_paths);
         }
 
         new_paths
@@ -243,7 +252,8 @@ impl KanjiVariantRewriter<'_> {
             new_segments[seg.idx] = self.lattice.to_rich_segment(idx);
             new_paths.push(ScoredPath {
                 segments: new_segments,
-                viterbi_cost: path.viterbi_cost.saturating_add(2000),
+                viterbi_cost: path.pre_history_cost().saturating_add(2000),
+                history_boost: 0,
             });
         }
     }
@@ -291,7 +301,8 @@ impl KanjiVariantRewriter<'_> {
             new_segments.insert(seg.idx + 1, right_seg);
             new_paths.push(ScoredPath {
                 segments: new_segments,
-                viterbi_cost: path.viterbi_cost.saturating_add(2000),
+                viterbi_cost: path.pre_history_cost().saturating_add(2000),
+                history_boost: 0,
             });
         }
     }
@@ -355,7 +366,11 @@ impl Rewriter for NumericRewriter<'_> {
         let mut candidates = Vec::new();
 
         if let Some(n) = numeric::parse_japanese_number(reading) {
-            let best_cost = paths.iter().map(|p| p.viterbi_cost).min().unwrap_or(0);
+            let best_cost = paths
+                .iter()
+                .map(|p| p.pre_history_cost())
+                .min()
+                .unwrap_or(0);
             let base_cost = worst_cost(paths).saturating_add(5000);
 
             // Kanji candidate
@@ -470,7 +485,11 @@ impl NumericRewriter<'_> {
         cands.sort_by(|a, b| a.cost.cmp(&b.cost).then_with(|| a.surface.cmp(b.surface)));
 
         let cheapest = cands.first().map(|c| c.cost).unwrap_or(0);
-        let best_cost = paths.iter().map(|p| p.viterbi_cost).min().unwrap_or(0);
+        let best_cost = paths
+            .iter()
+            .map(|p| p.pre_history_cost())
+            .min()
+            .unwrap_or(0);
         let base_cost = worst_cost(paths).saturating_add(5000);
         // Discount keeps the most-likely number+counter compound above the
         // current Viterbi top-1, since this segmentation isn't representable

--- a/engine/crates/lex-core/src/converter/tests/reranker.rs
+++ b/engine/crates/lex-core/src/converter/tests/reranker.rs
@@ -409,6 +409,10 @@ fn test_history_rerank_at_matches_compute_history_boost() {
     let actual_applied = initial_cost - paths[0].viterbi_cost;
 
     assert_eq!(actual_applied, expected_applied);
+    // The applied boost must also be stored on the path so that candidate
+    // generators running after history_rerank can recover the pre-boost cost
+    // via `pre_history_cost()`. Locks the `history_boost` field contract.
+    assert_eq!(paths[0].history_boost, expected_applied);
 }
 
 /// Build a connection matrix where all transitions cost the given value.

--- a/engine/crates/lex-core/src/converter/tests/reranker.rs
+++ b/engine/crates/lex-core/src/converter/tests/reranker.rs
@@ -41,6 +41,7 @@ fn test_rerank_penalizes_fragmented_path() {
                 },
             ],
             viterbi_cost: 1000,
+            history_boost: 0,
         },
         // Single segment path: 0 transitions → 0 structure cost
         ScoredPath {
@@ -52,6 +53,7 @@ fn test_rerank_penalizes_fragmented_path() {
                 word_cost: 0,
             }],
             viterbi_cost: 1040,
+            history_boost: 0,
         },
     ];
 
@@ -82,6 +84,7 @@ fn test_rerank_no_conn_no_structure_penalty() {
                 },
             ],
             viterbi_cost: 1000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![RichSegment {
@@ -92,6 +95,7 @@ fn test_rerank_no_conn_no_structure_penalty() {
                 word_cost: 0,
             }],
             viterbi_cost: 2000,
+            history_boost: 0,
         },
     ];
 
@@ -113,6 +117,7 @@ fn test_rerank_single_path_noop() {
             word_cost: 0,
         }],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     rerank(&mut paths, None, None);
@@ -151,6 +156,7 @@ fn test_rerank_penalizes_uneven_segments() {
                 },
             ],
             viterbi_cost: 5000,
+            history_boost: 0,
         },
         // Even: readings 2 + 2 chars → sum_sq_dev=0, penalty=0
         ScoredPath {
@@ -171,6 +177,7 @@ fn test_rerank_penalizes_uneven_segments() {
                 },
             ],
             viterbi_cost: 6500,
+            history_boost: 0,
         },
     ];
 
@@ -202,6 +209,7 @@ fn test_rerank_applies_script_cost() {
                 word_cost: 0,
             }],
             viterbi_cost: 3000,
+            history_boost: 0,
         },
         // Hiragana path: たら (no script penalty)
         ScoredPath {
@@ -213,6 +221,7 @@ fn test_rerank_applies_script_cost() {
                 word_cost: 0,
             }],
             viterbi_cost: 7000,
+            history_boost: 0,
         },
     ];
 
@@ -245,6 +254,7 @@ fn test_history_rerank_unigram_boost_reorders() {
                 word_cost: 0,
             }],
             viterbi_cost: 3000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![RichSegment {
@@ -255,6 +265,7 @@ fn test_history_rerank_unigram_boost_reorders() {
                 word_cost: 0,
             }],
             viterbi_cost: 5000,
+            history_boost: 0,
         },
     ];
 
@@ -289,6 +300,7 @@ fn test_history_rerank_bigram_boost() {
                 },
             ],
             viterbi_cost: 5000,
+            history_boost: 0,
         },
         // Path with bigram match: "今日" → "は"
         ScoredPath {
@@ -309,6 +321,7 @@ fn test_history_rerank_bigram_boost() {
                 },
             ],
             viterbi_cost: 7000,
+            history_boost: 0,
         },
     ];
 
@@ -332,6 +345,7 @@ fn test_history_rerank_empty_history_preserves_order() {
                 word_cost: 0,
             }],
             viterbi_cost: 1000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![RichSegment {
@@ -342,6 +356,7 @@ fn test_history_rerank_empty_history_preserves_order() {
                 word_cost: 0,
             }],
             viterbi_cost: 2000,
+            history_boost: 0,
         },
     ];
 
@@ -383,6 +398,7 @@ fn test_history_rerank_at_matches_compute_history_boost() {
             word_cost: 0,
         }],
         viterbi_cost: 10_000,
+        history_boost: 0,
     };
     let expected_applied =
         compute_history_boost(&path_before, &h, now).applied(path_before.segments.len());
@@ -425,6 +441,7 @@ fn test_filter_drops_fragmented_paths() {
                 word_cost: 0,
             }],
             viterbi_cost: 5000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![
@@ -444,6 +461,7 @@ fn test_filter_drops_fragmented_paths() {
                 },
             ],
             viterbi_cost: 4000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![
@@ -484,6 +502,7 @@ fn test_filter_drops_fragmented_paths() {
                 },
             ],
             viterbi_cost: 3000,
+            history_boost: 0,
         },
     ];
 
@@ -524,6 +543,7 @@ fn test_filter_keeps_all_when_all_exceed() {
                 seg("え", "絵"),
             ],
             viterbi_cost: 3000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![
@@ -533,6 +553,7 @@ fn test_filter_keeps_all_when_all_exceed() {
                 seg("え", "江"),
             ],
             viterbi_cost: 4000,
+            history_boost: 0,
         },
     ];
 
@@ -583,6 +604,7 @@ fn test_filter_preserves_minimum_path() {
                 },
             ],
             viterbi_cost: 1000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![RichSegment {
@@ -593,6 +615,7 @@ fn test_filter_preserves_minimum_path() {
                 word_cost: 0,
             }],
             viterbi_cost: 5000,
+            history_boost: 0,
         },
     ];
 
@@ -662,6 +685,7 @@ fn test_prefix_floor_prevents_low_baseline() {
                 },
             ],
             viterbi_cost: 3000,
+            history_boost: 0,
         },
         // Path B: content → content → content (sc = 8000)
         // Without floor this would be dropped (8000 > 6100).
@@ -691,6 +715,7 @@ fn test_prefix_floor_prevents_low_baseline() {
                 },
             ],
             viterbi_cost: 4000,
+            history_boost: 0,
         },
     ];
 

--- a/engine/crates/lex-core/src/converter/tests/rewriter/hiragana_variant.rs
+++ b/engine/crates/lex-core/src/converter/tests/rewriter/hiragana_variant.rs
@@ -36,6 +36,7 @@ fn test_hiragana_variant_replaces_kanji() {
             },
         ],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "りだいれくとされますか");
@@ -66,6 +67,7 @@ fn test_hiragana_variant_skips_all_hiragana() {
             },
         ],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "されます");
@@ -89,6 +91,7 @@ fn test_hiragana_variant_dedup_via_run_rewriters() {
                 word_cost: 0,
             }],
             viterbi_cost: 3000,
+            history_boost: 0,
         },
         ScoredPath {
             segments: vec![RichSegment {
@@ -99,6 +102,7 @@ fn test_hiragana_variant_dedup_via_run_rewriters() {
                 word_cost: 0,
             }],
             viterbi_cost: 4000,
+            history_boost: 0,
         },
     ];
 
@@ -128,6 +132,7 @@ fn test_hiragana_variant_keeps_katakana() {
             },
         ],
         viterbi_cost: 2000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "てすとちゅう");

--- a/engine/crates/lex-core/src/converter/tests/rewriter/kanji_variant.rs
+++ b/engine/crates/lex-core/src/converter/tests/rewriter/kanji_variant.rs
@@ -47,6 +47,7 @@ fn test_kanji_variant_replaces_2char_hiragana() {
             },
         ],
         viterbi_cost: 20000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "あったほうが");
@@ -57,6 +58,70 @@ fn test_kanji_variant_replaces_2char_hiragana() {
     assert!(result.iter().any(|p| p.surface_key() == "あった法が"));
     // All variants should have +2000 penalty
     assert!(result.iter().all(|p| p.viterbi_cost == 22000));
+}
+
+#[test]
+fn test_kanji_variant_does_not_inherit_history_boost() {
+    // Regression: KanjiVariantRewriter runs AFTER history_rerank, so a base
+    // path that received a large whole-path boost has a deeply negative
+    // viterbi_cost. Variants derived from it must use the PRE-boost cost
+    // (`pre_history_cost`), otherwise they inherit a boost for surfaces that
+    // were never confirmed and bury genuinely-boosted candidates.
+    let lattice = Lattice::from_test_nodes(
+        "あったほうが",
+        &[
+            (3, 5, "ほう", "ほう", 0, 0, 0),
+            (3, 5, "ほう", "方", 733, 0, 0),
+        ],
+    );
+    let rw = KanjiVariantRewriter { lattice: &lattice };
+
+    // pre_history_cost = 20000; history_rerank subtracted a 50000 boost.
+    let paths = vec![ScoredPath {
+        segments: vec![
+            RichSegment {
+                reading: "あっ".into(),
+                surface: "あっ".into(),
+                left_id: 0,
+                right_id: 0,
+                word_cost: 0,
+            },
+            RichSegment {
+                reading: "た".into(),
+                surface: "た".into(),
+                left_id: 0,
+                right_id: 0,
+                word_cost: 0,
+            },
+            RichSegment {
+                reading: "ほう".into(),
+                surface: "ほう".into(),
+                left_id: 0,
+                right_id: 0,
+                word_cost: 0,
+            },
+            RichSegment {
+                reading: "が".into(),
+                surface: "が".into(),
+                left_id: 0,
+                right_id: 0,
+                word_cost: 0,
+            },
+        ],
+        viterbi_cost: -30000,
+        history_boost: 50000,
+    }];
+
+    let result = rw.generate(&paths, "あったほうが");
+
+    assert!(result.iter().any(|p| p.surface_key() == "あった方が"));
+    // Variant cost = pre_history_cost (20000) + 2000, NOT the boosted
+    // viterbi_cost (-30000) + 2000.
+    assert!(
+        result.iter().all(|p| p.viterbi_cost == 22000),
+        "variants must derive from pre_history_cost, got {:?}",
+        result.iter().map(|p| p.viterbi_cost).collect::<Vec<_>>(),
+    );
 }
 
 #[test]
@@ -83,6 +148,7 @@ fn test_kanji_variant_skips_single_char() {
             },
         ],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "した");
@@ -104,6 +170,7 @@ fn test_kanji_variant_skips_single_segment() {
             word_cost: 0,
         }],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "ほう");
@@ -135,6 +202,7 @@ fn test_kanji_variant_skips_kanji_segments() {
             },
         ],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "したほう");
@@ -176,6 +244,7 @@ fn test_kanji_variant_skips_3char_segments_no_2char_kanji() {
             },
         ],
         viterbi_cost: 5000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "たほうが");
@@ -225,6 +294,7 @@ fn test_kanji_variant_subsplit_3char_segment() {
             },
         ],
         viterbi_cost: 20000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "あったほうが");
@@ -270,6 +340,7 @@ fn test_kanji_variant_subsplit_only_2char_prefix() {
             },
         ],
         viterbi_cost: 10000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "ほうがくが");
@@ -302,6 +373,7 @@ fn test_kanji_variant_reading_scan_single_segment() {
             word_cost: 0,
         }],
         viterbi_cost: 30000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "しておいたほうが");
@@ -331,6 +403,7 @@ fn test_kanji_variant_reading_scan_skips_edges() {
             word_cost: 0,
         }],
         viterbi_cost: 10000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "ほうが");

--- a/engine/crates/lex-core/src/converter/tests/rewriter/katakana.rs
+++ b/engine/crates/lex-core/src/converter/tests/rewriter/katakana.rs
@@ -13,6 +13,7 @@ fn test_katakana_rewriter_generates_candidate() {
             word_cost: 0,
         }],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "きょう");
@@ -34,6 +35,7 @@ fn test_katakana_dedup_via_run_rewriters() {
             word_cost: 0,
         }],
         viterbi_cost: 5000,
+        history_boost: 0,
     }];
 
     run_rewriters(&[&rw], &mut paths, "きょう");

--- a/engine/crates/lex-core/src/converter/tests/rewriter/numeric.rs
+++ b/engine/crates/lex-core/src/converter/tests/rewriter/numeric.rs
@@ -34,6 +34,7 @@ fn test_numeric_rewriter_generates_candidates() {
             word_cost: 0,
         }],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "にじゅうさん");
@@ -62,6 +63,7 @@ fn test_numeric_rewriter_kanji_duplicate_skip() {
             word_cost: 0,
         }],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     run_rewriters(&[&rw], &mut paths, "にじゅうさん");
@@ -88,6 +90,7 @@ fn test_numeric_rewriter_single_char_kanji_low_priority() {
             word_cost: 0,
         }],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     run_rewriters(&[&rw], &mut paths, "じゅう");
@@ -113,6 +116,7 @@ fn test_numeric_rewriter_skips_non_numeric() {
             word_cost: 0,
         }],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "きょう");
@@ -138,6 +142,7 @@ fn test_numeric_rewriter_skips_duplicate() {
             word_cost: 0,
         }],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     run_rewriters(&[&rw], &mut paths, "いち");
@@ -181,6 +186,7 @@ fn test_numeric_counter_generates_kanji_compound() {
             word_cost: 0,
         }],
         viterbi_cost: 5000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "さんぜんえん");
@@ -232,6 +238,7 @@ fn test_numeric_counter_dedupes_multi_pos_counter() {
             word_cost: 0,
         }],
         viterbi_cost: 4000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "ごえん");
@@ -266,6 +273,7 @@ fn test_numeric_counter_skips_when_prefix_not_a_number() {
             word_cost: 0,
         }],
         viterbi_cost: 4000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "あいえん");
@@ -290,6 +298,7 @@ fn test_numeric_counter_disabled_without_lattice_or_conn() {
             word_cost: 0,
         }],
         viterbi_cost: 5000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "さんぜんえん");
@@ -324,6 +333,7 @@ fn test_numeric_counter_deterministic_order_on_cost_tie() {
             word_cost: 0,
         }],
         viterbi_cost: 4000,
+        history_boost: 0,
     }];
 
     let mut emit_orders: Vec<Vec<String>> = Vec::new();
@@ -373,6 +383,7 @@ fn test_numeric_counter_extreme_cost_no_overflow() {
             word_cost: 0,
         }],
         viterbi_cost: 4000,
+        history_boost: 0,
     }];
 
     // Should not panic; should still emit candidates for both counters.

--- a/engine/crates/lex-core/src/converter/tests/rewriter/partial_hiragana.rs
+++ b/engine/crates/lex-core/src/converter/tests/rewriter/partial_hiragana.rs
@@ -22,6 +22,7 @@ fn test_partial_hiragana_basic() {
             },
         ],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "したほう");
@@ -61,6 +62,7 @@ fn test_partial_hiragana_multiple_kanji() {
             },
         ],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "したほうが");
@@ -93,6 +95,7 @@ fn test_partial_hiragana_dedup_via_run_rewriters() {
                 },
             ],
             viterbi_cost: 3000,
+            history_boost: 0,
         },
         // This path already has the surface "した方"
         ScoredPath {
@@ -113,6 +116,7 @@ fn test_partial_hiragana_dedup_via_run_rewriters() {
                 },
             ],
             viterbi_cost: 5000,
+            history_boost: 0,
         },
     ];
 
@@ -144,6 +148,7 @@ fn test_partial_hiragana_all_hiragana_no_variants() {
             },
         ],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "したほう");
@@ -175,6 +180,7 @@ fn test_partial_hiragana_keeps_katakana() {
             },
         ],
         viterbi_cost: 2000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "てすとちゅう");
@@ -196,6 +202,7 @@ fn test_partial_hiragana_single_segment_skip() {
             word_cost: 0,
         }],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     let result = rw.generate(&paths, "した");

--- a/engine/crates/lex-core/src/converter/tests/rewriter/run_rewriters.rs
+++ b/engine/crates/lex-core/src/converter/tests/rewriter/run_rewriters.rs
@@ -16,6 +16,7 @@ fn test_run_rewriters_applies_all() {
             word_cost: 0,
         }],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     run_rewriters(&[&rw], &mut paths, "あ");
@@ -50,6 +51,7 @@ fn test_run_rewriters_dedup_across_rewriters() {
             },
         ],
         viterbi_cost: 1000,
+        history_boost: 0,
     }];
 
     run_rewriters(&[&hiragana_rw, &partial_rw], &mut paths, "されます");
@@ -78,6 +80,7 @@ fn test_run_rewriters_cost_ordered_insertion() {
             word_cost: 0,
         }],
         viterbi_cost: 3000,
+        history_boost: 0,
     }];
 
     run_rewriters(&[&rw], &mut paths, "にじゅうさん");

--- a/engine/crates/lex-core/src/converter/viterbi.rs
+++ b/engine/crates/lex-core/src/converter/viterbi.rs
@@ -23,10 +23,20 @@ pub(crate) struct RichSegment {
 }
 
 /// A scored path from N-best Viterbi, carrying enough info for reranking.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct ScoredPath {
     pub segments: Vec<RichSegment>,
     pub viterbi_cost: i64,
+    /// History boost subtracted from `viterbi_cost` by `history_rerank_at`
+    /// (0 before history reranking, or when no history is applied).
+    ///
+    /// Kept so that candidate generators running *after* history_rerank can
+    /// recover the pre-boost cost via [`Self::pre_history_cost`]. Without this,
+    /// rewriters that derive a new candidate's cost from a base path would
+    /// inherit the base's whole-path boost into surfaces that were never
+    /// actually confirmed (e.g. kanji variants of a boosted hiragana path),
+    /// burying genuinely-boosted candidates below junk.
+    pub history_boost: i64,
 }
 
 impl ScoredPath {
@@ -41,7 +51,18 @@ impl ScoredPath {
                 word_cost: 0,
             }],
             viterbi_cost: cost,
+            history_boost: 0,
         }
+    }
+
+    /// Cost before any history boost was applied.
+    ///
+    /// `history_rerank_at` subtracts the boost from `viterbi_cost`; adding it
+    /// back recovers the intrinsic Viterbi/rerank cost. Candidate generators
+    /// that derive a new path's cost from a base path should use this so the
+    /// base's whole-path history boost does not leak into the derived surface.
+    pub fn pre_history_cost(&self) -> i64 {
+        self.viterbi_cost.saturating_add(self.history_boost)
     }
 
     /// Convert to public ConvertedSegment, dropping POS metadata.
@@ -176,6 +197,7 @@ pub(crate) fn viterbi_nbest<C: CostFunction>(
         let scored = ScoredPath {
             segments,
             viterbi_cost: total_cost,
+            history_boost: 0,
         };
         if seen_surfaces.insert(scored.surface_key()) {
             results.push(scored);

--- a/engine/crates/lex-core/src/neural/speculative.rs
+++ b/engine/crates/lex-core/src/neural/speculative.rs
@@ -265,6 +265,7 @@ mod tests {
                 },
             ],
             viterbi_cost: 5000,
+            history_boost: 0,
         };
 
         let segments = scored_path_to_segments(&path);

--- a/engine/testcorpus/accuracy-corpus-history.toml
+++ b/engine/testcorpus/accuracy-corpus-history.toml
@@ -62,6 +62,10 @@ repeat = 5
 segments = [["せんせい", "先生"], ["に", "に"], ["しつもん", "質問"], ["し", "し"], ["た", "た"]]
 repeat = 5
 
+[[history]]
+segments = [["おねがいします", "お願いします"]]
+repeat = 5
+
 # ═══════════════════════════════════════════════════════════════════
 # Word-level history override
 # ═══════════════════════════════════════════════════════════════════
@@ -125,3 +129,16 @@ baseline = "先生に質問した"
 category = "phrase"
 tags = ["history", "suru-verb"]
 note = "1-char variance exclusion により baseline が質問した に改善; 履歴なしでも正しい"
+
+# ═══════════════════════════════════════════════════════════════════
+# Regression: post-history rewriter must not inherit whole-path boost
+# ═══════════════════════════════════════════════════════════════════
+
+[[cases]]
+reading = "おねがいします"
+expected = "お願いします"
+baseline = "おねがいします"
+category = "regression"
+tags = ["history", "whole-path", "rewriter"]
+note = "学習済み お願いします が候補上位に出る。以前は history_rerank 後の KanjiVariantRewriter が boost 済みひらがなパスから漢字バリアントを量産し、その継承コストで お願いします を2ページ目に押し下げていた (pre_history_cost で修正)"
+pr = "#248"


### PR DESCRIPTION
## 背景

「変換履歴のブーストが候補に反映されづらい」という体感の調査 (2026-05-17 に初出、PR #247 で `convert_explain` に history boost 内訳を可視化済み)。今回 `おねがいします` → `お願いします` が**常に2ページ目 (rank 11) から動かない**という具体例が出たため、PR #247 の可視化で根本原因を特定した。

## 根本原因

パイプライン (`postprocess.rs`): `… → history_rerank → take(n) → numeric/katakana/kanji rewriter → group_segments`。

`KanjiVariantRewriter` Phase 2 (`rewriter.rs`) が、`history_rerank` **後**の boost 済みトップパス（ひらがな `おねがいします`, viterbi_cost=-72783）を base にして `base.viterbi_cost + 2000` で漢字バリアントを量産。確定されてもいない `おねがい嶋す` / `おねが石ます` … が boost を継承して全部 -70783 となり、rank 2-10 を占拠 → 正当に boost された `お願いします` (-61167) を2ページ目に押し下げていた。numeric/katakana の fallback コスト計算も同じく post-boost コストを参照していた。

## 修正

- `ScoredPath` に `history_boost` フィールドを追加し、`history_rerank_at` が差し引いた boost を記録。
- `pre_history_cost() = viterbi_cost + history_boost` を追加。
- rewriter の base/worst/best コスト計算を `pre_history_cost()` に変更。派生 surface が継承 boost を受けなくなる。
- **履歴なし時は `pre_history_cost == viterbi_cost`** なので素の変換挙動は不変。

結果: `おねがいします` で `お願いします` が **rank 11 → rank 2 (1ページ目)**、漢字バリアントは本来の 13811 に戻る。

## Accuracy (before → after)

| corpus | before | after |
|---|---|---|
| `accuracy` (plain) | 93 pass / 0 fail / 1 skip | **93 pass / 0 fail / 1 skip** (不変) |
| `accuracy-history` | 6 pass / 0 fail / 0 skip | **7 pass / 0 fail / 0 skip** (regression ケース +1) |

## テスト

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (全 pass)
- [x] `mise run accuracy` (93/93)
- [x] `mise run accuracy-history` (7/7、新 regression ケース `おねがいします` 含む)
- [x] 単体テスト追加: `test_kanji_variant_does_not_inherit_history_boost`
- [x] 実履歴ファイルでの `lextool explain` で rank 11→2 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)