### PR TITLE
fix(engine): avoid self-join panic in AsyncWorker::drop

### DIFF
--- a/engine/src/async_worker.rs
+++ b/engine/src/async_worker.rs
@@ -121,7 +121,13 @@ impl Drop for AsyncWorker {
         let mut inner = self.inner.lock().unwrap();
         inner.tx.take();
         if let Some(handle) = inner.thread_handle.take() {
-            let _ = handle.join();
+            // The last strong Arc<LexSession> can be dropped on the worker
+            // thread itself: deliver() upgrades the Weak while Swift releases
+            // its handle concurrently. Joining our own thread would deadlock
+            // (pthread_join EDEADLK panic), so let it exit on its own instead.
+            if handle.thread().id() != std::thread::current().id() {
+                let _ = handle.join();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

2026-07-02 の全体アーキテクチャレビューで検出した堅牢性修正。

worker スレッドが `deliver()` 中に `Weak::upgrade` で strong 参照を持っている間に Swift 側が最後の参照を離すと、`LexSession` の drop が **worker スレッド上で** 走り、`AsyncWorker::drop` が自分自身のスレッドを `join()` して EDEADLK panic になります。

現状は「Swift が release 前に必ず `shutdown()` を呼ぶ」という規約 (`SessionCoordinator.deinit`) だけで守られていました (doc コメント自身がこの依存を認めています)。drop 時にスレッド ID を比較し、自スレッドなら join をスキップします。sender は既に take 済みなので worker は自然に exit します。

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p lex_engine --features trace -- -D warnings`
- [x] `cargo test -p lex_engine --features trace` (11 passed、既存の deadlock regression テスト含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)