### PR TITLE
fix(core): reduce katakana_penalty to a tie-breaker (5000 -> 150)

### DIFF
--- a/engine/crates/lex-core/src/converter/tests/reranker.rs
+++ b/engine/crates/lex-core/src/converter/tests/reranker.rs
@@ -197,9 +197,11 @@ fn test_rerank_penalizes_uneven_segments() {
 
 #[test]
 fn test_rerank_applies_script_cost() {
-    // Katakana surface should receive +5000 penalty from script_cost
+    // All-katakana surfaces receive the katakana_penalty (default 150) from
+    // script_cost. Since #261 it is a tie-breaker: it decides near-ties in
+    // favor of hiragana but must not override a clear dictionary-cost lead.
     let mut paths = vec![
-        // Katakana path: タラ (katakana) → +5000 script penalty
+        // Katakana path: タラ (katakana) → +150 script penalty
         ScoredPath {
             segments: vec![RichSegment {
                 reading: "たら".into(),
@@ -211,7 +213,7 @@ fn test_rerank_applies_script_cost() {
             viterbi_cost: 3000,
             history_boost: 0,
         },
-        // Hiragana path: たら (no script penalty)
+        // Hiragana path: たら (no script penalty), raw cost 100 higher
         ScoredPath {
             segments: vec![RichSegment {
                 reading: "たら".into(),
@@ -220,20 +222,20 @@ fn test_rerank_applies_script_cost() {
                 right_id: 0,
                 word_cost: 0,
             }],
-            viterbi_cost: 7000,
+            viterbi_cost: 3100,
             history_boost: 0,
         },
     ];
 
     rerank(&mut paths, None, None);
 
-    // Katakana: 3000 + 5000 = 8000
-    // Hiragana: 7000 + 0    = 7000
-    // Hiragana should be ranked first
+    // Katakana: 3000 + 150 = 3150
+    // Hiragana: 3100 + 0   = 3100
+    // Hiragana wins the near-tie
     assert_eq!(paths[0].segments[0].surface, "たら");
-    assert_eq!(paths[0].viterbi_cost, 7000);
+    assert_eq!(paths[0].viterbi_cost, 3100);
     assert_eq!(paths[1].segments[0].surface, "タラ");
-    assert_eq!(paths[1].viterbi_cost, 8000);
+    assert_eq!(paths[1].viterbi_cost, 3150);
 }
 
 #[test]

--- a/engine/crates/lex-core/src/default_settings.toml
+++ b/engine/crates/lex-core/src/default_settings.toml
@@ -1,7 +1,12 @@
 [cost]
 segment_penalty = 5000
 mixed_script_bonus = 3000
-katakana_penalty = 5000
+# Tie-breaker only. Was 5000, which overrode the dictionary's own cost
+# ordering: in 9 of the 14 katakana misses mined in #261 the katakana path
+# had the lowest raw Viterbi cost and lost purely to this penalty (vs the
+# mixed-script bonus on the kanji competitor). 150 keeps hiragana ahead on
+# near-ties but lets the dictionary decide otherwise. Measurements: #261.
+katakana_penalty = 150
 pure_kanji_bonus = 1000
 latin_penalty = 20000
 unknown_word_cost = 10000

--- a/engine/crates/lex-core/src/settings.rs
+++ b/engine/crates/lex-core/src/settings.rs
@@ -314,7 +314,7 @@ mod tests {
         let s = parse_settings_toml(DEFAULT_SETTINGS_TOML).unwrap();
         assert_eq!(s.cost.segment_penalty, 5000);
         assert_eq!(s.cost.mixed_script_bonus, 3000);
-        assert_eq!(s.cost.katakana_penalty, 5000);
+        assert_eq!(s.cost.katakana_penalty, 150);
         assert_eq!(s.cost.pure_kanji_bonus, 1000);
         assert_eq!(s.cost.latin_penalty, 20000);
         assert_eq!(s.cost.unknown_word_cost, 10000);

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -714,18 +714,16 @@ reading = "ましん"
 expected = "マシン"
 category = "loanword"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#261"
-note = "麻しん が top-1、マシン は rank 5"
+note = "麻しん が top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "えんじん"
 expected = "エンジン"
 category = "loanword"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#261"
-note = "円陣 が top-1、エンジン は rank 6"
+note = "円陣 が top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "だめです"
@@ -741,18 +739,16 @@ reading = "ばぐを"
 expected = "バグを"
 category = "loanword"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#261"
-note = "馬具を が top-1"
+note = "馬具を が top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "ぱす"
 expected = "パス"
 category = "loanword"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#261"
-note = "ひらがな ぱす のままが top-1"
+note = "ひらがな ぱす のままが top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "まじで"
@@ -768,9 +764,8 @@ reading = "とれいと"
 expected = "トレイト"
 category = "loanword"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#261"
-note = "トレイと (トレイ+と) が top-1"
+note = "トレイと (トレイ+と) が top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "ねすてっど"
@@ -786,9 +781,8 @@ reading = "さいとりすと"
 expected = "サイトリスト"
 category = "loanword"
 tags = ["history-audit", "it", "compound"]
-skip = true
 issue = "#261"
-note = "再トリスト が top-1"
+note = "再トリスト が top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "すれ"
@@ -813,18 +807,16 @@ reading = "どる"
 expected = "ドル"
 category = "loanword"
 tags = ["history-audit"]
-skip = true
 issue = "#261"
-note = "取る が top-1 (読み不一致)、ドル は rank 4"
+note = "取る (連濁読みエントリ) が top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "ぷろだくしょんに"
 expected = "プロダクションに"
 category = "loanword"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#261"
-note = "ひらがなのままが top-1"
+note = "ひらがなのままが top-1 だった。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "はいつ"
@@ -993,9 +985,8 @@ reading = "こえたふぁいるはありませんか"
 expected = "超えたファイルはありませんか"
 category = "phrase"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#263"
-note = "超え他ファイルはありませんか と 他 が混入"
+note = "超え他ファイル と 他 が混入していた。katakana_penalty 5000→150 で fix"
 
 [[cases]]
 reading = "にしたほうがいい"
@@ -1041,3 +1032,29 @@ tags = ["history-audit", "it", "suffix-loanword"]
 skip = true
 issue = "#263"
 note = "レビュー死に が top-1。外来語+時 の複合が組めない"
+
+# ── katakana policy guards (#261: katakana_penalty 5000→150) ──
+# 現代慣用でカタカナ表記が標準の語は penalty 縮小後にカタカナが top-1。
+# かっこ→カッコ は設計判断 (履歴 1 回で 括弧 に戻る) として許容を明文化。
+
+[[cases]]
+reading = "めも"
+expected = "メモ"
+category = "loanword"
+tags = ["katakana-policy"]
+issue = "#261"
+
+[[cases]]
+reading = "ぺん"
+expected = "ペン"
+category = "loanword"
+tags = ["katakana-policy"]
+issue = "#261"
+
+[[cases]]
+reading = "かっこ"
+expected = "カッコ"
+category = "loanword"
+tags = ["katakana-policy"]
+issue = "#261"
+note = "設計判断: 括弧 rank 2 を許容 (#261 Q1)。漢字が欲しい場合は履歴学習で flip"


### PR DESCRIPTION
## Summary

#261 の Fix 1。max-effort 診断 (lextool explain / dictool 実測 + 反実仮想検証) の結果、カタカナ語ミス 14 件のうち **9 件は期待パスが raw Viterbi で全候補最安**（例: マシン 10336 vs 麻しん 12578）なのに、一律 +5000 の katakana penalty と相手側 mixed-script bonus (-2000) の最大 7000/segment スイングが rerank で逆転させていることが判明。辞書のコスト序列を script feature が上書きする構造だった。

`katakana_penalty` を **5000 → 150** に変更し、「完全同点近傍でひらがなを優先するタイブレーク」に格下げする。

- 設計判断（ユーザー確認済み）: かっこ→カッコ の flip を許容（括弧 は rank 2、履歴 1 回で戻る）。corpus ケースとして明文化
- ガードケース追加: めも→メモ、ぺん→ペン、かっこ→カッコ（katakana-policy タグ）
- 旧値前提だった `test_rerank_applies_script_cost` をタイブレーク挙動の検証に更新

## Accuracy before/after

| | before | after |
|---|---|---|
| accuracy total | 131 | 134 (+3 guards) |
| pass | 93 | **105** (+9 flips +3 guards) |
| fail | 0 | 0 |
| skip | 38 | 29 |
| pass rate | 100.0% | 100.0% |
| accuracy-history | 7/7 | 7/7 (baseline 無傷) |

**flip した 9 件** (#261/#263): ましん→マシン、えんじん→エンジン、ばぐを→バグを、ぱす→パス、とれいと→トレイト、さいとりすと→サイトリスト、どる→ドル、ぷろだくしょんに→プロダクションに、こえたふぁいるはありませんか→超えたファイルはありませんか

**順位改善（top-1 未達、skip 継続）**: だめです 5→3、まじで 7→3、すれ 11→3、ずれ 4→2、はいつ 9→4

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-features -- -D warnings` pass
- [x] `cargo test --workspace --all-features` 全 pass
- [x] `mise run accuracy` 105/105 (0 fail)、`mise run accuracy-history` 7/7 — before/after 上表
- [x] 同音カタカナ語スイープ（診断時）: めも/ぺん/こーひー/がらす 等は現代慣用方向の改善のみ、争点は かっこ のみ（許容決定済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)