### PR TITLE
fix(cli): pin mozc fetch to a single upstream commit via version stamp

### DIFF
--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -7,10 +7,8 @@ use super::{
 };
 use lex_core::dict::DictEntry;
 
-const MOZC_CONTENTS_URL: &str =
-    "https://api.github.com/repos/google/mozc/contents/src/data/dictionary_oss";
-const MOZC_LICENSE_URL: &str = "https://raw.githubusercontent.com/google/mozc/master/LICENSE";
-const MOZC_CONNECTION_URL: &str = "https://raw.githubusercontent.com/google/mozc/master/src/data/dictionary_oss/connection_single_column.txt";
+const MOZC_API_BASE: &str = "https://api.github.com/repos/google/mozc";
+const MOZC_RAW_BASE: &str = "https://raw.githubusercontent.com/google/mozc";
 
 /// Mozc TSV dictionary source.
 ///
@@ -30,10 +28,26 @@ impl MozcSource {
         Ok(())
     }
 
-    /// List dictionary files via GitHub Contents API and return (name, download_url) pairs
-    /// for `dictionary*.txt` and `id.def`.
-    fn list_remote_files() -> Result<Vec<(String, String)>, DictSourceError> {
-        let body = ureq::get(MOZC_CONTENTS_URL)
+    /// Resolve the latest commit SHA of `master` via the GitHub Commits API.
+    /// All raw-file downloads in a fetch run are pinned to this single SHA so
+    /// the cached snapshot can never mix files from two upstream states.
+    fn latest_commit_sha() -> Result<String, DictSourceError> {
+        let url = format!("{MOZC_API_BASE}/commits/master");
+        let body = ureq::get(&url)
+            .call()
+            .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?
+            .into_body()
+            .read_to_string()
+            .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?;
+        parse_commit_sha(&body)
+    }
+
+    /// List dictionary files via GitHub Contents API **pinned to `sha`** and
+    /// return (name, download_url) pairs for `dictionary*.txt` and `id.def`.
+    /// The returned `download_url`s point at the same pinned SHA.
+    fn list_remote_files(sha: &str) -> Result<Vec<(String, String)>, DictSourceError> {
+        let url = format!("{MOZC_API_BASE}/contents/src/data/dictionary_oss?ref={sha}");
+        let body = ureq::get(&url)
             .call()
             .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?
             .into_body()
@@ -41,6 +55,62 @@ impl MozcSource {
             .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?;
         parse_remote_files(&body)
     }
+}
+
+/// Extract and validate the commit SHA from a GitHub Commits API response.
+fn parse_commit_sha(json: &str) -> Result<String, DictSourceError> {
+    let v: serde_json::Value = serde_json::from_str(json)
+        .map_err(|e| DictSourceError::Parse(format!("GitHub commit JSON: {e}")))?;
+    let sha = v["sha"]
+        .as_str()
+        .ok_or_else(|| DictSourceError::Parse("GitHub commit JSON: missing sha".to_string()))?;
+    // A full commit SHA is 40 hex chars; reject anything else so a malformed
+    // response can't end up embedded in raw URLs or the stamp file.
+    if sha.len() != 40 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(DictSourceError::Parse(format!(
+            "GitHub commit JSON: invalid sha {sha:?}"
+        )));
+    }
+    Ok(sha.to_string())
+}
+
+/// Read the version stamp. Missing / empty / whitespace-only stamps (including
+/// the legacy pre-versioning empty `.stamp`) all count as "no version".
+fn read_stamp(path: &Path) -> Option<String> {
+    fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// True if `name` is one of the files this source fetches into the cache dir.
+fn is_fetched_file(name: &str) -> bool {
+    (name.starts_with("dictionary") && name.ends_with(".txt"))
+        || name == "id.def"
+        || name == "connection_single_column.txt"
+        || name == "LICENSE"
+}
+
+/// True if any previously fetched file exists in `dest`.
+fn any_fetched_file_exists(dest: &Path) -> bool {
+    fs::read_dir(dest)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .any(|e| is_fetched_file(&e.file_name().to_string_lossy()))
+        })
+        .unwrap_or(false)
+}
+
+/// Remove all fetched files plus the stamp so a re-download starts clean.
+fn wipe_cache(dest: &Path, stamp_path: &Path) {
+    if let Ok(rd) = fs::read_dir(dest) {
+        for entry in rd.filter_map(|e| e.ok()) {
+            if is_fetched_file(&entry.file_name().to_string_lossy()) {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
+    }
+    let _ = fs::remove_file(stamp_path);
 }
 
 /// Parse GitHub Contents API JSON and return (name, download_url) pairs
@@ -100,12 +170,62 @@ impl DictSource for MozcSource {
         )
     }
 
+    /// Fetch the Mozc dictionary snapshot into `dest`. Same cache discipline
+    /// as the SudachiDict fetcher (`candidates/sudachi.rs`, PR #242): **the
+    /// stamp file must equal the resolved upstream version exactly**, here
+    /// the latest commit SHA of `google/mozc` master. Anything else (stamp
+    /// missing, legacy empty stamp, mismatched SHA — with or without leftover
+    /// files) triggers a clean wipe + full re-download.
+    ///
+    /// Crucially, every download in a run is pinned to that one SHA via
+    /// `raw.githubusercontent.com/google/mozc/<sha>/...`, so `id.def` and
+    /// `dictionary*.txt` can never come from two different upstream states —
+    /// neither across runs (stale per-file cache) nor within a run (upstream
+    /// moving while we fetch). A skew there silently shifts POS ids and
+    /// corrupts conversion quality without any visible error.
+    ///
+    /// Within a still-valid cache (stamp == latest SHA), individual missing
+    /// files are re-downloaded from that same SHA, so an interrupted run
+    /// recovers without re-fetching everything.
+    ///
+    /// Offline behavior: if the SHA can't be resolved but a complete cached
+    /// snapshot exists (non-empty stamp — only written after a fully
+    /// successful fetch), warn and keep using it; otherwise fail.
     fn fetch(&self, dest: &Path) -> Result<(), DictSourceError> {
         fs::create_dir_all(dest).map_err(DictSourceError::Io)?;
+        let stamp_path = dest.join(".stamp");
+        let cached = read_stamp(&stamp_path);
 
-        eprintln!("Downloading Mozc dictionary files to {}...", dest.display());
+        let sha = match Self::latest_commit_sha() {
+            Ok(sha) => sha,
+            Err(e) => {
+                if let Some(v) = &cached {
+                    eprintln!(
+                        "Warning: could not resolve latest mozc commit ({e}); \
+                         using cached snapshot {v}."
+                    );
+                    return Ok(());
+                }
+                return Err(e);
+            }
+        };
 
-        let remote_files = Self::list_remote_files()?;
+        let cache_valid = cached.as_deref() == Some(sha.as_str());
+        if !cache_valid {
+            if let Some(v) = &cached {
+                eprintln!("Cache commit {v} != latest {sha}; wiping stale files.");
+            } else if any_fetched_file_exists(dest) {
+                eprintln!("Cache has no version stamp but files present; wiping.");
+            }
+            wipe_cache(dest, &stamp_path);
+        }
+
+        eprintln!(
+            "Downloading Mozc dictionary files (commit {sha}) to {}...",
+            dest.display()
+        );
+
+        let remote_files = Self::list_remote_files(&sha)?;
         for (name, url) in &remote_files {
             let file_path = dest.join(name);
             if file_path.exists() {
@@ -122,7 +242,10 @@ impl DictSource for MozcSource {
             eprintln!("  connection_single_column.txt (already exists, skipping)");
         } else {
             eprintln!("  connection_single_column.txt");
-            Self::download_file(MOZC_CONNECTION_URL, &connection)?;
+            let url = format!(
+                "{MOZC_RAW_BASE}/{sha}/src/data/dictionary_oss/connection_single_column.txt"
+            );
+            Self::download_file(&url, &connection)?;
         }
 
         // Download LICENSE
@@ -131,11 +254,12 @@ impl DictSource for MozcSource {
             eprintln!("  LICENSE (already exists, skipping)");
         } else {
             eprintln!("  LICENSE");
-            Self::download_file(MOZC_LICENSE_URL, &license)?;
+            let url = format!("{MOZC_RAW_BASE}/{sha}/LICENSE");
+            Self::download_file(&url, &license)?;
         }
 
-        // Create stamp file
-        fs::write(dest.join(".stamp"), "").map_err(DictSourceError::Io)?;
+        // Record the snapshot version only after every file landed.
+        fs::write(&stamp_path, &sha).map_err(DictSourceError::Io)?;
         eprintln!("Done. Files saved to {}", dest.display());
         Ok(())
     }
@@ -230,5 +354,132 @@ mod tests {
         let files = parse_remote_files(json).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].0, "dictionary00.txt");
+    }
+
+    #[test]
+    fn test_parse_commit_sha() {
+        let sha = "0123456789abcdef0123456789abcdef01234567";
+        let json = format!(r#"{{"sha": "{sha}", "commit": {{}}}}"#);
+        assert_eq!(parse_commit_sha(&json).unwrap(), sha);
+    }
+
+    #[test]
+    fn test_parse_commit_sha_rejects_malformed() {
+        // Missing sha field
+        assert!(parse_commit_sha(r#"{"commit": {}}"#).is_err());
+        // Not JSON
+        assert!(parse_commit_sha("not json").is_err());
+        // Wrong length
+        assert!(parse_commit_sha(r#"{"sha": "abc123"}"#).is_err());
+        // Right length but non-hex (could smuggle path segments into raw URLs)
+        assert!(
+            parse_commit_sha(r#"{"sha": "0123456789abcdef0123456789abcdef0123456z"}"#).is_err()
+        );
+    }
+
+    #[test]
+    fn test_read_stamp_roundtrip() {
+        let dir = std::env::temp_dir().join("lexime_test_mozc_stamp");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let stamp = dir.join(".stamp");
+
+        // Missing → None
+        assert!(read_stamp(&stamp).is_none());
+
+        // Legacy empty stamp (pre-versioning marker) → None, so it triggers
+        // a wipe + re-download instead of being trusted as current.
+        fs::write(&stamp, "").unwrap();
+        assert!(read_stamp(&stamp).is_none());
+
+        // Whitespace-only → None
+        fs::write(&stamp, "  \n").unwrap();
+        assert!(read_stamp(&stamp).is_none());
+
+        // Trim trailing newline
+        fs::write(&stamp, "0123456789abcdef0123456789abcdef01234567\n").unwrap();
+        assert_eq!(
+            read_stamp(&stamp).as_deref(),
+            Some("0123456789abcdef0123456789abcdef01234567")
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Pins the cache_valid predicate that drives wipe decisions — the mozc
+    /// counterpart of `candidates/sudachi.rs::test_stale_cache_invariant`
+    /// (PR #242). Covers SHA mismatch, missing stamp, and the legacy empty
+    /// stamp left behind by the pre-versioning fetch. Network path is
+    /// exercised by manual `dictool fetch --source mozc` runs.
+    #[test]
+    fn test_stale_cache_invariant() {
+        fn should_wipe(dest: &Path, latest: &str) -> bool {
+            let cached = read_stamp(&dest.join(".stamp"));
+            cached.as_deref() != Some(latest)
+        }
+
+        let dir = std::env::temp_dir().join("lexime_test_mozc_invariant");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let latest = "0123456789abcdef0123456789abcdef01234567";
+        let older = "fedcba9876543210fedcba9876543210fedcba98";
+
+        // Case 1: stamp matches latest SHA → no wipe.
+        fs::write(dir.join(".stamp"), latest).unwrap();
+        assert!(!should_wipe(&dir, latest));
+
+        // Case 2: stamp records an older SHA → wipe.
+        fs::write(dir.join(".stamp"), older).unwrap();
+        assert!(should_wipe(&dir, latest));
+
+        // Case 3: stamp missing entirely → wipe.
+        fs::remove_file(dir.join(".stamp")).unwrap();
+        assert!(should_wipe(&dir, latest));
+
+        // Case 4: legacy empty stamp → wipe.
+        fs::write(dir.join(".stamp"), "").unwrap();
+        assert!(should_wipe(&dir, latest));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A SHA mismatch must remove every fetched artifact — leaving id.def from
+    /// snapshot A next to dictionary*.txt from snapshot B silently shifts POS
+    /// ids and corrupts conversion quality.
+    #[test]
+    fn test_wipe_cache_removes_all_fetched_files() {
+        let dir = std::env::temp_dir().join("lexime_test_mozc_wipe");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let fetched = [
+            "dictionary00.txt",
+            "dictionary09.txt",
+            "id.def",
+            "connection_single_column.txt",
+            "LICENSE",
+        ];
+        for name in fetched {
+            fs::write(dir.join(name), "stale").unwrap();
+        }
+        fs::write(
+            dir.join(".stamp"),
+            "fedcba9876543210fedcba9876543210fedcba98",
+        )
+        .unwrap();
+        // A user-placed file must survive the wipe.
+        fs::write(dir.join("notes.md"), "keep me").unwrap();
+
+        assert!(any_fetched_file_exists(&dir));
+        wipe_cache(&dir, &dir.join(".stamp"));
+
+        for name in fetched {
+            assert!(!dir.join(name).exists(), "{name} should have been wiped");
+        }
+        assert!(!dir.join(".stamp").exists());
+        assert!(dir.join("notes.md").exists());
+        assert!(!any_fetched_file_exists(&dir));
+
+        fs::remove_dir_all(&dir).ok();
     }
 }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -403,6 +403,22 @@ fn parse_remote_files(json: &str) -> Result<Vec<(String, String)>, DictSourceErr
         }
     }
     files.sort();
+    // The listing must contain everything downstream needs — id.def and at
+    // least one numbered shard. Without this gate, a restructured upstream
+    // directory would fetch "successfully", write a manifest stamp, and leave
+    // an unusable cache that cache_complete / the offline fallback then treat
+    // as complete. Both the repair and staging paths share this chokepoint.
+    if !files.iter().any(|(n, _)| n == "id.def") {
+        return Err(DictSourceError::Parse(
+            "GitHub listing has no id.def — upstream layout changed?".to_string(),
+        ));
+    }
+    if !files.iter().any(|(n, _)| is_numbered_dictionary(n)) {
+        return Err(DictSourceError::Parse(
+            "GitHub listing has no dictionary<digits>.txt shards — upstream layout changed?"
+                .to_string(),
+        ));
+    }
     Ok(files)
 }
 
@@ -672,23 +688,43 @@ mod tests {
         let json = r#"[
             {"name": "dictionary_extra.txt", "download_url": "https://example.com/a"},
             {"name": "dictionary-custom.txt", "download_url": "https://example.com/b"},
-            {"name": "dictionary00.txt", "download_url": "https://example.com/c"}
+            {"name": "dictionary00.txt", "download_url": "https://example.com/c"},
+            {"name": "id.def", "download_url": "https://example.com/d"}
         ]"#;
         let files = parse_remote_files(json).unwrap();
-        assert_eq!(files.len(), 1);
+        assert_eq!(files.len(), 2);
         assert_eq!(files[0].0, "dictionary00.txt");
+        assert_eq!(files[1].0, "id.def");
         for (name, _) in &files {
             assert!(is_upstream_file_name(name));
         }
     }
 
     #[test]
+    fn test_parse_remote_files_requires_core_artifacts() {
+        // A listing without id.def (or without any numbered shard) must fail
+        // loudly instead of producing a "successful" fetch whose stamp vouches
+        // for an unusable cache (Copilot review R9 on PR #266).
+        let no_id_def = r#"[
+            {"name": "dictionary00.txt", "download_url": "https://example.com/a"}
+        ]"#;
+        assert!(parse_remote_files(no_id_def).is_err());
+
+        let no_shards = r#"[
+            {"name": "id.def", "download_url": "https://example.com/a"},
+            {"name": "dictionary-custom.txt", "download_url": "https://example.com/b"}
+        ]"#;
+        assert!(parse_remote_files(no_shards).is_err());
+    }
+
+    #[test]
     fn test_parse_remote_files_sanitizes_path() {
         let json = r#"[
-            {"name": "../../../etc/dictionary00.txt", "download_url": "https://example.com/x"}
+            {"name": "../../../etc/dictionary00.txt", "download_url": "https://example.com/x"},
+            {"name": "id.def", "download_url": "https://example.com/id.def"}
         ]"#;
         let files = parse_remote_files(json).unwrap();
-        assert_eq!(files.len(), 1);
+        assert_eq!(files.len(), 2);
         assert_eq!(files[0].0, "dictionary00.txt");
     }
 

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -230,7 +230,11 @@ fn write_stamp(path: &Path, sha: &str, manifest: &[String]) -> Result<(), DictSo
     // tmp + rename: an interrupted write must not leave a truncated stamp
     // whose valid SHA line + partial manifest would satisfy cache_complete
     // and mask an incomplete snapshot.
-    let tmp = path.with_extension("stamp.tmp");
+    // Not with_extension(): for a dotfile like `.stamp` that has no extension,
+    // with_extension would yield `.stamp.stamp.tmp`. Append to the name instead.
+    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(".tmp");
+    let tmp = path.with_file_name(tmp_name);
     fs::write(&tmp, contents).map_err(DictSourceError::Io)?;
     fs::rename(&tmp, path).map_err(DictSourceError::Io)
 }
@@ -255,7 +259,12 @@ fn parse_remote_files(json: &str) -> Result<Vec<(String, String)>, DictSourceErr
             .file_name()
             .unwrap_or_default()
             .to_string_lossy();
-        let wanted = (name.starts_with("dictionary") && name.ends_with(".txt")) || name == "id.def";
+        // Invariant: everything fetch downloads must pass is_upstream_file_name,
+        // because the manifest read-filter (read_stamp) and wipe_cache only
+        // recognize those names. A broader match here (e.g. plain
+        // `dictionary*.txt`) would download files the wipe never removes,
+        // re-introducing cross-snapshot mixing on the next version bump.
+        let wanted = is_numbered_dictionary(&name) || name == "id.def";
         if wanted {
             files.push((name.into_owned(), url.to_string()));
         }
@@ -526,6 +535,24 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_remote_files_only_recognized_names() {
+        // Invariant: fetched ⊆ recognized (is_upstream_file_name). A file the
+        // wipe/manifest layer doesn't recognize must not be downloaded, or it
+        // would survive version bumps and mix into the next snapshot.
+        let json = r#"[
+            {"name": "dictionary_extra.txt", "download_url": "https://example.com/a"},
+            {"name": "dictionary-custom.txt", "download_url": "https://example.com/b"},
+            {"name": "dictionary00.txt", "download_url": "https://example.com/c"}
+        ]"#;
+        let files = parse_remote_files(json).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].0, "dictionary00.txt");
+        for (name, _) in &files {
+            assert!(is_upstream_file_name(name));
+        }
+    }
+
+    #[test]
     fn test_parse_remote_files_sanitizes_path() {
         let json = r#"[
             {"name": "../../../etc/dictionary00.txt", "download_url": "https://example.com/x"}
@@ -631,6 +658,25 @@ mod tests {
              dictionary-custom.txt\nnotes.md\ndictionary00.txt\n",
         )
         .unwrap();
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.manifest, vec!["dictionary00.txt"]);
+
+        // write_stamp uses tmp+rename with a proper `.stamp.tmp` sibling —
+        // for a dotfile, with_extension would have produced `.stamp.stamp.tmp`
+        // (Copilot review on PR #266). No tmp residue after a write.
+        write_stamp(
+            &stamp,
+            "0123456789abcdef0123456789abcdef01234567",
+            &["dictionary00.txt".to_string()],
+        )
+        .unwrap();
+        let residue: Vec<String> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(residue.is_empty(), "tmp residue left behind: {residue:?}");
         let st = read_stamp(&stamp).unwrap();
         assert_eq!(st.manifest, vec!["dictionary00.txt"]);
 

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io;
 use std::path::Path;
 
 use super::{
@@ -93,10 +94,11 @@ struct Stamp {
 /// Read the version stamp. Only a stamp whose first line is a well-formed
 /// commit SHA counts: missing / empty / legacy pre-versioning empty `.stamp` /
 /// corrupted or hand-edited contents all return `None`, which the caller
-/// treats as "no version" (wipe + full re-download). Manifest entries are
-/// restricted to plain file names — anything containing a path separator or
-/// `..` is dropped so a tampered stamp cannot direct the wipe outside the
-/// cache dir.
+/// treats as "no version" (wipe + full re-download). Manifest entries must
+/// pass `is_upstream_file_name`; anything else (path traversal attempts, or a
+/// hand-edited entry naming a user file like `dictionary-custom.txt`) is
+/// dropped so a tampered stamp can neither direct the wipe outside the cache
+/// dir nor at files this source never fetched.
 fn read_stamp(path: &Path) -> Option<Stamp> {
     let content = fs::read_to_string(path).ok()?;
     let mut lines = content.lines();
@@ -106,7 +108,7 @@ fn read_stamp(path: &Path) -> Option<Stamp> {
     }
     let manifest = lines
         .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.contains('/') && !l.contains('\\') && *l != "..")
+        .filter(|l| is_upstream_file_name(l))
         .map(str::to_string)
         .collect();
     Some(Stamp {
@@ -115,34 +117,48 @@ fn read_stamp(path: &Path) -> Option<Stamp> {
     })
 }
 
+/// True if `name` is an upstream dictionary shard: `dictionary<digits>.txt`.
+/// Deliberately narrower than the `dictionary*.txt` glob that `parse_dir`
+/// accepts, so a user-placed `dictionary-custom.txt` is never mistaken for a
+/// fetched artifact (Codex review on PR #266).
+fn is_numbered_dictionary(name: &str) -> bool {
+    name.strip_prefix("dictionary")
+        .and_then(|rest| rest.strip_suffix(".txt"))
+        .is_some_and(|mid| !mid.is_empty() && mid.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// True if `name` matches the exact upstream naming of the files this source
 /// fetches: `dictionary<digits>.txt`, `id.def`, `connection_single_column.txt`
-/// or `LICENSE`. Deliberately narrower than the `dictionary*.txt` glob that
-/// `parse_dir` accepts, so a user-placed `dictionary-custom.txt` is never
-/// mistaken for a fetched artifact (Codex review on PR #266).
+/// or `LICENSE`.
 fn is_upstream_file_name(name: &str) -> bool {
-    let is_numbered_dictionary = name
-        .strip_prefix("dictionary")
-        .and_then(|rest| rest.strip_suffix(".txt"))
-        .is_some_and(|mid| !mid.is_empty() && mid.bytes().all(|b| b.is_ascii_digit()));
-    is_numbered_dictionary
+    is_numbered_dictionary(name)
         || name == "id.def"
         || name == "connection_single_column.txt"
         || name == "LICENSE"
 }
 
+/// True if the cached snapshot vouched for by `stamp` is fully on disk.
+/// Only a manifest-carrying stamp can prove completeness (every recorded
+/// file must exist); a legacy SHA-only stamp cannot, so it returns false
+/// and the caller falls back to weaker heuristics or a re-download.
+fn cache_complete(stamp: &Stamp, dest: &Path) -> bool {
+    !stamp.manifest.is_empty() && stamp.manifest.iter().all(|f| dest.join(f).exists())
+}
+
 /// True if the files required by downstream consumers are all present:
-/// `id.def`, `connection_single_column.txt`, and at least one
-/// `dictionary*.txt`. Used by the offline fallback — a stamp alone is not
-/// enough evidence if the artifacts themselves have since been deleted.
+/// `id.def`, `connection_single_column.txt`, and at least one upstream
+/// dictionary shard (`dictionary<digits>.txt` — a user-placed
+/// `dictionary-custom.txt` does not count). Offline-fallback heuristic for
+/// legacy SHA-only stamps, which record no manifest: it cannot detect a
+/// partially deleted shard set (e.g. `dictionary01.txt` missing while
+/// `dictionary00.txt` survives). This weakness is transitional — the first
+/// online fetch rewrites the stamp with a manifest, after which
+/// `cache_complete` gives an exact answer.
 fn required_files_present(dest: &Path) -> bool {
     let any_dictionary = fs::read_dir(dest)
         .map(|rd| {
-            rd.filter_map(|e| e.ok()).any(|e| {
-                let n = e.file_name();
-                let s = n.to_string_lossy();
-                s.starts_with("dictionary") && s.ends_with(".txt")
-            })
+            rd.filter_map(|e| e.ok())
+                .any(|e| is_numbered_dictionary(&e.file_name().to_string_lossy()))
         })
         .unwrap_or(false);
     any_dictionary
@@ -160,26 +176,54 @@ fn any_fetched_file_exists(dest: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Remove `path` treating "already gone" as success. Any other failure is
+/// propagated — see `wipe_cache`.
+fn remove_if_exists(path: &Path) -> Result<(), DictSourceError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(DictSourceError::Io(io::Error::new(
+            e.kind(),
+            format!("failed to remove stale {}: {e}", path.display()),
+        ))),
+    }
+}
+
 /// Remove fetched files plus the stamp so a re-download starts clean.
 /// Deletes exactly the files recorded in the stamp's manifest when one is
 /// available; without a manifest (legacy SHA-only stamp, no stamp at all)
 /// it falls back to the exact upstream naming pattern. Either way,
 /// user-placed files like `dictionary-custom.txt` survive.
-fn wipe_cache(dest: &Path, stamp_path: &Path, manifest: &[String]) {
+///
+/// Removal failures are errors, not warnings: a stale file that survives the
+/// wipe would sit next to freshly downloaded files from a different upstream
+/// snapshot — exactly the id.def / dictionary*.txt mix this module exists to
+/// prevent. The caller must abort the fetch (Codex review on PR #266).
+fn wipe_cache(dest: &Path, stamp_path: &Path, manifest: &[String]) -> Result<(), DictSourceError> {
     if manifest.is_empty() {
         if let Ok(rd) = fs::read_dir(dest) {
             for entry in rd.filter_map(|e| e.ok()) {
                 if is_upstream_file_name(&entry.file_name().to_string_lossy()) {
-                    let _ = fs::remove_file(entry.path());
+                    remove_if_exists(&entry.path())?;
                 }
             }
         }
     } else {
         for name in manifest {
-            let _ = fs::remove_file(dest.join(name));
+            remove_if_exists(&dest.join(name))?;
         }
     }
-    let _ = fs::remove_file(stamp_path);
+    remove_if_exists(stamp_path)
+}
+
+/// Write the stamp: line 1 = pinned commit SHA, lines 2+ = manifest.
+fn write_stamp(path: &Path, sha: &str, manifest: &[String]) -> Result<(), DictSourceError> {
+    let mut contents = sha.to_string();
+    for name in manifest {
+        contents.push('\n');
+        contents.push_str(name);
+    }
+    fs::write(path, contents).map_err(DictSourceError::Io)
 }
 
 /// Parse GitHub Contents API JSON and return (name, download_url) pairs
@@ -253,10 +297,15 @@ impl DictSource for MozcSource {
     /// moving while we fetch). A skew there silently shifts POS ids and
     /// corrupts conversion quality without any visible error.
     ///
-    /// Within a still-valid cache (stamp == latest SHA), individual missing
-    /// files (e.g. deleted by hand after a successful fetch) are re-downloaded
-    /// from that same pinned SHA. An interrupted run never writes a stamp, so
-    /// it takes the wipe + full re-download path on the next attempt.
+    /// When the cached snapshot is already at the latest SHA and its manifest
+    /// is fully on disk, the fetch returns early without touching the
+    /// Contents API at all — a valid cache must not fail on rate limits or
+    /// transient listing errors. Within a valid-but-incomplete cache (files
+    /// deleted by hand after a successful fetch), only the missing files are
+    /// re-downloaded, from that same pinned SHA. An interrupted run never
+    /// writes a stamp, so it takes the wipe + full re-download path on the
+    /// next attempt; if the wipe itself cannot remove a stale file, the fetch
+    /// aborts rather than risk mixing snapshots.
     ///
     /// Offline behavior: if the SHA can't be resolved but a cached snapshot
     /// exists (valid stamp — only written after a fully successful fetch) and
@@ -281,7 +330,7 @@ impl DictSource for MozcSource {
                     let complete = if st.manifest.is_empty() {
                         required_files_present(dest)
                     } else {
-                        st.manifest.iter().all(|f| dest.join(f).exists())
+                        cache_complete(st, dest)
                     };
                     if complete {
                         eprintln!(
@@ -303,7 +352,19 @@ impl DictSource for MozcSource {
         };
 
         let cache_valid = cached.as_ref().map(|s| s.sha.as_str()) == Some(sha.as_str());
-        if !cache_valid {
+
+        // Fast path: latest SHA with every manifest file on disk — done,
+        // without spending a Contents API call (or risking its failure).
+        if cache_valid {
+            let st = cached.as_ref().expect("cache_valid implies stamp");
+            if cache_complete(st, dest) {
+                eprintln!("Mozc dictionary cache is up to date (commit {sha}).");
+                // Rewrite the (identical) stamp so its mtime satisfies
+                // mise's outputs-based staleness check.
+                write_stamp(&stamp_path, &st.sha, &st.manifest)?;
+                return Ok(());
+            }
+        } else {
             if let Some(st) = &cached {
                 eprintln!(
                     "Cache commit {} != latest {sha}; wiping stale files.",
@@ -316,7 +377,7 @@ impl DictSource for MozcSource {
                 .as_ref()
                 .map(|s| s.manifest.as_slice())
                 .unwrap_or(&[]);
-            wipe_cache(dest, &stamp_path, manifest);
+            wipe_cache(dest, &stamp_path, manifest)?;
         }
 
         eprintln!(
@@ -331,9 +392,13 @@ impl DictSource for MozcSource {
         manifest.push("connection_single_column.txt".to_string());
         manifest.push("LICENSE".to_string());
 
+        // Skipping an existing file is only sound within a valid cache
+        // (same pinned SHA). After a wipe, download unconditionally —
+        // fs::write overwrites — so no pre-existing file can leak into the
+        // new snapshot.
         for (name, url) in &remote_files {
             let file_path = dest.join(name);
-            if file_path.exists() {
+            if cache_valid && file_path.exists() {
                 eprintln!("  {name} (already exists, skipping)");
                 continue;
             }
@@ -343,7 +408,7 @@ impl DictSource for MozcSource {
 
         // Download connection matrix
         let connection = dest.join("connection_single_column.txt");
-        if connection.exists() {
+        if cache_valid && connection.exists() {
             eprintln!("  connection_single_column.txt (already exists, skipping)");
         } else {
             eprintln!("  connection_single_column.txt");
@@ -355,7 +420,7 @@ impl DictSource for MozcSource {
 
         // Download LICENSE
         let license = dest.join("LICENSE");
-        if license.exists() {
+        if cache_valid && license.exists() {
             eprintln!("  LICENSE (already exists, skipping)");
         } else {
             eprintln!("  LICENSE");
@@ -364,12 +429,7 @@ impl DictSource for MozcSource {
         }
 
         // Record the snapshot version + manifest only after every file landed.
-        let mut stamp_contents = sha.clone();
-        for name in &manifest {
-            stamp_contents.push('\n');
-            stamp_contents.push_str(name);
-        }
-        fs::write(&stamp_path, &stamp_contents).map_err(DictSourceError::Io)?;
+        write_stamp(&stamp_path, &sha, &manifest)?;
         eprintln!("Done. Files saved to {}", dest.display());
         Ok(())
     }
@@ -553,6 +613,51 @@ mod tests {
         let st = read_stamp(&stamp).unwrap();
         assert_eq!(st.manifest, vec!["id.def"]);
 
+        // Hand-edited manifest entries naming files this source never
+        // fetches are dropped too, so a tampered stamp can't aim the wipe
+        // at user files (Copilot review on PR #266).
+        fs::write(
+            &stamp,
+            "0123456789abcdef0123456789abcdef01234567\n\
+             dictionary-custom.txt\nnotes.md\ndictionary00.txt\n",
+        )
+        .unwrap();
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.manifest, vec!["dictionary00.txt"]);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Pins the fast-path predicate: a manifest stamp with every file on disk
+    /// is complete (fetch early-returns without any Contents API call); a
+    /// missing file or a legacy manifest-less stamp is not.
+    #[test]
+    fn test_cache_complete() {
+        let dir = std::env::temp_dir().join("lexime_test_mozc_complete");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let sha = "0123456789abcdef0123456789abcdef01234567".to_string();
+
+        // Legacy SHA-only stamp: no manifest → cannot prove completeness.
+        let legacy = Stamp {
+            sha: sha.clone(),
+            manifest: vec![],
+        };
+        assert!(!cache_complete(&legacy, &dir));
+
+        let st = Stamp {
+            sha,
+            manifest: vec!["dictionary00.txt".to_string(), "id.def".to_string()],
+        };
+        // Manifest recorded but files absent → incomplete.
+        assert!(!cache_complete(&st, &dir));
+
+        fs::write(dir.join("dictionary00.txt"), "x").unwrap();
+        assert!(!cache_complete(&st, &dir), "one of two files → incomplete");
+
+        fs::write(dir.join("id.def"), "x").unwrap();
+        assert!(cache_complete(&st, &dir));
+
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -631,6 +736,10 @@ mod tests {
         assert!(!required_files_present(&dir));
         fs::write(dir.join("connection_single_column.txt"), "x").unwrap();
         assert!(!required_files_present(&dir));
+        // A user-placed dictionary must NOT satisfy the shard requirement
+        // (Codex + Copilot review on PR #266) — only dictionary<digits>.txt.
+        fs::write(dir.join("dictionary-custom.txt"), "x").unwrap();
+        assert!(!required_files_present(&dir));
         fs::write(dir.join("dictionary00.txt"), "x").unwrap();
         assert!(required_files_present(&dir));
 
@@ -674,7 +783,7 @@ mod tests {
 
         assert!(any_fetched_file_exists(&dir));
         let st = read_stamp(&dir.join(".stamp")).unwrap();
-        wipe_cache(&dir, &dir.join(".stamp"), &st.manifest);
+        wipe_cache(&dir, &dir.join(".stamp"), &st.manifest).unwrap();
 
         for name in fetched {
             assert!(!dir.join(name).exists(), "{name} should have been wiped");
@@ -715,7 +824,7 @@ mod tests {
         fs::write(dir.join("notes.md"), "keep me").unwrap();
         fs::write(dir.join("dictionary-custom.txt"), "user entries").unwrap();
 
-        wipe_cache(&dir, &dir.join(".stamp"), &[]);
+        wipe_cache(&dir, &dir.join(".stamp"), &[]).unwrap();
 
         for name in fetched {
             assert!(!dir.join(name).exists(), "{name} should have been wiped");
@@ -723,6 +832,31 @@ mod tests {
         assert!(!dir.join(".stamp").exists());
         assert!(dir.join("notes.md").exists());
         assert!(dir.join("dictionary-custom.txt").exists());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A wipe that cannot actually remove a stale file must abort the fetch:
+    /// carrying on would put files from two upstream snapshots side by side —
+    /// the exact mix this module exists to prevent (Codex review on PR #266).
+    #[test]
+    fn test_wipe_cache_propagates_removal_failure() {
+        let dir = std::env::temp_dir().join("lexime_test_mozc_wipe_fail");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Manifest entries that are simply absent are fine (already gone).
+        let manifest = vec!["dictionary00.txt".to_string()];
+        assert!(wipe_cache(&dir, &dir.join(".stamp"), &manifest).is_ok());
+
+        // A manifest entry that is a non-empty directory makes remove_file
+        // fail with something other than NotFound → the wipe must error.
+        fs::create_dir_all(dir.join("dictionary00.txt")).unwrap();
+        fs::write(dir.join("dictionary00.txt").join("blocker"), "x").unwrap();
+        assert!(wipe_cache(&dir, &dir.join(".stamp"), &manifest).is_err());
+
+        // Same failure through the legacy (pattern-scan) path.
+        assert!(wipe_cache(&dir, &dir.join(".stamp"), &[]).is_err());
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -276,11 +276,13 @@ fn remove_if_exists(path: &Path) -> Result<(), DictSourceError> {
 /// prevent. The caller must abort the fetch (Codex review on PR #266).
 fn wipe_cache(dest: &Path, stamp_path: &Path, manifest: &[String]) -> Result<(), DictSourceError> {
     if manifest.is_empty() {
-        if let Ok(rd) = fs::read_dir(dest) {
-            for entry in rd.filter_map(|e| e.ok()) {
-                if is_upstream_file_name(&entry.file_name().to_string_lossy()) {
-                    remove_if_exists(&entry.path())?;
-                }
+        // Propagate scan errors: silently skipping unreadable entries could
+        // leave stale upstream-named files behind and reintroduce the
+        // cross-snapshot mixing this wipe exists to prevent.
+        for entry in fs::read_dir(dest).map_err(DictSourceError::Io)? {
+            let entry = entry.map_err(DictSourceError::Io)?;
+            if is_upstream_file_name(&entry.file_name().to_string_lossy()) {
+                remove_if_exists(&entry.path())?;
             }
         }
     } else {
@@ -306,6 +308,10 @@ fn write_stamp(path: &Path, sha: &str, manifest: &[String]) -> Result<(), DictSo
     let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
     tmp_name.push(".tmp");
     let tmp = path.with_file_name(tmp_name);
+    // Guard cleans the temp up if the write or rename fails (no-op after a
+    // successful rename). rename-onto-existing is atomic on POSIX; this tool
+    // only targets macOS (the IME's sole platform).
+    let _guard = TmpFileGuard(tmp.clone());
     fs::write(&tmp, contents).map_err(DictSourceError::Io)?;
     fs::rename(&tmp, path).map_err(DictSourceError::Io)
 }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -368,7 +368,15 @@ fn commit_staged(
             ))
         })?;
     }
-    let _ = fs::remove_dir_all(staging);
+    // Cleanup failure must not fail the fetch — the snapshot is already
+    // committed and valid, and the next run removes a leftover `.staging`
+    // at startup. Warn for visibility instead of failing or staying silent.
+    if let Err(e) = fs::remove_dir_all(staging) {
+        eprintln!(
+            "Warning: could not remove staging dir {}: {e}",
+            staging.display()
+        );
+    }
     write_stamp(stamp_path, sha, new_manifest)
 }
 

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -142,7 +142,9 @@ fn is_upstream_file_name(name: &str) -> bool {
 /// file must exist); a legacy SHA-only stamp cannot, so it returns false
 /// and the caller falls back to weaker heuristics or a re-download.
 fn cache_complete(stamp: &Stamp, dest: &Path) -> bool {
-    !stamp.manifest.is_empty() && stamp.manifest.iter().all(|f| dest.join(f).exists())
+    // is_file(), not exists(): a directory squatting on an artifact name must
+    // not count as a cached file (it would poison the fast path).
+    !stamp.manifest.is_empty() && stamp.manifest.iter().all(|f| dest.join(f).is_file())
 }
 
 /// True if the files required by downstream consumers are all present:
@@ -157,13 +159,14 @@ fn cache_complete(stamp: &Stamp, dest: &Path) -> bool {
 fn required_files_present(dest: &Path) -> bool {
     let any_dictionary = fs::read_dir(dest)
         .map(|rd| {
-            rd.filter_map(|e| e.ok())
-                .any(|e| is_numbered_dictionary(&e.file_name().to_string_lossy()))
+            rd.filter_map(|e| e.ok()).any(|e| {
+                is_numbered_dictionary(&e.file_name().to_string_lossy()) && e.path().is_file()
+            })
         })
         .unwrap_or(false);
     any_dictionary
-        && dest.join("id.def").exists()
-        && dest.join("connection_single_column.txt").exists()
+        && dest.join("id.def").is_file()
+        && dest.join("connection_single_column.txt").is_file()
 }
 
 /// True if any upstream-named fetched file exists in `dest`.
@@ -398,7 +401,7 @@ impl DictSource for MozcSource {
         // new snapshot.
         for (name, url) in &remote_files {
             let file_path = dest.join(name);
-            if cache_valid && file_path.exists() {
+            if cache_valid && file_path.is_file() {
                 eprintln!("  {name} (already exists, skipping)");
                 continue;
             }
@@ -408,7 +411,7 @@ impl DictSource for MozcSource {
 
         // Download connection matrix
         let connection = dest.join("connection_single_column.txt");
-        if cache_valid && connection.exists() {
+        if cache_valid && connection.is_file() {
             eprintln!("  connection_single_column.txt (already exists, skipping)");
         } else {
             eprintln!("  connection_single_column.txt");
@@ -420,7 +423,7 @@ impl DictSource for MozcSource {
 
         // Download LICENSE
         let license = dest.join("LICENSE");
-        if cache_valid && license.exists() {
+        if cache_valid && license.is_file() {
             eprintln!("  LICENSE (already exists, skipping)");
         } else {
             eprintln!("  LICENSE");
@@ -657,6 +660,14 @@ mod tests {
 
         fs::write(dir.join("id.def"), "x").unwrap();
         assert!(cache_complete(&st, &dir));
+
+        // A directory squatting on an artifact name is not a cached file.
+        fs::remove_file(dir.join("id.def")).unwrap();
+        fs::create_dir(dir.join("id.def")).unwrap();
+        assert!(
+            !cache_complete(&st, &dir),
+            "directory in place of a file → incomplete"
+        );
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -57,6 +57,13 @@ impl MozcSource {
     }
 }
 
+/// True if `s` is a full commit SHA: exactly 40 hex chars. Anything else is
+/// rejected so a malformed value can't end up embedded in raw URLs or trusted
+/// as a cache version.
+fn is_valid_sha(s: &str) -> bool {
+    s.len() == 40 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 /// Extract and validate the commit SHA from a GitHub Commits API response.
 fn parse_commit_sha(json: &str) -> Result<String, DictSourceError> {
     let v: serde_json::Value = serde_json::from_str(json)
@@ -64,9 +71,7 @@ fn parse_commit_sha(json: &str) -> Result<String, DictSourceError> {
     let sha = v["sha"]
         .as_str()
         .ok_or_else(|| DictSourceError::Parse("GitHub commit JSON: missing sha".to_string()))?;
-    // A full commit SHA is 40 hex chars; reject anything else so a malformed
-    // response can't end up embedded in raw URLs or the stamp file.
-    if sha.len() != 40 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+    if !is_valid_sha(sha) {
         return Err(DictSourceError::Parse(format!(
             "GitHub commit JSON: invalid sha {sha:?}"
         )));
@@ -74,13 +79,15 @@ fn parse_commit_sha(json: &str) -> Result<String, DictSourceError> {
     Ok(sha.to_string())
 }
 
-/// Read the version stamp. Missing / empty / whitespace-only stamps (including
-/// the legacy pre-versioning empty `.stamp`) all count as "no version".
+/// Read the version stamp. Only a well-formed commit SHA counts as a version:
+/// missing / empty / legacy pre-versioning empty `.stamp` / corrupted or
+/// hand-edited contents all return `None`, which the caller treats as
+/// "no version" (wipe + full re-download).
 fn read_stamp(path: &Path) -> Option<String> {
     fs::read_to_string(path)
         .ok()
         .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+        .filter(|s| is_valid_sha(s))
 }
 
 /// True if `name` is one of the files this source fetches into the cache dir.
@@ -89,6 +96,25 @@ fn is_fetched_file(name: &str) -> bool {
         || name == "id.def"
         || name == "connection_single_column.txt"
         || name == "LICENSE"
+}
+
+/// True if the files required by downstream consumers are all present:
+/// `id.def`, `connection_single_column.txt`, and at least one
+/// `dictionary*.txt`. Used by the offline fallback — a stamp alone is not
+/// enough evidence if the artifacts themselves have since been deleted.
+fn required_files_present(dest: &Path) -> bool {
+    let any_dictionary = fs::read_dir(dest)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok()).any(|e| {
+                let n = e.file_name();
+                let s = n.to_string_lossy();
+                s.starts_with("dictionary") && s.ends_with(".txt")
+            })
+        })
+        .unwrap_or(false);
+    any_dictionary
+        && dest.join("id.def").exists()
+        && dest.join("connection_single_column.txt").exists()
 }
 
 /// True if any previously fetched file exists in `dest`.
@@ -185,12 +211,14 @@ impl DictSource for MozcSource {
     /// corrupts conversion quality without any visible error.
     ///
     /// Within a still-valid cache (stamp == latest SHA), individual missing
-    /// files are re-downloaded from that same SHA, so an interrupted run
-    /// recovers without re-fetching everything.
+    /// files (e.g. deleted by hand after a successful fetch) are re-downloaded
+    /// from that same pinned SHA. An interrupted run never writes a stamp, so
+    /// it takes the wipe + full re-download path on the next attempt.
     ///
-    /// Offline behavior: if the SHA can't be resolved but a complete cached
-    /// snapshot exists (non-empty stamp — only written after a fully
-    /// successful fetch), warn and keep using it; otherwise fail.
+    /// Offline behavior: if the SHA can't be resolved but a cached snapshot
+    /// exists (valid stamp — only written after a fully successful fetch) and
+    /// the required artifacts are still on disk, warn and keep using it;
+    /// otherwise fail.
     fn fetch(&self, dest: &Path) -> Result<(), DictSourceError> {
         fs::create_dir_all(dest).map_err(DictSourceError::Io)?;
         let stamp_path = dest.join(".stamp");
@@ -200,11 +228,18 @@ impl DictSource for MozcSource {
             Ok(sha) => sha,
             Err(e) => {
                 if let Some(v) = &cached {
-                    eprintln!(
-                        "Warning: could not resolve latest mozc commit ({e}); \
-                         using cached snapshot {v}."
-                    );
-                    return Ok(());
+                    if required_files_present(dest) {
+                        eprintln!(
+                            "Warning: could not resolve latest mozc commit ({e}); \
+                             using cached snapshot {v}."
+                        );
+                        return Ok(());
+                    }
+                    return Err(DictSourceError::Http(format!(
+                        "could not resolve latest mozc commit ({e}) and cached snapshot {v} \
+                         in {} is missing required files",
+                        dest.display()
+                    )));
                 }
                 return Err(e);
             }
@@ -357,6 +392,19 @@ mod tests {
     }
 
     #[test]
+    fn test_is_valid_sha() {
+        assert!(is_valid_sha("0123456789abcdef0123456789abcdef01234567"));
+        assert!(is_valid_sha("0123456789ABCDEF0123456789ABCDEF01234567"));
+        // Wrong length
+        assert!(!is_valid_sha(""));
+        assert!(!is_valid_sha("abc123"));
+        assert!(!is_valid_sha("0123456789abcdef0123456789abcdef012345678"));
+        // Right length, non-hex
+        assert!(!is_valid_sha("0123456789abcdef0123456789abcdef0123456z"));
+        assert!(!is_valid_sha("../../../../../../../../../../../../etc/x"));
+    }
+
+    #[test]
     fn test_parse_commit_sha() {
         let sha = "0123456789abcdef0123456789abcdef01234567";
         let json = format!(r#"{{"sha": "{sha}", "commit": {{}}}}"#);
@@ -394,6 +442,14 @@ mod tests {
 
         // Whitespace-only → None
         fs::write(&stamp, "  \n").unwrap();
+        assert!(read_stamp(&stamp).is_none());
+
+        // Corrupted / hand-edited (not a 40-hex SHA) → None, so it is treated
+        // as "no version" and triggers a wipe + re-download instead of being
+        // trusted (Copilot review on PR #266).
+        fs::write(&stamp, "master\n").unwrap();
+        assert!(read_stamp(&stamp).is_none());
+        fs::write(&stamp, "0123456789abcdef0123456789abcdef0123456z\n").unwrap();
         assert!(read_stamp(&stamp).is_none());
 
         // Trim trailing newline
@@ -439,6 +495,37 @@ mod tests {
         // Case 4: legacy empty stamp → wipe.
         fs::write(dir.join(".stamp"), "").unwrap();
         assert!(should_wipe(&dir, latest));
+
+        // Case 5: corrupted / hand-edited stamp (not a 40-hex SHA) → wipe.
+        fs::write(dir.join(".stamp"), "master").unwrap();
+        assert!(should_wipe(&dir, latest));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Pins the offline-fallback guard (Copilot review on PR #266): a stamp
+    /// alone must not be enough to skip fetching — the required artifacts
+    /// (id.def, connection matrix, ≥1 dictionary*.txt) must still be on disk.
+    #[test]
+    fn test_required_files_present() {
+        let dir = std::env::temp_dir().join("lexime_test_mozc_required");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Empty dir → incomplete.
+        assert!(!required_files_present(&dir));
+
+        // Build up piece by piece; only the full set passes.
+        fs::write(dir.join("id.def"), "x").unwrap();
+        assert!(!required_files_present(&dir));
+        fs::write(dir.join("connection_single_column.txt"), "x").unwrap();
+        assert!(!required_files_present(&dir));
+        fs::write(dir.join("dictionary00.txt"), "x").unwrap();
+        assert!(required_files_present(&dir));
+
+        // Losing any one required artifact flips it back to incomplete.
+        fs::remove_file(dir.join("id.def")).unwrap();
+        assert!(!required_files_present(&dir));
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -91,14 +91,15 @@ struct Stamp {
     manifest: Vec<String>,
 }
 
-/// Read the version stamp. Only a stamp whose first line is a well-formed
-/// commit SHA counts: missing / empty / legacy pre-versioning empty `.stamp` /
-/// corrupted or hand-edited contents all return `None`, which the caller
-/// treats as "no version" (wipe + full re-download). Manifest entries must
-/// pass `is_upstream_file_name`; anything else (path traversal attempts, or a
-/// hand-edited entry naming a user file like `dictionary-custom.txt`) is
-/// dropped so a tampered stamp can neither direct the wipe outside the cache
-/// dir nor at files this source never fetched.
+/// Read the version stamp. Returns `None` when the first line is not a
+/// well-formed commit SHA (missing file, empty / legacy pre-versioning
+/// `.stamp`, corrupted or hand-edited SHA line) — the caller treats that as
+/// "no version" (wipe + full re-download). Manifest entries on lines 2+ are
+/// filtered, not fatal: anything that fails `is_upstream_file_name` (path
+/// traversal attempts, or a hand-edited entry naming a user file like
+/// `dictionary-custom.txt`) is silently dropped so a tampered stamp can
+/// neither direct the wipe outside the cache dir nor at files this source
+/// never fetched.
 fn read_stamp(path: &Path) -> Option<Stamp> {
     let content = fs::read_to_string(path).ok()?;
     let mut lines = content.lines();
@@ -226,7 +227,12 @@ fn write_stamp(path: &Path, sha: &str, manifest: &[String]) -> Result<(), DictSo
         contents.push('\n');
         contents.push_str(name);
     }
-    fs::write(path, contents).map_err(DictSourceError::Io)
+    // tmp + rename: an interrupted write must not leave a truncated stamp
+    // whose valid SHA line + partial manifest would satisfy cache_complete
+    // and mask an incomplete snapshot.
+    let tmp = path.with_extension("stamp.tmp");
+    fs::write(&tmp, contents).map_err(DictSourceError::Io)?;
+    fs::rename(&tmp, path).map_err(DictSourceError::Io)
 }
 
 /// Parse GitHub Contents API JSON and return (name, download_url) pairs

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -357,6 +357,11 @@ impl DictSource for MozcSource {
                              using cached snapshot {}.",
                             st.sha
                         );
+                        // Same-content rewrite, like the online fast path:
+                        // a successful (offline-verified) fetch refreshes the
+                        // stamp mtime so mise's sources-vs-outputs staleness
+                        // check doesn't re-run this task on every build.
+                        write_stamp(&stamp_path, &st.sha, &st.manifest)?;
                         return Ok(());
                     }
                     return Err(DictSourceError::Http(format!(

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -79,20 +79,53 @@ fn parse_commit_sha(json: &str) -> Result<String, DictSourceError> {
     Ok(sha.to_string())
 }
 
-/// Read the version stamp. Only a well-formed commit SHA counts as a version:
-/// missing / empty / legacy pre-versioning empty `.stamp` / corrupted or
-/// hand-edited contents all return `None`, which the caller treats as
-/// "no version" (wipe + full re-download).
-fn read_stamp(path: &Path) -> Option<String> {
-    fs::read_to_string(path)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| is_valid_sha(s))
+/// A parsed version stamp: line 1 is the pinned commit SHA, lines 2+ are the
+/// manifest — the names of the files that fetch run downloaded. The manifest
+/// is what `wipe_cache` deletes, so user-placed files (e.g. a hand-added
+/// `dictionary-custom.txt`, which `parse_dir`'s `dictionary*.txt` glob happily
+/// reads) are never deleted just because upstream moved. A legacy SHA-only
+/// stamp yields an empty manifest.
+struct Stamp {
+    sha: String,
+    manifest: Vec<String>,
 }
 
-/// True if `name` is one of the files this source fetches into the cache dir.
-fn is_fetched_file(name: &str) -> bool {
-    (name.starts_with("dictionary") && name.ends_with(".txt"))
+/// Read the version stamp. Only a stamp whose first line is a well-formed
+/// commit SHA counts: missing / empty / legacy pre-versioning empty `.stamp` /
+/// corrupted or hand-edited contents all return `None`, which the caller
+/// treats as "no version" (wipe + full re-download). Manifest entries are
+/// restricted to plain file names — anything containing a path separator or
+/// `..` is dropped so a tampered stamp cannot direct the wipe outside the
+/// cache dir.
+fn read_stamp(path: &Path) -> Option<Stamp> {
+    let content = fs::read_to_string(path).ok()?;
+    let mut lines = content.lines();
+    let sha = lines.next()?.trim();
+    if !is_valid_sha(sha) {
+        return None;
+    }
+    let manifest = lines
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.contains('/') && !l.contains('\\') && *l != "..")
+        .map(str::to_string)
+        .collect();
+    Some(Stamp {
+        sha: sha.to_string(),
+        manifest,
+    })
+}
+
+/// True if `name` matches the exact upstream naming of the files this source
+/// fetches: `dictionary<digits>.txt`, `id.def`, `connection_single_column.txt`
+/// or `LICENSE`. Deliberately narrower than the `dictionary*.txt` glob that
+/// `parse_dir` accepts, so a user-placed `dictionary-custom.txt` is never
+/// mistaken for a fetched artifact (Codex review on PR #266).
+fn is_upstream_file_name(name: &str) -> bool {
+    let is_numbered_dictionary = name
+        .strip_prefix("dictionary")
+        .and_then(|rest| rest.strip_suffix(".txt"))
+        .is_some_and(|mid| !mid.is_empty() && mid.bytes().all(|b| b.is_ascii_digit()));
+    is_numbered_dictionary
         || name == "id.def"
         || name == "connection_single_column.txt"
         || name == "LICENSE"
@@ -117,23 +150,33 @@ fn required_files_present(dest: &Path) -> bool {
         && dest.join("connection_single_column.txt").exists()
 }
 
-/// True if any previously fetched file exists in `dest`.
+/// True if any upstream-named fetched file exists in `dest`.
 fn any_fetched_file_exists(dest: &Path) -> bool {
     fs::read_dir(dest)
         .map(|rd| {
             rd.filter_map(|e| e.ok())
-                .any(|e| is_fetched_file(&e.file_name().to_string_lossy()))
+                .any(|e| is_upstream_file_name(&e.file_name().to_string_lossy()))
         })
         .unwrap_or(false)
 }
 
-/// Remove all fetched files plus the stamp so a re-download starts clean.
-fn wipe_cache(dest: &Path, stamp_path: &Path) {
-    if let Ok(rd) = fs::read_dir(dest) {
-        for entry in rd.filter_map(|e| e.ok()) {
-            if is_fetched_file(&entry.file_name().to_string_lossy()) {
-                let _ = fs::remove_file(entry.path());
+/// Remove fetched files plus the stamp so a re-download starts clean.
+/// Deletes exactly the files recorded in the stamp's manifest when one is
+/// available; without a manifest (legacy SHA-only stamp, no stamp at all)
+/// it falls back to the exact upstream naming pattern. Either way,
+/// user-placed files like `dictionary-custom.txt` survive.
+fn wipe_cache(dest: &Path, stamp_path: &Path, manifest: &[String]) {
+    if manifest.is_empty() {
+        if let Ok(rd) = fs::read_dir(dest) {
+            for entry in rd.filter_map(|e| e.ok()) {
+                if is_upstream_file_name(&entry.file_name().to_string_lossy()) {
+                    let _ = fs::remove_file(entry.path());
+                }
             }
+        }
+    } else {
+        for name in manifest {
+            let _ = fs::remove_file(dest.join(name));
         }
     }
     let _ = fs::remove_file(stamp_path);
@@ -217,8 +260,12 @@ impl DictSource for MozcSource {
     ///
     /// Offline behavior: if the SHA can't be resolved but a cached snapshot
     /// exists (valid stamp — only written after a fully successful fetch) and
-    /// the required artifacts are still on disk, warn and keep using it;
-    /// otherwise fail.
+    /// its artifacts are still on disk, warn and keep using it; otherwise
+    /// fail.
+    ///
+    /// The stamp records, after the SHA, the manifest of files this fetch
+    /// downloaded; a later wipe deletes exactly those, so user-placed files
+    /// in the cache dir survive version bumps.
     fn fetch(&self, dest: &Path) -> Result<(), DictSourceError> {
         fs::create_dir_all(dest).map_err(DictSourceError::Io)?;
         let stamp_path = dest.join(".stamp");
@@ -227,17 +274,27 @@ impl DictSource for MozcSource {
         let sha = match Self::latest_commit_sha() {
             Ok(sha) => sha,
             Err(e) => {
-                if let Some(v) = &cached {
-                    if required_files_present(dest) {
+                if let Some(st) = &cached {
+                    // A stamp alone is not enough — verify the artifacts it
+                    // vouches for are still on disk (manifest when recorded,
+                    // required-file heuristic for legacy SHA-only stamps).
+                    let complete = if st.manifest.is_empty() {
+                        required_files_present(dest)
+                    } else {
+                        st.manifest.iter().all(|f| dest.join(f).exists())
+                    };
+                    if complete {
                         eprintln!(
                             "Warning: could not resolve latest mozc commit ({e}); \
-                             using cached snapshot {v}."
+                             using cached snapshot {}.",
+                            st.sha
                         );
                         return Ok(());
                     }
                     return Err(DictSourceError::Http(format!(
-                        "could not resolve latest mozc commit ({e}) and cached snapshot {v} \
+                        "could not resolve latest mozc commit ({e}) and cached snapshot {} \
                          in {} is missing required files",
+                        st.sha,
                         dest.display()
                     )));
                 }
@@ -245,14 +302,21 @@ impl DictSource for MozcSource {
             }
         };
 
-        let cache_valid = cached.as_deref() == Some(sha.as_str());
+        let cache_valid = cached.as_ref().map(|s| s.sha.as_str()) == Some(sha.as_str());
         if !cache_valid {
-            if let Some(v) = &cached {
-                eprintln!("Cache commit {v} != latest {sha}; wiping stale files.");
+            if let Some(st) = &cached {
+                eprintln!(
+                    "Cache commit {} != latest {sha}; wiping stale files.",
+                    st.sha
+                );
             } else if any_fetched_file_exists(dest) {
                 eprintln!("Cache has no version stamp but files present; wiping.");
             }
-            wipe_cache(dest, &stamp_path);
+            let manifest = cached
+                .as_ref()
+                .map(|s| s.manifest.as_slice())
+                .unwrap_or(&[]);
+            wipe_cache(dest, &stamp_path, manifest);
         }
 
         eprintln!(
@@ -261,6 +325,12 @@ impl DictSource for MozcSource {
         );
 
         let remote_files = Self::list_remote_files(&sha)?;
+        // Manifest of everything this snapshot owns — written into the stamp
+        // so a future wipe removes exactly these files and nothing else.
+        let mut manifest: Vec<String> = remote_files.iter().map(|(n, _)| n.clone()).collect();
+        manifest.push("connection_single_column.txt".to_string());
+        manifest.push("LICENSE".to_string());
+
         for (name, url) in &remote_files {
             let file_path = dest.join(name);
             if file_path.exists() {
@@ -293,8 +363,13 @@ impl DictSource for MozcSource {
             Self::download_file(&url, &license)?;
         }
 
-        // Record the snapshot version only after every file landed.
-        fs::write(&stamp_path, &sha).map_err(DictSourceError::Io)?;
+        // Record the snapshot version + manifest only after every file landed.
+        let mut stamp_contents = sha.clone();
+        for name in &manifest {
+            stamp_contents.push('\n');
+            stamp_contents.push_str(name);
+        }
+        fs::write(&stamp_path, &stamp_contents).map_err(DictSourceError::Io)?;
         eprintln!("Done. Files saved to {}", dest.display());
         Ok(())
     }
@@ -452,14 +527,50 @@ mod tests {
         fs::write(&stamp, "0123456789abcdef0123456789abcdef0123456z\n").unwrap();
         assert!(read_stamp(&stamp).is_none());
 
-        // Trim trailing newline
+        // Legacy SHA-only stamp (no manifest) → sha parsed, empty manifest.
         fs::write(&stamp, "0123456789abcdef0123456789abcdef01234567\n").unwrap();
-        assert_eq!(
-            read_stamp(&stamp).as_deref(),
-            Some("0123456789abcdef0123456789abcdef01234567")
-        );
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.sha, "0123456789abcdef0123456789abcdef01234567");
+        assert!(st.manifest.is_empty());
+
+        // SHA + manifest roundtrip.
+        fs::write(
+            &stamp,
+            "0123456789abcdef0123456789abcdef01234567\ndictionary00.txt\nid.def\n",
+        )
+        .unwrap();
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.sha, "0123456789abcdef0123456789abcdef01234567");
+        assert_eq!(st.manifest, vec!["dictionary00.txt", "id.def"]);
+
+        // Tampered manifest entries with path separators / `..` are dropped
+        // so a wipe can never escape the cache dir.
+        fs::write(
+            &stamp,
+            "0123456789abcdef0123456789abcdef01234567\n../evil\nsub/dir.txt\n..\nid.def\n",
+        )
+        .unwrap();
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.manifest, vec!["id.def"]);
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_is_upstream_file_name() {
+        // Exact upstream names are matched.
+        assert!(is_upstream_file_name("dictionary00.txt"));
+        assert!(is_upstream_file_name("dictionary09.txt"));
+        assert!(is_upstream_file_name("id.def"));
+        assert!(is_upstream_file_name("connection_single_column.txt"));
+        assert!(is_upstream_file_name("LICENSE"));
+        // User-placed dictionaries that parse_dir's glob would read must NOT
+        // be treated as fetched artifacts (Codex review on PR #266).
+        assert!(!is_upstream_file_name("dictionary-custom.txt"));
+        assert!(!is_upstream_file_name("dictionary.txt"));
+        assert!(!is_upstream_file_name("dictionary_backup01.txt"));
+        assert!(!is_upstream_file_name("notes.md"));
+        assert!(!is_upstream_file_name(".stamp"));
     }
 
     /// Pins the cache_valid predicate that drives wipe decisions — the mozc
@@ -471,7 +582,7 @@ mod tests {
     fn test_stale_cache_invariant() {
         fn should_wipe(dest: &Path, latest: &str) -> bool {
             let cached = read_stamp(&dest.join(".stamp"));
-            cached.as_deref() != Some(latest)
+            cached.as_ref().map(|s| s.sha.as_str()) != Some(latest)
         }
 
         let dir = std::env::temp_dir().join("lexime_test_mozc_invariant");
@@ -532,9 +643,11 @@ mod tests {
 
     /// A SHA mismatch must remove every fetched artifact — leaving id.def from
     /// snapshot A next to dictionary*.txt from snapshot B silently shifts POS
-    /// ids and corrupts conversion quality.
+    /// ids and corrupts conversion quality. With a manifest in the stamp, the
+    /// wipe deletes exactly the recorded files; user-placed files survive
+    /// (Codex review on PR #266).
     #[test]
-    fn test_wipe_cache_removes_all_fetched_files() {
+    fn test_wipe_cache_manifest_mode_spares_user_files() {
         let dir = std::env::temp_dir().join("lexime_test_mozc_wipe");
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
@@ -549,23 +662,67 @@ mod tests {
         for name in fetched {
             fs::write(dir.join(name), "stale").unwrap();
         }
-        fs::write(
-            dir.join(".stamp"),
-            "fedcba9876543210fedcba9876543210fedcba98",
-        )
-        .unwrap();
-        // A user-placed file must survive the wipe.
+        let stamp_contents = format!(
+            "fedcba9876543210fedcba9876543210fedcba98\n{}",
+            fetched.join("\n")
+        );
+        fs::write(dir.join(".stamp"), &stamp_contents).unwrap();
+        // User-placed files must survive the wipe — including one that
+        // parse_dir's dictionary*.txt glob matches.
         fs::write(dir.join("notes.md"), "keep me").unwrap();
+        fs::write(dir.join("dictionary-custom.txt"), "user entries").unwrap();
 
         assert!(any_fetched_file_exists(&dir));
-        wipe_cache(&dir, &dir.join(".stamp"));
+        let st = read_stamp(&dir.join(".stamp")).unwrap();
+        wipe_cache(&dir, &dir.join(".stamp"), &st.manifest);
 
         for name in fetched {
             assert!(!dir.join(name).exists(), "{name} should have been wiped");
         }
         assert!(!dir.join(".stamp").exists());
         assert!(dir.join("notes.md").exists());
+        assert!(dir.join("dictionary-custom.txt").exists());
         assert!(!any_fetched_file_exists(&dir));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Without a manifest (legacy SHA-only stamp, or no stamp at all) the
+    /// wipe falls back to the exact upstream naming pattern — which still
+    /// spares user-placed files like dictionary-custom.txt.
+    #[test]
+    fn test_wipe_cache_legacy_mode_spares_user_files() {
+        let dir = std::env::temp_dir().join("lexime_test_mozc_wipe_legacy");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let fetched = [
+            "dictionary00.txt",
+            "dictionary09.txt",
+            "id.def",
+            "connection_single_column.txt",
+            "LICENSE",
+        ];
+        for name in fetched {
+            fs::write(dir.join(name), "stale").unwrap();
+        }
+        // Legacy stamp: SHA only, no manifest.
+        fs::write(
+            dir.join(".stamp"),
+            "fedcba9876543210fedcba9876543210fedcba98",
+        )
+        .unwrap();
+        fs::write(dir.join("notes.md"), "keep me").unwrap();
+        fs::write(dir.join("dictionary-custom.txt"), "user entries").unwrap();
+
+        wipe_cache(&dir, &dir.join(".stamp"), &[]);
+
+        for name in fetched {
+            assert!(!dir.join(name).exists(), "{name} should have been wiped");
+        }
+        assert!(!dir.join(".stamp").exists());
+        assert!(dir.join("notes.md").exists());
+        assert!(dir.join("dictionary-custom.txt").exists());
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -18,6 +18,12 @@ const MOZC_RAW_BASE: &str = "https://raw.githubusercontent.com/google/mozc";
 pub struct MozcSource;
 
 impl MozcSource {
+    /// Download `url` into `dest` atomically: the body is staged in a
+    /// dot-prefixed temp file next to `dest` and renamed into place. An
+    /// interrupted run therefore never leaves a partial download under a
+    /// final artifact name — which the repair path (`cache_complete` /
+    /// skip-existing) would otherwise trust as a complete file (Codex
+    /// review R3 on PR #266). The temp file is removed on every error path.
     fn download_file(url: &str, dest: &Path) -> Result<(), DictSourceError> {
         let body = ureq::get(url)
             .call()
@@ -25,7 +31,62 @@ impl MozcSource {
             .into_body()
             .read_to_vec()
             .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?;
-        fs::write(dest, &body).map_err(DictSourceError::Io)?;
+        let mut tmp_name = std::ffi::OsString::from(".");
+        tmp_name.push(dest.file_name().ok_or_else(|| {
+            DictSourceError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid download path {}", dest.display()),
+            ))
+        })?);
+        tmp_name.push(format!(".tmp.{}", std::process::id()));
+        let tmp = dest.with_file_name(tmp_name);
+        let _guard = TmpFileGuard(tmp.clone());
+        fs::write(&tmp, &body).map_err(DictSourceError::Io)?;
+        fs::rename(&tmp, dest).map_err(DictSourceError::Io)?;
+        Ok(())
+    }
+
+    /// Download one snapshot's files — the listed shards + `id.def`, plus the
+    /// fixed-URL connection matrix and LICENSE — pinned to `sha`, into
+    /// `target`. With `skip_existing` (repair within a valid cache), files
+    /// already present are left alone: they are guaranteed to come from the
+    /// same pinned SHA, and `download_file`'s tmp+rename guarantees none of
+    /// them is a torn write.
+    fn download_snapshot(
+        sha: &str,
+        remote_files: &[(String, String)],
+        target: &Path,
+        skip_existing: bool,
+    ) -> Result<(), DictSourceError> {
+        for (name, url) in remote_files {
+            let path = target.join(name);
+            if skip_existing && path.is_file() {
+                eprintln!("  {name} (already exists, skipping)");
+                continue;
+            }
+            eprintln!("  {name}");
+            Self::download_file(url, &path)?;
+        }
+
+        let connection = target.join("connection_single_column.txt");
+        if skip_existing && connection.is_file() {
+            eprintln!("  connection_single_column.txt (already exists, skipping)");
+        } else {
+            eprintln!("  connection_single_column.txt");
+            let url = format!(
+                "{MOZC_RAW_BASE}/{sha}/src/data/dictionary_oss/connection_single_column.txt"
+            );
+            Self::download_file(&url, &connection)?;
+        }
+
+        let license = target.join("LICENSE");
+        if skip_existing && license.is_file() {
+            eprintln!("  LICENSE (already exists, skipping)");
+        } else {
+            eprintln!("  LICENSE");
+            let url = format!("{MOZC_RAW_BASE}/{sha}/LICENSE");
+            Self::download_file(&url, &license)?;
+        }
         Ok(())
     }
 
@@ -56,6 +117,15 @@ impl MozcSource {
             .read_to_string()
             .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?;
         parse_remote_files(&body)
+    }
+}
+
+/// Removes the staged temp file on drop so error paths don't leak it. After
+/// a successful rename the path no longer exists and the removal is a no-op.
+struct TmpFileGuard(std::path::PathBuf);
+impl Drop for TmpFileGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
     }
 }
 
@@ -240,6 +310,62 @@ fn write_stamp(path: &Path, sha: &str, manifest: &[String]) -> Result<(), DictSo
     fs::rename(&tmp, path).map_err(DictSourceError::Io)
 }
 
+/// The full manifest of a snapshot: the listed shard / `id.def` names plus
+/// the two fixed-URL files.
+fn snapshot_manifest(remote_files: &[(String, String)]) -> Vec<String> {
+    let mut manifest: Vec<String> = remote_files.iter().map(|(n, _)| n.clone()).collect();
+    manifest.push("connection_single_column.txt".to_string());
+    manifest.push("LICENSE".to_string());
+    manifest
+}
+
+/// Swap a fully staged snapshot into `dest`. Pure file operations, ordered so
+/// that no crash point leaves a state the next run would *trust*:
+///
+/// 1. Preflight — every `new_manifest` file must exist in `staging`; bail
+///    before touching `dest` otherwise, leaving the current cache intact.
+/// 2. Delete the stamp. From here on the cache is officially "no version":
+///    a crash mid-swap leaves a mixed dir at worst, and the next run wipes
+///    and re-downloads it rather than mistaking it for a complete snapshot.
+/// 3. Wipe the old snapshot files (old manifest, or the upstream naming
+///    pattern for legacy stamps). User-placed files survive as usual.
+/// 4. Rename the staged files into place (same filesystem — `staging` lives
+///    inside `dest` — so these are atomic per file).
+/// 5. Remove the now-empty staging dir and write the new stamp, which
+///    re-validates the cache.
+fn commit_staged(
+    dest: &Path,
+    stamp_path: &Path,
+    staging: &Path,
+    old_manifest: &[String],
+    sha: &str,
+    new_manifest: &[String],
+) -> Result<(), DictSourceError> {
+    for name in new_manifest {
+        if !staging.join(name).is_file() {
+            return Err(DictSourceError::Io(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "staged snapshot in {} is missing {name}; leaving current cache untouched",
+                    staging.display()
+                ),
+            )));
+        }
+    }
+    remove_if_exists(stamp_path)?;
+    wipe_cache(dest, stamp_path, old_manifest)?;
+    for name in new_manifest {
+        fs::rename(staging.join(name), dest.join(name)).map_err(|e| {
+            DictSourceError::Io(io::Error::new(
+                e.kind(),
+                format!("failed to move staged {name} into place: {e}"),
+            ))
+        })?;
+    }
+    let _ = fs::remove_dir_all(staging);
+    write_stamp(stamp_path, sha, new_manifest)
+}
+
 /// Parse GitHub Contents API JSON and return (name, download_url) pairs
 /// for the upstream-numbered shards (`dictionary<digits>.txt`) and `id.def`.
 fn parse_remote_files(json: &str) -> Result<Vec<(String, String)>, DictSourceError> {
@@ -307,7 +433,12 @@ impl DictSource for MozcSource {
     /// stamp file must equal the resolved upstream version exactly**, here
     /// the latest commit SHA of `google/mozc` master. Anything else (stamp
     /// missing, legacy empty stamp, mismatched SHA — with or without leftover
-    /// files) triggers a clean wipe + full re-download.
+    /// files) triggers a full re-download of the new snapshot into a
+    /// `.staging` subdirectory, followed by a transactional swap
+    /// (`commit_staged`): the old snapshot keeps working — and remains
+    /// available to the offline fallback — until the entire new snapshot has
+    /// landed. A transient listing/download failure therefore never costs a
+    /// previously working cache.
     ///
     /// Crucially, every download in a run is pinned to that one SHA via
     /// `raw.githubusercontent.com/google/mozc/<sha>/...`, so `id.def` and
@@ -321,10 +452,12 @@ impl DictSource for MozcSource {
     /// Contents API at all — a valid cache must not fail on rate limits or
     /// transient listing errors. Within a valid-but-incomplete cache (files
     /// deleted by hand after a successful fetch), only the missing files are
-    /// re-downloaded, from that same pinned SHA. An interrupted run never
-    /// writes a stamp, so it takes the wipe + full re-download path on the
-    /// next attempt; if the wipe itself cannot remove a stale file, the fetch
-    /// aborts rather than risk mixing snapshots.
+    /// re-downloaded, from that same pinned SHA, atomically per file
+    /// (tmp+rename), so an interrupted repair never leaves a partial file
+    /// under a final name. An interrupted swap never leaves a stamp, so the
+    /// next run wipes and re-downloads instead of trusting a mixed dir; if
+    /// that wipe cannot remove a stale file, the fetch aborts rather than
+    /// risk mixing snapshots.
     ///
     /// Offline behavior: if the SHA can't be resolved but a cached snapshot
     /// exists (valid stamp — only written after a fully successful fetch) and
@@ -337,6 +470,13 @@ impl DictSource for MozcSource {
     fn fetch(&self, dest: &Path) -> Result<(), DictSourceError> {
         fs::create_dir_all(dest).map_err(DictSourceError::Io)?;
         let stamp_path = dest.join(".stamp");
+        // Clear staging leftovers from an interrupted previous run up front.
+        // `.staging` is dot-prefixed, so parse_dir's dictionary*.txt glob and
+        // the wipe/presence scans never see it or its contents.
+        let staging = dest.join(".staging");
+        if staging.exists() {
+            fs::remove_dir_all(&staging).map_err(DictSourceError::Io)?;
+        }
         let cached = read_stamp(&stamp_path);
 
         let sha = match Self::latest_commit_sha() {
@@ -377,10 +517,11 @@ impl DictSource for MozcSource {
 
         let cache_valid = cached.as_ref().map(|s| s.sha.as_str()) == Some(sha.as_str());
 
-        // Fast path: latest SHA with every manifest file on disk — done,
-        // without spending a Contents API call (or risking its failure).
         if cache_valid {
             let st = cached.as_ref().expect("cache_valid implies stamp");
+
+            // Fast path: latest SHA with every manifest file on disk — done,
+            // without spending a Contents API call (or risking its failure).
             if cache_complete(st, dest) {
                 eprintln!("Mozc dictionary cache is up to date (commit {sha}).");
                 // Rewrite the (identical) stamp so its mtime satisfies
@@ -388,72 +529,49 @@ impl DictSource for MozcSource {
                 write_stamp(&stamp_path, &st.sha, &st.manifest)?;
                 return Ok(());
             }
-        } else {
-            if let Some(st) = &cached {
-                eprintln!(
-                    "Cache commit {} != latest {sha}; wiping stale files.",
-                    st.sha
-                );
-            } else if any_fetched_file_exists(dest) {
-                eprintln!("Cache has no version stamp but files present; wiping.");
-            }
-            let manifest = cached
-                .as_ref()
-                .map(|s| s.manifest.as_slice())
-                .unwrap_or(&[]);
-            wipe_cache(dest, &stamp_path, manifest)?;
-        }
 
-        eprintln!(
-            "Downloading Mozc dictionary files (commit {sha}) to {}...",
-            dest.display()
-        );
-
-        let remote_files = Self::list_remote_files(&sha)?;
-        // Manifest of everything this snapshot owns — written into the stamp
-        // so a future wipe removes exactly these files and nothing else.
-        let mut manifest: Vec<String> = remote_files.iter().map(|(n, _)| n.clone()).collect();
-        manifest.push("connection_single_column.txt".to_string());
-        manifest.push("LICENSE".to_string());
-
-        // Skipping an existing file is only sound within a valid cache
-        // (same pinned SHA). After a wipe, download unconditionally —
-        // fs::write overwrites — so no pre-existing file can leak into the
-        // new snapshot.
-        for (name, url) in &remote_files {
-            let file_path = dest.join(name);
-            if cache_valid && file_path.is_file() {
-                eprintln!("  {name} (already exists, skipping)");
-                continue;
-            }
-            eprintln!("  {name}");
-            Self::download_file(url, &file_path)?;
-        }
-
-        // Download connection matrix
-        let connection = dest.join("connection_single_column.txt");
-        if cache_valid && connection.is_file() {
-            eprintln!("  connection_single_column.txt (already exists, skipping)");
-        } else {
-            eprintln!("  connection_single_column.txt");
-            let url = format!(
-                "{MOZC_RAW_BASE}/{sha}/src/data/dictionary_oss/connection_single_column.txt"
+            // Repair path: same SHA but files missing (deleted by hand, or a
+            // legacy manifest-less stamp). Fill in only the gaps, straight
+            // into dest — sound because everything already present is from
+            // the same pinned SHA and download_file lands each file
+            // atomically, so nothing partial can be mistaken for complete.
+            eprintln!(
+                "Repairing Mozc dictionary cache (commit {sha}) in {}...",
+                dest.display()
             );
-            Self::download_file(&url, &connection)?;
+            let remote_files = Self::list_remote_files(&sha)?;
+            let manifest = snapshot_manifest(&remote_files);
+            Self::download_snapshot(&sha, &remote_files, dest, true)?;
+            write_stamp(&stamp_path, &sha, &manifest)?;
+            eprintln!("Done. Files saved to {}", dest.display());
+            return Ok(());
         }
 
-        // Download LICENSE
-        let license = dest.join("LICENSE");
-        if cache_valid && license.is_file() {
-            eprintln!("  LICENSE (already exists, skipping)");
-        } else {
-            eprintln!("  LICENSE");
-            let url = format!("{MOZC_RAW_BASE}/{sha}/LICENSE");
-            Self::download_file(&url, &license)?;
+        // Stale (or unversioned) cache: transactional snapshot swap. Nothing
+        // in dest is touched until the ENTIRE new snapshot sits in staging —
+        // a transient listing/download failure leaves the old snapshot
+        // working and offline-usable (Codex review R3 on PR #266: wiping
+        // up front traded a working cache for any network hiccup).
+        if let Some(st) = &cached {
+            eprintln!(
+                "Cache commit {} != latest {sha}; downloading new snapshot before replacing.",
+                st.sha
+            );
+        } else if any_fetched_file_exists(dest) {
+            eprintln!("Cache has no version stamp; will replace files after download.");
         }
 
-        // Record the snapshot version + manifest only after every file landed.
-        write_stamp(&stamp_path, &sha, &manifest)?;
+        eprintln!("Downloading Mozc dictionary files (commit {sha}) to staging...");
+        let remote_files = Self::list_remote_files(&sha)?;
+        let manifest = snapshot_manifest(&remote_files);
+        fs::create_dir_all(&staging).map_err(DictSourceError::Io)?;
+        Self::download_snapshot(&sha, &remote_files, &staging, false)?;
+
+        let old_manifest = cached
+            .as_ref()
+            .map(|s| s.manifest.as_slice())
+            .unwrap_or(&[]);
+        commit_staged(dest, &stamp_path, &staging, old_manifest, &sha, &manifest)?;
         eprintln!("Done. Files saved to {}", dest.display());
         Ok(())
     }
@@ -926,6 +1044,143 @@ mod tests {
 
         // Same failure through the legacy (pattern-scan) path.
         assert!(wipe_cache(&dir, &dir.join(".stamp"), &[]).is_err());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    const OLD_SHA: &str = "fedcba9876543210fedcba9876543210fedcba98";
+    const NEW_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    /// Build a cache dir holding an "old" snapshot (files + manifest stamp)
+    /// plus user files, and a staging dir holding a "new" snapshot. Returns
+    /// (dir, staging, old_manifest, new_manifest).
+    fn setup_swap_fixture(
+        tag: &str,
+    ) -> (
+        std::path::PathBuf,
+        std::path::PathBuf,
+        Vec<String>,
+        Vec<String>,
+    ) {
+        let dir = std::env::temp_dir().join(format!("lexime_test_mozc_swap_{tag}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Old snapshot: has a shard (dictionary09.txt) the new one drops.
+        let old_manifest: Vec<String> = ["dictionary00.txt", "dictionary09.txt", "id.def"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        for name in &old_manifest {
+            fs::write(dir.join(name), "old").unwrap();
+        }
+        write_stamp(&dir.join(".stamp"), OLD_SHA, &old_manifest).unwrap();
+
+        // User files that must survive any swap.
+        fs::write(dir.join("notes.md"), "keep me").unwrap();
+        fs::write(dir.join("dictionary-custom.txt"), "user entries").unwrap();
+
+        // New snapshot fully staged.
+        let new_manifest: Vec<String> = ["dictionary00.txt", "id.def", "LICENSE"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let staging = dir.join(".staging");
+        fs::create_dir_all(&staging).unwrap();
+        for name in &new_manifest {
+            fs::write(staging.join(name), "new").unwrap();
+        }
+
+        (dir, staging, old_manifest, new_manifest)
+    }
+
+    /// Happy path of the transactional swap (Codex review R3 on PR #266):
+    /// old snapshot files go away — including a shard the new snapshot no
+    /// longer has — staged files land under their final names, the stamp
+    /// records the new SHA + manifest, staging is gone, user files survive.
+    #[test]
+    fn test_commit_staged_swaps_snapshots() {
+        let (dir, staging, old_manifest, new_manifest) = setup_swap_fixture("ok");
+        let stamp = dir.join(".stamp");
+
+        commit_staged(
+            &dir,
+            &stamp,
+            &staging,
+            &old_manifest,
+            NEW_SHA,
+            &new_manifest,
+        )
+        .unwrap();
+
+        for name in &new_manifest {
+            assert_eq!(fs::read_to_string(dir.join(name)).unwrap(), "new");
+        }
+        assert!(
+            !dir.join("dictionary09.txt").exists(),
+            "shard dropped upstream must not survive the swap"
+        );
+        assert!(!staging.exists(), "staging dir should be removed");
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.sha, NEW_SHA);
+        assert_eq!(st.manifest, new_manifest);
+        assert!(dir.join("notes.md").exists());
+        assert!(dir.join("dictionary-custom.txt").exists());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// If staging is missing any manifest file, the commit must fail BEFORE
+    /// touching dest: old snapshot files and the old stamp stay intact, so
+    /// the working cache (and the offline fallback) is never sacrificed to
+    /// an incomplete download.
+    #[test]
+    fn test_commit_staged_incomplete_staging_leaves_dest_untouched() {
+        let (dir, staging, old_manifest, new_manifest) = setup_swap_fixture("incomplete");
+        let stamp = dir.join(".stamp");
+        fs::remove_file(staging.join("id.def")).unwrap();
+
+        let result = commit_staged(
+            &dir,
+            &stamp,
+            &staging,
+            &old_manifest,
+            NEW_SHA,
+            &new_manifest,
+        );
+        assert!(result.is_err());
+
+        // Old snapshot untouched and still trusted.
+        for name in &old_manifest {
+            assert_eq!(fs::read_to_string(dir.join(name)).unwrap(), "old");
+        }
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.sha, OLD_SHA);
+        assert_eq!(st.manifest, old_manifest);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Legacy path: no old manifest (SHA-only stamp) → the wipe inside the
+    /// commit falls back to the upstream naming pattern. Old upstream-named
+    /// files are still replaced/removed and user files still survive.
+    #[test]
+    fn test_commit_staged_legacy_old_manifest() {
+        let (dir, staging, _old_manifest, new_manifest) = setup_swap_fixture("legacy");
+        let stamp = dir.join(".stamp");
+        // Downgrade to a legacy SHA-only stamp.
+        fs::write(&stamp, OLD_SHA).unwrap();
+
+        commit_staged(&dir, &stamp, &staging, &[], NEW_SHA, &new_manifest).unwrap();
+
+        for name in &new_manifest {
+            assert_eq!(fs::read_to_string(dir.join(name)).unwrap(), "new");
+        }
+        assert!(!dir.join("dictionary09.txt").exists());
+        assert!(dir.join("notes.md").exists());
+        assert!(dir.join("dictionary-custom.txt").exists());
+        let st = read_stamp(&stamp).unwrap();
+        assert_eq!(st.sha, NEW_SHA);
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -36,24 +36,25 @@ impl MozcSource {
         let url = format!("{MOZC_API_BASE}/commits/master");
         let body = ureq::get(&url)
             .call()
-            .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?
+            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?
             .into_body()
             .read_to_string()
-            .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?;
+            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?;
         parse_commit_sha(&body)
     }
 
     /// List dictionary files via GitHub Contents API **pinned to `sha`** and
-    /// return (name, download_url) pairs for `dictionary*.txt` and `id.def`.
+    /// return (name, download_url) pairs for the upstream-numbered shards
+    /// (`dictionary<digits>.txt`) and `id.def`.
     /// The returned `download_url`s point at the same pinned SHA.
     fn list_remote_files(sha: &str) -> Result<Vec<(String, String)>, DictSourceError> {
         let url = format!("{MOZC_API_BASE}/contents/src/data/dictionary_oss?ref={sha}");
         let body = ureq::get(&url)
             .call()
-            .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?
+            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?
             .into_body()
             .read_to_string()
-            .map_err(|e| DictSourceError::Http(format!("GitHub API: {e}")))?;
+            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?;
         parse_remote_files(&body)
     }
 }
@@ -240,7 +241,7 @@ fn write_stamp(path: &Path, sha: &str, manifest: &[String]) -> Result<(), DictSo
 }
 
 /// Parse GitHub Contents API JSON and return (name, download_url) pairs
-/// for `dictionary*.txt` and `id.def`.
+/// for the upstream-numbered shards (`dictionary<digits>.txt`) and `id.def`.
 fn parse_remote_files(json: &str) -> Result<Vec<(String, String)>, DictSourceError> {
     let entries: Vec<serde_json::Value> = serde_json::from_str(json)
         .map_err(|e| DictSourceError::Parse(format!("GitHub API JSON: {e}")))?;


### PR DESCRIPTION
## 背景

`MozcSource::fetch` のキャッシュ判定は「ファイルが存在すれば skip」で、`.stamp` は空マーカーだった。このため上流 (google/mozc master) 更新後にキャッシュの一部だけ欠けた状態で fetch すると、**id.def と dictionary*.txt が異なる上流スナップショットの混成**になり得た。id.def の並びが変わると品詞 ID が静かにずれ、変換品質がエラーなしで崩壊する。

さらに従来は全ファイルを `master` 直指定の URL から取得していたため、fetch 実行中に上流が更新されると **1 回の fetch 内でも混成し得た**。

## 変更内容

sudachi fetcher (`candidates/sudachi.rs`, PR #242) の stamp 規律「stamp = 上流バージョン完全一致、不一致なら全消し再取得」を mozc に移植:

- GitHub Commits API で master の最新 commit SHA を解決し、`.stamp` の記録 SHA と完全一致した場合のみキャッシュ有効
- 不一致 / stamp なし / legacy 空 stamp (取得物が残っている場合) → 取得物を全消しして再取得
- **全ダウンロードを解決済みの単一 SHA に固定** — Contents API は `?ref=<sha>`、connection matrix / LICENSE は `raw.githubusercontent.com/google/mozc/<sha>/...`。run 間・run 中どちらの混成も構造的に排除
- `.stamp` には SHA を記録。**全ファイル取得成功後にのみ書き込む**ため、非空 stamp = 完全なスナップショットという不変条件が成立 (中断された run は次回 wipe + 再取得で回復)
- オフライン時: SHA 解決に失敗しても完全なキャッシュ (非空 stamp) があれば警告して続行、なければエラー
- `parse_commit_sha` は 40 桁 hex を検証 (不正なレスポンスが URL や stamp に混入しない)

`mise.toml` の `fetch-dict-mozc` タスクとの整合: outputs は `engine/data/mozc-raw/.stamp` のままで変更不要 (stamp は成功時に毎回書き込まれ mtime が更新される)。

## テストプラン

- [x] `cargo test -p lex-cli` 全 52 件 pass (新規: `parse_commit_sha` 正常系/異常系、`read_stamp` roundtrip、stale-cache invariant、wipe が取得物のみ消し user ファイルを残すこと)
- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-features -- -D warnings` pass
- [x] 実 fetch 検証 (一時ディレクトリ):
  - 1 回目: commit `7c1e06d3` に固定して全 13 ファイル取得、`.stamp` に SHA 記録
  - 2 回目: stamp 一致 → 全ファイル "already exists, skipping"
  - stamp を偽 SHA に書き換え → "Cache commit ... != latest ...; wiping stale files." で全再取得
  - 中断された run (stamp なし + ファイル残存) → "Cache has no version stamp but files present; wiping." で全再取得して回復

🤖 Generated with [Claude Code](https://claude.com/claude-code)