### PR TITLE
feat(cli): add lextool history-audit subcommand

### DIFF
--- a/engine/crates/lex-cli/src/bin/lextool.rs
+++ b/engine/crates/lex-cli/src/bin/lextool.rs
@@ -113,6 +113,26 @@ enum Command {
         top_n: usize,
     },
 
+    /// Audit user history: compare raw engine top-1 against the user's
+    /// dominant committed surface for each learned reading
+    HistoryAudit {
+        /// Path to the compiled dictionary file
+        dict_file: String,
+        /// Path to the compiled connection matrix file
+        conn_file: String,
+        /// Path to the user history checkpoint (.lxud; adjacent WAL is replayed)
+        history_file: String,
+        /// Minimum commit frequency for a reading to be audited
+        #[arg(long, default_value = "2")]
+        min_freq: u32,
+        /// N-best depth used to locate the rank of the dominant choice
+        #[arg(short, long, default_value = "10")]
+        n: usize,
+        /// Output as JSON instead of text
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Compare current output against a saved snapshot
     DiffSnapshot {
         /// Path to the compiled dictionary file
@@ -218,6 +238,40 @@ struct AccuracySummary {
 struct AccuracyReport {
     results: Vec<AccuracyResult>,
     summary: AccuracySummary,
+}
+
+// --- History audit types ---
+
+/// A reading where the raw engine top-1 disagrees with the user's dominant choice.
+#[derive(Debug, Serialize)]
+struct AuditMiss {
+    reading: String,
+    /// The surface the user committed most often for this reading.
+    dominant: String,
+    /// Commit frequency of the dominant surface.
+    frequency: u32,
+    /// Raw (no-history) top-1 conversion.
+    raw_top1: String,
+    /// 1-based rank of the dominant surface in the raw N-best; None = absent.
+    rank: Option<usize>,
+    /// Whether the history-boosted top-1 matches the dominant surface.
+    history_fixed: bool,
+}
+
+/// A reading the user regularly commits with more than one surface.
+#[derive(Debug, Serialize)]
+struct AuditFlipFlop {
+    reading: String,
+    surfaces: Vec<(String, u32)>,
+}
+
+#[derive(Debug, Serialize)]
+struct AuditReport {
+    audited: usize,
+    agree: usize,
+    agree_rate: String,
+    misses: Vec<AuditMiss>,
+    flip_flops: Vec<AuditFlipFlop>,
 }
 
 fn open_resources(
@@ -690,6 +744,120 @@ fn main() {
             }
         }
 
+        Command::HistoryAudit {
+            dict_file,
+            conn_file,
+            history_file,
+            min_freq,
+            n,
+            json,
+        } => {
+            let (dict, conn, _) = open_resources(&dict_file, Some(&conn_file), &None);
+            let conn = conn.expect("connection matrix is required for history-audit");
+
+            let (hist, _wal) = lex_core::user_history::wal::open_with_wal(Path::new(&history_file))
+                .unwrap_or_else(|e| {
+                    eprintln!("Failed to open user history at {}: {}", history_file, e);
+                    process::exit(1);
+                });
+
+            // Group unigrams by reading
+            let mut by_reading: HashMap<&str, Vec<(&str, u32, u64)>> = HashMap::new();
+            for (reading, surface, entry) in hist.unigrams() {
+                by_reading.entry(reading).or_default().push((
+                    surface,
+                    entry.frequency,
+                    entry.last_used,
+                ));
+            }
+
+            let mut misses: Vec<AuditMiss> = Vec::new();
+            let mut flip_flops: Vec<AuditFlipFlop> = Vec::new();
+            let mut audited = 0usize;
+            let mut agree = 0usize;
+
+            for (reading, mut surfaces) in by_reading {
+                surfaces.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+                let (dominant, frequency, _) = surfaces[0];
+                if frequency < min_freq {
+                    continue;
+                }
+                audited += 1;
+
+                let regulars: Vec<(String, u32)> = surfaces
+                    .iter()
+                    .filter(|s| s.1 >= min_freq)
+                    .map(|(s, f, _)| (s.to_string(), *f))
+                    .collect();
+                if regulars.len() >= 2 {
+                    flip_flops.push(AuditFlipFlop {
+                        reading: reading.to_string(),
+                        surfaces: regulars,
+                    });
+                }
+
+                let paths = convert_nbest(&dict, Some(&conn), reading, n);
+                let joined: Vec<String> = paths
+                    .iter()
+                    .map(|segs| segs.iter().map(|s| s.surface.as_str()).collect())
+                    .collect();
+                let raw_top1 = joined.first().cloned().unwrap_or_default();
+                if raw_top1 == dominant {
+                    agree += 1;
+                    continue;
+                }
+
+                let rank = joined.iter().position(|s| s == dominant).map(|i| i + 1);
+                let hist_top1: String =
+                    convert_nbest_with_history(&dict, Some(&conn), &hist, reading, 1)
+                        .first()
+                        .map(|segs| segs.iter().map(|s| s.surface.as_str()).collect())
+                        .unwrap_or_default();
+
+                misses.push(AuditMiss {
+                    reading: reading.to_string(),
+                    dominant: dominant.to_string(),
+                    frequency,
+                    raw_top1,
+                    rank,
+                    history_fixed: hist_top1 == dominant,
+                });
+            }
+
+            misses.sort_by(|a, b| {
+                b.frequency
+                    .cmp(&a.frequency)
+                    .then_with(|| a.reading.cmp(&b.reading))
+            });
+            flip_flops.sort_by(|a, b| {
+                let fa: u32 = a.surfaces.iter().map(|(_, f)| f).sum();
+                let fb: u32 = b.surfaces.iter().map(|(_, f)| f).sum();
+                fb.cmp(&fa).then_with(|| a.reading.cmp(&b.reading))
+            });
+
+            let rate = if audited > 0 {
+                agree as f64 / audited as f64 * 100.0
+            } else {
+                0.0
+            };
+            let report = AuditReport {
+                audited,
+                agree,
+                agree_rate: format!("{:.1}%", rate),
+                misses,
+                flip_flops,
+            };
+
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report).expect("JSON serialization failed")
+                );
+            } else {
+                print_audit_text(&report, min_freq, n);
+            }
+        }
+
         Command::DiffSnapshot {
             dict_file,
             conn_file,
@@ -791,6 +959,60 @@ fn main() {
             }
         }
     }
