### PR TITLE
chore(deny): ignore RUSTSEC-2026-0186 pending memmap2 quarantine

### DIFF
--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -12,8 +12,8 @@ ignore = [
     { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 is stable, migration planned" },
     # memmap2 0.9.11 fixes this (unsound offset/len in advise_range/flush_range)
     # but is in the 7-day supply-chain quarantine; bump and drop this once it
-    # clears (~2026-06-30). lex-core only mmaps the read-only dict, not the
-    # affected advise/flush paths, so practical exposure is nil.
+    # clears. lex-core only mmaps the read-only dict and does not call the
+    # affected advise/flush paths, so practical exposure is low.
     { id = "RUSTSEC-2026-0186", reason = "memmap2 0.9.11 has the fix but is in 7-day quarantine; bump when it clears. lex-core uses read-only mmap, not the affected advise/flush paths" },
 ]
 

--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -10,6 +10,11 @@ unmaintained = "workspace"
 ignore = [
     # bincode 1.3.3 is unmaintained but stable; migrate to postcard later
     { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 is stable, migration planned" },
+    # memmap2 0.9.11 fixes this (unsound offset/len in advise_range/flush_range)
+    # but is in the 7-day supply-chain quarantine; bump and drop this once it
+    # clears (~2026-06-30). lex-core only mmaps the read-only dict, not the
+    # affected advise/flush paths, so practical exposure is nil.
+    { id = "RUSTSEC-2026-0186", reason = "memmap2 0.9.11 has the fix but is in 7-day quarantine; bump when it clears. lex-core uses read-only mmap, not the affected advise/flush paths" },
 ]
 
 [licenses]


### PR DESCRIPTION
## 背景

`audit` (cargo-deny) が新規 advisory **RUSTSEC-2026-0186**（`memmap2` の unsound: `advise_range`/`flush_range` で offset/len 検証不足）で fail。`memmap2` は lex-core の直接依存（dict mmap 用、現在 0.9.9）。

修正版 **0.9.11 は本日公開**されたばかりで、リポジトリの **7日間 supply-chain 隔離（Quarantine check）** に引っかかり今は採用できない（`published 0 days ago, minimum: 7`）。

## 変更

deny.toml に **reason 付き ignore** を追加（既存の bincode RUSTSEC-2025-0141 と同じ運用）。**memmap2 は 0.9.9 のまま**。隔離が明ける ~2026-06-30 に 0.9.11 へバンプして本 ignore を外す。

## 実リスク

lex-core は dict を **読み取り専用 mmap** するだけで、advisory の対象 `advise_range`/`flush_range` の untrusted offset 経路は使っていない → 実害ほぼなし。

## テスト

- [x] CI (audit 含む) green を確認

## 経緯

当初 0.9.11 バンプ PR (#251) を出したが、7日隔離で audit が通らないため close。本 PR で一時 ignore に切替。進行中の #250（履歴ブースト修正）の audit ブロックもこれで解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)