### PR TITLE
chore: raise MSRV to Rust 1.85

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,7 +14,7 @@ toml = "0.8"
 name = "lex_engine"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.85"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -10,11 +10,14 @@ thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 toml = "0.8"
 
+[workspace.package]
+rust-version = "1.85"
+
 [package]
 name = "lex_engine"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version.workspace = true
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/engine/crates/lex-cli/Cargo.toml
+++ b/engine/crates/lex-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lex-cli"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 name = "lex_cli"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lex-core"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 name = "lex_core"

--- a/engine/crates/lex-session/Cargo.toml
+++ b/engine/crates/lex-session/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lex-session"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 name = "lex_session"


### PR DESCRIPTION
## 背景

deps refresh (#253) で複数の依存が **Rust 1.85+ を要求**することが判明（Codex レビューが検出）:
- indexmap 2.14, ureq 3.3, clap_lex 1.1, zeroize 1.9（いずれも edition 2024 / MSRV 1.85）

workspace は `engine/Cargo.toml` で `rust-version = "1.77"` を宣言していたが、**CI は stable のみ**で MSRV を検証していなかったため、宣言が形骸化し refresh のたびに壁に当たっていた。

## 変更

`rust-version` を **1.77 → 1.85** に更新（実態＝依存エコシステムに合わせる）。自前ビルドの macOS IME なので 1.77〜1.84 サポートを落とす実害は小さい。

## フォローアップ（別 PR）

declare しただけでは再発するので、**CI に MSRV ジョブ（`cargo +1.85 check`）を追加**して実際に enforce する。これは別 PR で対応予定。

## 効果

これで #253（月次 deps refresh ルーチン PR）の MSRV 違反群（indexmap/ureq/clap_lex/zeroize）が解消し、フル refresh が通せるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)