### PR TITLE
fix(ci): run swift job on any layer change, not only rust+swift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,9 @@ jobs:
   swift:
     needs: changes
     if: >-
-      (needs.changes.outputs.core == 'true' || needs.changes.outputs.session == 'true' || needs.changes.outputs.ffi == 'true') &&
+      needs.changes.outputs.core == 'true' ||
+      needs.changes.outputs.session == 'true' ||
+      needs.changes.outputs.ffi == 'true' ||
       needs.changes.outputs.swift == 'true'
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
## Summary

2026-07-02 の全体アーキテクチャレビューで検出した CI ゲートのバグ修正。

swift ジョブの実行条件が `(core || session || ffi) && swift` の **AND** になっていたため:

- **純 Swift-only の PR** (Sources/Tests のみ変更) で Swift テストが一切走らない
- **エンジンのみの PR** でも UniFFI round-trip テストが走らない

の両方が起きていました。ジョブの実際の依存グラフは「FFI 表面か Swift ソースに影響し得る変更すべて」なので、4 フィルタの OR に修正します。

トレードオフ: エンジンのみの変更でも macOS ランナーが走るようになりますが、FFI round-trip テスト (TestRomajiFFI / TestDictFFI / TestSessionFFI) はまさにエンジン側の regression を捕まえるためのものなので意図に合致します。

## Test plan

- [x] `ruby -ryaml` で YAML 構文検証
- [x] 条件ロジックの机上確認 (swift-only → 走る / engine-only → 走る / 無関係変更 → 走らない)
- [ ] この PR 自体は ci.yml 変更なので core フィルタに該当し、全ジョブが走ることを PR チェックで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)