+}
+
+fn print_audit_text(report: &AuditReport, min_freq: u32, n: usize) {
+    if !report.misses.is_empty() {
+        println!();
+        println!("=== Misses (raw top-1 != your dominant choice) ===");
+        for m in &report.misses {
+            let rank = match m.rank {
+                Some(r) => format!("rank {}", r),
+                None => format!("not in top-{}", n),
+            };
+            let hist = if m.history_fixed {
+                "history: fixed"
+            } else {
+                "history: NOT fixed"
+            };
+            println!(
+                "  \u{2717} {}: you={} \u{00d7}{}, engine={} ({}, {})",
+                m.reading, m.dominant, m.frequency, m.raw_top1, rank, hist
+            );
+        }
+    }
+
+    if !report.flip_flops.is_empty() {
+        println!();
+        println!("=== Flip-flops (multiple surfaces in regular use) ===");
+        for f in &report.flip_flops {
+            let surfaces: Vec<String> = f
+                .surfaces
+                .iter()
+                .map(|(s, freq)| format!("{} \u{00d7}{}", s, freq))
+                .collect();
+            println!("  ~ {}: {}", f.reading, surfaces.join(" / "));
+        }
+    }
+
+    let history_fixed = report.misses.iter().filter(|m| m.history_fixed).count();
+    println!();
+    println!("=== Summary ===");
+    println!(
+        "  Readings audited: {} (dominant freq >= {})",
+        report.audited, min_freq
+    );
+    println!(
+        "  Raw top-1 agreement: {} ({}/{})",
+        report.agree_rate, report.agree, report.audited
+    );
+    println!(
+        "  Misses: {} (history fixes {}, leaves {})",
+        report.misses.len(),
+        history_fixed,
+        report.misses.len() - history_fixed
+    );
+    println!("  Flip-flops: {}", report.flip_flops.len());
 }
 
 fn print_tune_text(result: &tune::TuneResult) {

--- a/engine/crates/lex-cli/src/bin/lextool.rs
+++ b/engine/crates/lex-cli/src/bin/lextool.rs
@@ -755,7 +755,20 @@ fn main() {
             let (dict, conn, _) = open_resources(&dict_file, Some(&conn_file), &None);
             let conn = conn.expect("connection matrix is required for history-audit");
 
-            let (hist, _wal) = lex_core::user_history::wal::open_with_wal(Path::new(&history_file))
+            // open_with_wal silently returns an empty history for a missing
+            // checkpoint; a mistyped path must fail instead of reporting a
+            // plausible-looking zero-reading audit.
+            let checkpoint_path = Path::new(&history_file);
+            let wal_path = checkpoint_path.with_extension("lxud.wal");
+            if !checkpoint_path.exists() && !wal_path.exists() {
+                eprintln!(
+                    "User history not found: neither {} nor {} exists",
+                    checkpoint_path.display(),
+                    wal_path.display()
+                );
+                process::exit(1);
+            }
+            let (hist, _wal) = lex_core::user_history::wal::open_with_wal(checkpoint_path)
                 .unwrap_or_else(|e| {
                     eprintln!("Failed to open user history at {}: {}", history_file, e);
                     process::exit(1);
@@ -777,7 +790,10 @@ fn main() {
             let mut agree = 0usize;
 
             for (reading, mut surfaces) in by_reading {
-                surfaces.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+                // Tie-break by surface text: frequency and last_used can both
+                // collide (records in one batch share the same second), and
+                // HashMap order would make the dominant pick non-deterministic.
+                surfaces.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)).then(a.0.cmp(b.0)));
                 let (dominant, frequency, _) = surfaces[0];
                 if frequency < min_freq {
                     continue;
@@ -807,7 +823,14 @@ fn main() {
                     continue;
                 }
 
-                let rank = joined.iter().position(|s| s == dominant).map(|i| i + 1);
+                // Post-Viterbi rewriters can append candidates beyond the
+                // requested depth, so paths may exceed n; scan only the first
+                // n to keep "rank" and "not in top-n" semantics uniform.
+                let rank = joined
+                    .iter()
+                    .take(n)
+                    .position(|s| s == dominant)
+                    .map(|i| i + 1);
                 let hist_top1: String =
                     convert_nbest_with_history(&dict, Some(&conn), &hist, reading, 1)
                         .first()

--- a/engine/crates/lex-core/src/user_history/mod.rs
+++ b/engine/crates/lex-core/src/user_history/mod.rs
@@ -224,6 +224,16 @@ impl UserHistory {
         results
     }
 
+    /// Iterate all unigram records as (reading, surface, entry).
+    /// Used by offline tooling (`lextool history-audit`) to mine the history.
+    pub fn unigrams(&self) -> impl Iterator<Item = (&str, &str, &HistoryEntry)> {
+        self.unigrams.iter().flat_map(|(reading, inner)| {
+            inner
+                .iter()
+                .map(move |(surface, entry)| (reading.as_str(), surface.as_str(), entry))
+        })
+    }
+
     /// Reorder dictionary candidates so learned entries appear first.
     pub fn reorder_candidates(&self, reading: &str, entries: &[DictEntry]) -> Vec<DictEntry> {
         let now = now_epoch();

--- a/engine/crates/lex-core/src/user_history/tests.rs
+++ b/engine/crates/lex-core/src/user_history/tests.rs
@@ -30,6 +30,27 @@ fn test_frequency_increment() {
 }
 
 #[test]
+fn test_unigrams_iterator() {
+    let mut h = UserHistory::new();
+    h.record(&[("きょう".into(), "今日".into())]);
+    h.record(&[("きょう".into(), "今日".into())]);
+    h.record(&[("きょう".into(), "京".into())]);
+
+    let mut records: Vec<(String, String, u32)> = h
+        .unigrams()
+        .map(|(r, s, e)| (r.to_string(), s.to_string(), e.frequency))
+        .collect();
+    records.sort();
+    assert_eq!(
+        records,
+        vec![
+            ("きょう".to_string(), "京".to_string(), 1),
+            ("きょう".to_string(), "今日".to_string(), 2),
+        ]
+    );
+}
+
+#[test]
 fn test_serialize_roundtrip() {
     let mut h = UserHistory::new();
     h.record(&[("きょう".into(), "今日".into()), ("は".into(), "は".into())]);

--- a/mise.toml
+++ b/mise.toml
@@ -302,6 +302,15 @@ cd engine && cargo run --release -p lex-cli --bin lextool -- diff-snapshot \
   testcorpus/snapshot-readings.txt data/snapshot.jsonl -n 5
 """
 
+[tasks.history-audit]
+description = "Audit user history against raw engine top-1"
+depends = ["dict", "conn"]
+run = """
+cd engine && cargo run --release -p lex-cli --bin lextool -- history-audit \
+  data/lexime.dict data/lexime.conn \
+  "$HOME/Library/Application Support/Lexime/user_history.lxud" "$@"
+"""
+
 [tasks.trace-log]
 description = "Stream trace JSONL output"
 run = "tail -f ~/Library/Logs/Lexime/lexime-trace.jsonl | python3 -m json.tool --no-ensure-ascii"


### PR DESCRIPTION
## Summary

変換品質改善のデータ駆動化・第一弾。ユーザーの学習履歴 (checkpoint + WAL) をマイニングして、「素のエンジン top-1」と「ユーザーが実際に最も多く確定してきた surface」を突合する `lextool history-audit` を追加する。

- **lex-core**: `UserHistory` に public な `unigrams()` イテレータを追加（オフラインツール用の読み取り口）
- **lextool**: 新サブコマンド `history-audit`
  - 各ミスに raw N-best 内の rank を付与（**ランキング問題** vs **候補欠落**の切り分け）
  - 履歴ブースト適用後 top-1 で直っているかを判定（`history: fixed / NOT fixed`）
  - 同一読みで複数 surface を常用している flip-flop を別リストで報告
  - text / `--json` 出力
- **mise**: `mise run history-audit`（実機の履歴パスがデフォルト）

読み取り専用で、履歴ファイルへの書き込みは行わない。

## 実データでの実行結果（集計のみ）

```
Readings audited: 3971 (dominant freq >= 2)
Raw top-1 agreement: 82.3% (3268/3971)
Misses: 703 (history fixes 623, leaves 80)
Flip-flops: 162
```

履歴ブーストでも直っていない 80 件が今後の改善候補の一次ソースになる（内訳の傾向: 補助表現のかな好みに対する過剰漢字化、カタカナ語ペナルティ過剰、分節崩れ）。個別内容は入力履歴由来のため PR には貼らない。

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-features -- -D warnings` pass
- [x] `cargo test --workspace --all-features` pass（`unigrams()` イテレータのテスト追加含む）
- [x] 実機の `user_history.lxud` (1.1MB + WAL 47KB) に対して `mise run history-audit` を実行し、text / JSON 両出力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)