### PR TITLE
fix(converter): exclude function-word segments from per-segment history boost

### DIFF
--- a/engine/crates/lex-core/src/converter/explain.rs
+++ b/engine/crates/lex-core/src/converter/explain.rs
@@ -134,6 +134,9 @@ struct PreHistorySnapshot {
 /// from these maps and fall back to zero in the caller.
 struct ExplainObserver<'a> {
     history: Option<&'a UserHistory>,
+    /// Needed so the displayed breakdown matches `history_rerank`'s
+    /// function-word exclusion for per-segment unigram boosts.
+    conn: Option<&'a ConnectionMatrix>,
     now: u64,
     /// viterbi_cost before resegment/rerank — the raw Viterbi output.
     original_costs: HashMap<String, i64>,
@@ -142,9 +145,10 @@ struct ExplainObserver<'a> {
 }
 
 impl<'a> ExplainObserver<'a> {
-    fn new(history: Option<&'a UserHistory>, now: u64) -> Self {
+    fn new(history: Option<&'a UserHistory>, conn: Option<&'a ConnectionMatrix>, now: u64) -> Self {
         Self {
             history,
+            conn,
             now,
             original_costs: HashMap::new(),
             pre_history: HashMap::new(),
@@ -165,7 +169,7 @@ impl PostprocessObserver for ExplainObserver<'_> {
         for p in paths {
             let (breakdown, applied) = match self.history {
                 Some(h) => {
-                    let b = compute_history_boost(p, h, self.now);
+                    let b = compute_history_boost(p, h, self.conn, self.now);
                     let a = b.applied(p.segments.len());
                     (b, a)
                 }
@@ -279,7 +283,7 @@ pub fn explain(
     let mut raw_paths = viterbi_nbest(&lattice, &cost_fn, oversample);
 
     let now = crate::user_history::now_epoch();
-    let mut observer = ExplainObserver::new(history, now);
+    let mut observer = ExplainObserver::new(history, conn, now);
     let ctx = PostprocessContext {
         lattice: &lattice,
         conn,

--- a/engine/crates/lex-core/src/converter/postprocess.rs
+++ b/engine/crates/lex-core/src/converter/postprocess.rs
@@ -117,7 +117,7 @@ pub(crate) fn postprocess_observed<O: PostprocessObserver>(
     };
 
     if let Some(h) = ctx.history {
-        reranker::history_rerank_at(paths, h, ctx.now);
+        reranker::history_rerank_at(paths, h, ctx.conn, ctx.now);
     }
     let mut top: Vec<ScoredPath> = paths.drain(..ctx.n.min(paths.len())).collect();
 

--- a/engine/crates/lex-core/src/converter/reranker.rs
+++ b/engine/crates/lex-core/src/converter/reranker.rs
@@ -128,10 +128,22 @@ impl HistoryBoostBreakdown {
 pub fn compute_history_boost(
     path: &ScoredPath,
     history: &UserHistory,
+    conn: Option<&ConnectionMatrix>,
     now: u64,
 ) -> HistoryBoostBreakdown {
     let mut unigram_sum: i64 = 0;
     for seg in &path.segments {
+        // Skip per-segment unigram boost for function-word segments (particles
+        // like に/は/が, auxiliaries). These are grammatical glue, not lexical
+        // choices: the user confirms them in nearly every sentence, so their
+        // unigram boost saturates and would inflate ANY fragmented
+        // mis-segmentation that isolates the particle (e.g. 代/に/段 for
+        // だいにだん), burying the correct compound. Restricting per-segment
+        // unigram boost to content words keeps it a homophone-disambiguation
+        // signal. Whole-path and bigram boosts are unaffected.
+        if conn.is_some_and(|c| c.is_function_word(seg.left_id)) {
+            continue;
+        }
         unigram_sum += history.unigram_boost(&seg.reading, &seg.surface, now);
     }
     let mut bigram_sum: i64 = 0;
@@ -160,19 +172,25 @@ pub fn compute_history_boost(
 /// paths (not individual lattice nodes), it cannot cause the fragmentation
 /// problems that in-Viterbi boosting could.
 ///
-/// Per-segment boosts are normalized by segment count: fragmented paths
-/// (e.g. き→機 + が + し + ます) would otherwise accumulate boosts from common
-/// particles across ALL prior conversions, gaining a structural advantage over
-/// compound paths. The whole-path boost is the strongest signal and is not
+/// Per-segment unigram boosts skip function-word segments (see
+/// [`compute_history_boost`]) and are normalized by segment count, so
+/// fragmented paths (e.g. き→機 + が + し + ます) cannot gain a structural
+/// advantage by accumulating common-particle boosts across ALL prior
+/// conversions. The whole-path boost is the strongest signal and is not
 /// normalized — it only fires when the full reading→surface was explicitly
 /// selected.
-pub fn history_rerank_at(paths: &mut [ScoredPath], history: &UserHistory, now: u64) {
+pub fn history_rerank_at(
+    paths: &mut [ScoredPath],
+    history: &UserHistory,
+    conn: Option<&ConnectionMatrix>,
+    now: u64,
+) {
     let _span = debug_span!("history_rerank", paths_count = paths.len()).entered();
     if paths.is_empty() {
         return;
     }
     for path in paths.iter_mut() {
-        let breakdown = compute_history_boost(path, history, now);
+        let breakdown = compute_history_boost(path, history, conn, now);
         let applied = breakdown.applied(path.segments.len());
         path.viterbi_cost -= applied;
         // Remember the boost so candidate generators running after this step

--- a/engine/crates/lex-core/src/converter/tests/reranker.rs
+++ b/engine/crates/lex-core/src/converter/tests/reranker.rs
@@ -269,7 +269,7 @@ fn test_history_rerank_unigram_boost_reorders() {
         },
     ];
 
-    history_rerank_at(&mut paths, &h, now_epoch());
+    history_rerank_at(&mut paths, &h, None, now_epoch());
 
     // "京" should be boosted to first place
     assert_eq!(paths[0].segments[0].surface, "京");
@@ -325,7 +325,7 @@ fn test_history_rerank_bigram_boost() {
         },
     ];
 
-    history_rerank_at(&mut paths, &h, now_epoch());
+    history_rerank_at(&mut paths, &h, None, now_epoch());
 
     // "今日は" path should be boosted (both unigram + bigram) to first
     assert_eq!(paths[0].segments[0].surface, "今日");
@@ -360,7 +360,7 @@ fn test_history_rerank_empty_history_preserves_order() {
         },
     ];
 
-    history_rerank_at(&mut paths, &h, now_epoch());
+    history_rerank_at(&mut paths, &h, None, now_epoch());
 
     assert_eq!(paths[0].segments[0].surface, "亜");
     assert_eq!(paths[0].viterbi_cost, 1000);
@@ -372,7 +372,7 @@ fn test_history_rerank_empty_history_preserves_order() {
 fn test_history_rerank_empty_paths() {
     let h = UserHistory::new();
     let mut paths: Vec<ScoredPath> = Vec::new();
-    history_rerank_at(&mut paths, &h, now_epoch());
+    history_rerank_at(&mut paths, &h, None, now_epoch());
     assert!(paths.is_empty());
 }
 
@@ -401,11 +401,11 @@ fn test_history_rerank_at_matches_compute_history_boost() {
         history_boost: 0,
     };
     let expected_applied =
-        compute_history_boost(&path_before, &h, now).applied(path_before.segments.len());
+        compute_history_boost(&path_before, &h, None, now).applied(path_before.segments.len());
 
     let initial_cost = path_before.viterbi_cost;
     let mut paths = vec![path_before];
-    history_rerank_at(&mut paths, &h, now);
+    history_rerank_at(&mut paths, &h, None, now);
     let actual_applied = initial_cost - paths[0].viterbi_cost;
 
     assert_eq!(actual_applied, expected_applied);
@@ -413,6 +413,62 @@ fn test_history_rerank_at_matches_compute_history_boost() {
     // generators running after history_rerank can recover the pre-boost cost
     // via `pre_history_cost()`. Locks the `history_boost` field contract.
     assert_eq!(paths[0].history_boost, expected_applied);
+}
+
+#[test]
+fn test_compute_history_boost_skips_function_word_unigram() {
+    // Per-segment unigram boost must NOT count function-word segments
+    // (particles). A particle like に is confirmed in nearly every sentence, so
+    // its unigram boost saturates and would inflate any fragmented
+    // mis-segmentation that isolates it (e.g. 代/に/段 for だいにだん), burying
+    // the correct compound. Regression for だいにだん → 第二弾.
+    use crate::converter::reranker::compute_history_boost;
+
+    // POS IDs: 1 = content word, 2 = function word (fw_min=fw_max=2).
+    let text = format!("3 3\n{}", "0\n".repeat(9));
+    let conn = ConnectionMatrix::from_text_with_roles(&text, 2, 2, vec![0, 0, 0]).unwrap();
+    assert!(conn.is_function_word(2));
+    assert!(!conn.is_function_word(1));
+
+    let mut h = UserHistory::new();
+    h.record(&[("だい".into(), "代".into())]);
+    for _ in 0..5 {
+        h.record(&[("に".into(), "に".into())]);
+    }
+    let now = now_epoch();
+
+    let path = ScoredPath {
+        segments: vec![
+            RichSegment {
+                reading: "だい".into(),
+                surface: "代".into(),
+                left_id: 1,
+                right_id: 1,
+                word_cost: 0,
+            },
+            RichSegment {
+                reading: "に".into(),
+                surface: "に".into(),
+                left_id: 2,
+                right_id: 2,
+                word_cost: 0,
+            },
+        ],
+        viterbi_cost: 0,
+        history_boost: 0,
+    };
+
+    let content_boost = h.unigram_boost("だい", "代", now);
+    let particle_boost = h.unigram_boost("に", "に", now);
+    assert!(particle_boost > 0, "precondition: particle is boosted");
+
+    // Without conn: both content word and particle contribute.
+    let without = compute_history_boost(&path, &h, None, now);
+    assert_eq!(without.unigram_sum, content_boost + particle_boost);
+
+    // With conn: the function-word particle is excluded from per-segment boost.
+    let with = compute_history_boost(&path, &h, Some(&conn), now);
+    assert_eq!(with.unigram_sum, content_boost);
 }
 
 /// Build a connection matrix where all transitions cost the given value.


### PR DESCRIPTION
## 背景

「`だいにだん` で `第二弾` が変換候補に出ない（`だいいちだん` の `第一弾` は出る）」というユーザ報告の調査。`convert_explain` の history boost 内訳で根本原因を特定。

## 根本原因

per-segment unigram history boost が**助詞（function word）セグメントにも効いていた**。`に` のような助詞はほぼ毎文で確定されるため unigram boost が最大値に飽和し、`history_rerank` の `/seg_count` 正規化でも抑えきれず、**助詞を分節に含む断片化した誤変換パスが軒並みブーストされる**。

`だいにだん` では `代/に/段`・`台/に/断`・`代/に/弾` 等が `に` 由来の boost ~4100 を得て rank 2-9 を占拠し、正しい複合語 `第二弾` を rank 8 まで押し下げていた。`だいいちだん` は `いち` が飽和助詞ではないため `第一弾` が rank 7 に残り、報告の非対称（第二弾 だけ出ない）になっていた。

## 修正

per-segment unigram boost を **content word に限定**（セグメントの `left_id` が connection matrix の function-word 範囲なら skip）。whole-path / bigram boost は不変（確定フレーズは依然ブースト、遷移も依然カウント）。`compute_history_boost` / `history_rerank_at` が `conn` を受け取るようにし、explain observer にも通して表示内訳を一致させた。

**結果（だいにだん, 実履歴）**: `第二弾` rank 8 → **rank 4**（1ページ目, maxDisplay=9）。`代に/台に` の断片化 junk は上位から完全に消えた。

## テスト

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`（全 pass）
- [x] 単体テスト追加: `test_compute_history_boost_skips_function_word_unigram`（助詞 unigram 除外を直接ロック）
- [x] 実履歴での `lextool explain` で rank 8→4 を確認

### accuracy (before → after)

| corpus | before | after |
|---|---|---|
| `accuracy` (plain) | 93 pass / 0 fail / 1 skip | **93 / 0 / 1**（不変） |
| `accuracy-history` | 7 pass / 0 fail / 0 skip | **7 / 0 / 0**（不変。`せんせいにしつもんした`(に)・`きょうはいいてんき`(は) 等の助詞含むフレーズも全 pass） |

### コーパスケースについて

本修正は **top-1 ではなく mid-list の順位改善**（第二弾 rank 8→4）で、accuracy コーパスは top-1 のみ検証するため end-to-end では捕捉できない。回帰ガードは上記ユニットテストが担う。

## 関連
直前の PR #248（post-history rewriter の boost 継承）と同じ「履歴ブースト」周りの別失敗モード。

🤖 Generated with [Claude Code](https://claude.com/claude-code)