### PR TITLE
fix(core): keep identity paths selectable for history rescue

### DIFF
--- a/engine/crates/lex-core/src/converter/reranker.rs
+++ b/engine/crates/lex-core/src/converter/reranker.rs
@@ -66,8 +66,13 @@ pub fn rerank(
     let mut kept_sc: Vec<i64> = Vec::new();
     {
         let mut i = 0;
-        paths.retain(|_| {
-            let keep = structure_costs[i] <= threshold;
+        paths.retain(|p| {
+            // Identity paths (surface == reading throughout) are exempt: they
+            // are the user's typed input and must stay selectable so history
+            // learning can rescue readings the cost model gets wrong (#263).
+            // Their fragmented FW chains otherwise trip the structure filter.
+            let identity = p.segments.iter().all(|s| s.surface == s.reading);
+            let keep = identity || structure_costs[i] <= threshold;
             if keep {
                 kept_sc.push(structure_costs[i]);
             }

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -52,9 +52,21 @@ pub(crate) fn run_rewriters(
     for rw in rewriters {
         let candidates = rw.generate(paths, reading);
         for candidate in candidates {
-            if seen.insert(candidate.surface_key()) {
+            let key = candidate.surface_key();
+            if seen.insert(key.clone()) {
                 let pos = paths.partition_point(|p| p.viterbi_cost < candidate.viterbi_cost);
                 paths.insert(pos, candidate);
+            } else if let Some(i) = paths.iter().position(|p| p.surface_key() == key) {
+                // Same surface already in the list (e.g. a retained identity
+                // path) at a worse cost: reprice it to the rewriter's cost so
+                // the surface ranks where the fallback intended, keeping the
+                // real path's segments for per-segment history recording.
+                if candidate.viterbi_cost < paths[i].viterbi_cost {
+                    let mut existing = paths.remove(i);
+                    existing.viterbi_cost = candidate.viterbi_cost;
+                    let pos = paths.partition_point(|p| p.viterbi_cost < existing.viterbi_cost);
+                    paths.insert(pos, existing);
+                }
             }
         }
     }
@@ -131,14 +143,12 @@ pub(crate) struct PartialHiraganaRewriter;
 
 impl Rewriter for PartialHiraganaRewriter {
     fn generate(&self, paths: &[ScoredPath], _reading: &str) -> Vec<ScoredPath> {
-        let source_count = paths.len().min(5);
         let mut new_paths = Vec::new();
 
-        for path in paths.iter().take(source_count) {
-            if path.segments.len() <= 1 {
-                continue;
-            }
-
+        // Select the 5 cheapest multi-segment paths BEFORE limiting: injected
+        // single-segment fallbacks (e.g. HiraganaVariantRewriter at best+4000)
+        // sort into the top 5 and must not displace a real source path.
+        for path in paths.iter().filter(|p| p.segments.len() > 1).take(5) {
             for seg_idx in 0..path.segments.len() {
                 let seg = &path.segments[seg_idx];
                 if seg.surface == seg.reading || seg.surface.chars().all(is_katakana) {

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -58,12 +58,20 @@ pub(crate) fn run_rewriters(
                 paths.insert(pos, candidate);
             } else if let Some(i) = paths.iter().position(|p| p.surface_key() == key) {
                 // Same surface already in the list (e.g. a retained identity
-                // path) at a worse cost: reprice it to the rewriter's cost so
-                // the surface ranks where the fallback intended, keeping the
-                // real path's segments for per-segment history recording.
+                // path) at a worse cost: adopt the cheaper rewriter price so
+                // the surface ranks where the fallback intended. Keep the
+                // richer segmentation of the two (a real multi-segment path
+                // beats a synthetic single) so committing it records
+                // per-segment history. The adopted price is synthetic and
+                // un-boosted, so any stale whole-path boost is cleared.
                 if candidate.viterbi_cost < paths[i].viterbi_cost {
                     let mut existing = paths.remove(i);
-                    existing.viterbi_cost = candidate.viterbi_cost;
+                    if candidate.segments.len() > existing.segments.len() {
+                        existing = candidate;
+                    } else {
+                        existing.viterbi_cost = candidate.viterbi_cost;
+                        existing.history_boost = 0;
+                    }
                     let pos = paths.partition_point(|p| p.viterbi_cost < existing.viterbi_cost);
                     paths.insert(pos, existing);
                 }
@@ -145,10 +153,20 @@ impl Rewriter for PartialHiraganaRewriter {
     fn generate(&self, paths: &[ScoredPath], _reading: &str) -> Vec<ScoredPath> {
         let mut new_paths = Vec::new();
 
-        // Select the 5 cheapest multi-segment paths BEFORE limiting: injected
-        // single-segment fallbacks (e.g. HiraganaVariantRewriter at best+4000)
-        // sort into the top 5 and must not displace a real source path.
-        for path in paths.iter().filter(|p| p.segments.len() > 1).take(5) {
+        // Select the 5 cheapest paths that can actually yield variants BEFORE
+        // limiting: injected single-segment fallbacks and repriced identity
+        // paths (no replaceable segment) sort into the top 5 and must not
+        // displace a real kanji-bearing source path.
+        for path in paths
+            .iter()
+            .filter(|p| {
+                p.segments.len() > 1
+                    && p.segments
+                        .iter()
+                        .any(|s| s.surface != s.reading && !s.surface.chars().all(is_katakana))
+            })
+            .take(5)
+        {
             for seg_idx in 0..path.segments.len() {
                 let seg = &path.segments[seg_idx];
                 if seg.surface == seg.reading || seg.surface.chars().all(is_katakana) {

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -110,11 +110,15 @@ impl Rewriter for HiraganaVariantRewriter {
             return Vec::new();
         }
 
-        let wc = worst_cost(paths);
+        // Anchor to the BEST path, not the worst: the kana variant is the
+        // rescue candidate when the cost model kanjifies wrongly (#263), so
+        // it must land mid-list where it is visible and history-boostable.
+        // Bottom-anchored (worst+5000) it could never be reached once the
+        // n-best filled with 20 lattice paths.
         vec![ScoredPath::single(
             combined_reading,
             combined_surface,
-            wc.saturating_add(5000),
+            best.viterbi_cost.saturating_add(4000),
         )]
     }
 }

--- a/engine/crates/lex-core/src/converter/rewriter.rs
+++ b/engine/crates/lex-core/src/converter/rewriter.rs
@@ -118,7 +118,7 @@ impl Rewriter for HiraganaVariantRewriter {
         vec![ScoredPath::single(
             combined_reading,
             combined_surface,
-            best.viterbi_cost.saturating_add(4000),
+            best.pre_history_cost().saturating_add(4000),
         )]
     }
 }

--- a/engine/crates/lex-core/src/converter/tests/rewriter/hiragana_variant.rs
+++ b/engine/crates/lex-core/src/converter/tests/rewriter/hiragana_variant.rs
@@ -43,7 +43,8 @@ fn test_hiragana_variant_replaces_kanji() {
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].surface_key(), "リダイレクトされますか");
-    assert_eq!(result[0].viterbi_cost, 3000 + 5000);
+    // Anchored to the best path (+4000), not the worst (#263)
+    assert_eq!(result[0].viterbi_cost, 3000 + 4000);
 }
 
 #[test]

--- a/engine/crates/lex-core/src/converter/tune.rs
+++ b/engine/crates/lex-core/src/converter/tune.rs
@@ -186,7 +186,12 @@ fn hard_filter(paired: &mut Vec<(ScoredPath, PathFeatures)>, prefix_floor: i64, 
         .unwrap_or(0);
     let threshold = min_sc + filter;
 
-    paired.retain(|(_, f)| f.structure_cost <= threshold);
+    // Identity paths (surface == reading throughout) are exempt, mirroring
+    // the production filter in reranker step 2 (#263) — the tuner must
+    // optimize against the same candidate set production keeps.
+    paired.retain(|(p, f)| {
+        p.segments.iter().all(|s| s.surface == s.reading) || f.structure_cost <= threshold
+    });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#263 診断の Fix 3（可用性 fix、top-1 の変更なし）。「ユーザーが打った通りのひらがな」が候補リストから構造的に消えるのを防ぐ:

1. **reranker**: identity パス（全 segment で surface == reading）を structure_cost hard filter の対象外に。機能語連鎖の identity は filter に引っかかりやすく、したんでしたっけ は候補から完全に消えていた。候補に無いものは履歴学習（設計上の救済機構）でも救えない
2. **HiraganaVariantRewriter**: fallback の価格を worst+5000 → **best+4000** に変更。最下位アンカーだと n-best が 20 本埋まった時点で永遠に届かない位置だった

## 検証

- **top-1 不変**: accuracy 107/107 (0 fail)、accuracy-history 7/7、baseline 無傷
- **可用性**: identity 候補が したんでしたっけ 圏外→**rank 7**、しそうです 圏外→rank 15
- **救済の実証**: 履歴 2 回の学習で 紫檀でしたっけ → したんでしたっけ に flip することを確認（修正前は filter 除去のため履歴でも不可能だった）

これで #263 の残ケース（しそうです・したんでしたっけ 等の Viterbi 層構造問題）は「履歴で救える」状態になり、Fix 6 で history corpus に baseline 付き移管する準備が整う。

## Test plan

- [x] `cargo fmt` / `clippy -D warnings` / `cargo test --workspace --all-features` 全 pass（rewriter テストは新アンカー値に更新）
- [x] `mise run accuracy` 107/107、`mise run accuracy-history` 7/7 — before/after 完全一致（意図通り）
- [x] identity rank と履歴救済の動作確認（上記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)