### PR TITLE
chore(engine): mark all workspace crates as publish = false

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,6 +18,7 @@ name = "lex_engine"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+publish = false
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/engine/crates/lex-cli/Cargo.toml
+++ b/engine/crates/lex-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "lex-cli"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+publish = false
 
 [lib]
 name = "lex_cli"

--- a/engine/crates/lex-core/Cargo.toml
+++ b/engine/crates/lex-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "lex-core"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+publish = false
 
 [lib]
 name = "lex_core"

--- a/engine/crates/lex-session/Cargo.toml
+++ b/engine/crates/lex-session/Cargo.toml
@@ -3,6 +3,7 @@ name = "lex-session"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
+publish = false
 
 [lib]
 name = "lex_session"


### PR DESCRIPTION
## Summary

- Rust ワークスペースの全クレート (`lex_engine`, `lex-core`, `lex-session`, `lex-cli`) の `[package]` に `publish = false` を追加

## 背景

これらはすべて内部クレートで crates.io に公開しない。`publish = false` により:

- `cargo publish` の誤実行による誤公開を防止
- 「public API はワークスペース内部専用であり、breaking change は自由」であることを明文化

PR #267 の Copilot レビュー指摘 (public struct の breaking change 懸念) への恒久対応でもある。

## Test plan

- [x] `cargo check --workspace` が pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)