### PR TITLE
fix: remove unbounded committed_context accumulation

### DIFF
--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -101,9 +101,6 @@ impl InputSession {
         // Include prefix in the committed text
         let committed_text = format!("{}{}", prefix_text, committed_surface);
 
-        // Accumulate committed text for context
-        self.committed_context.push_str(&committed_text);
-
         let mut resp = KeyResponse::consumed();
         resp.commit = Some(committed_text);
 

--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -14,11 +14,6 @@ impl InputSession {
             });
         }
 
-        // Accumulate committed text for context
-        if let Some(ref committed) = resp.commit {
-            self.committed_context.push_str(committed);
-        }
-
         self.reset_state();
         resp
     }
@@ -53,11 +48,6 @@ impl InputSession {
                     text: String::new(),
                 });
             }
-        }
-
-        // Accumulate committed text for context
-        if let Some(ref committed) = resp.commit {
-            self.committed_context.push_str(committed);
         }
 
         self.reset_state();

--- a/engine/crates/lex-session/src/key_handlers.rs
+++ b/engine/crates/lex-session/src/key_handlers.rs
@@ -88,7 +88,6 @@ impl InputSession {
             // Falls back to direct commit if the text isn't handled by trie/romaji (e.g. \ in idle).
             KeyEvent::Remapped { text, .. } => {
                 if self.abc_passthrough {
-                    self.committed_context.push_str(&text);
                     let mut r = KeyResponse::consumed();
                     r.commit = Some(text);
                     r
@@ -100,7 +99,6 @@ impl InputSession {
                         r
                     } else {
                         // Not handled by trie/romaji (e.g. \) — commit directly
-                        self.committed_context.push_str(&text);
                         let mut r = KeyResponse::consumed();
                         r.commit = Some(text);
                         r
@@ -110,7 +108,6 @@ impl InputSession {
 
             // ABC passthrough: Space is printable but comes as KeyEvent::Space, not Text.
             KeyEvent::Space if self.abc_passthrough => {
-                self.committed_context.push(' ');
                 let mut r = KeyResponse::consumed();
                 r.commit = Some(" ".to_string());
                 r
@@ -120,10 +117,8 @@ impl InputSession {
             // Text and special keys in ABC mode.
             KeyEvent::Text { ref text, .. } if self.abc_passthrough => match text.chars().next() {
                 Some(c) if (' '..='~').contains(&c) => {
-                    let text = text.clone();
-                    self.committed_context.push_str(&text);
                     let mut r = KeyResponse::consumed();
-                    r.commit = Some(text);
+                    r.commit = Some(text.clone());
                     r
                 }
                 _ => KeyResponse::not_consumed(),

--- a/engine/crates/lex-session/src/lib.rs
+++ b/engine/crates/lex-session/src/lib.rs
@@ -64,9 +64,6 @@ pub struct InputSession {
     /// ABC passthrough mode: all keys pass through to app, except Kana.
     abc_passthrough: bool,
 
-    // Accumulated committed text (conversion context)
-    committed_context: String,
-
     snippet_store: Option<Arc<SnippetStore>>,
 }
 
@@ -89,7 +86,6 @@ impl InputSession {
             lattice_cache: LatticeCache::new(),
             history_records: Vec::new(),
             abc_passthrough: false,
-            committed_context: String::new(),
             snippet_store: None,
         }
     }
@@ -176,10 +172,5 @@ impl InputSession {
     /// The caller should feed these to `UserHistory::record()`.
     pub fn take_history_records(&mut self) -> Vec<LearningRecord> {
         std::mem::take(&mut self.history_records)
-    }
-
-    /// Get the accumulated committed text (conversion context).
-    pub fn committed_context(&self) -> String {
-        self.committed_context.clone()
     }
 }

--- a/engine/crates/lex-session/src/snippet_handler.rs
+++ b/engine/crates/lex-session/src/snippet_handler.rs
@@ -139,7 +139,6 @@ impl InputSession {
 
         let (_key, body) = s.matches[s.selected].clone();
 
-        self.committed_context.push_str(&body);
         self.reset_state();
 
         let mut resp = KeyResponse::consumed().with_hide_candidates();


### PR DESCRIPTION
## 概要

アーキテクチャレビュー指摘の対応。`InputSession::committed_context` (engine/crates/lex-session/src/lib.rs) はセッション寿命の間、ABC パススルー入力を含む全確定テキストを無制限に蓄積し続けていた。IME としてプロセスメモリに全入力履歴を保持するのはプライバシー露出であり、メモリも単調増加する。

## 選択した方針: 削除 (YAGNI)

truncate (リングバッファ化) ではなく**フィールドごと削除**を選択した。理由:

- **読者ゼロ**: getter `committed_context()` は FFI (lex_engine) 未輸出、Swift 側にも参照なし、エンジン内・テスト内の消費者もなし (`committed_context()` / `committedContext` の grep で 0 件)
- **元の消費者は削除済み**: ghost text 機能 (a605bd1 で全削除) が本来の用途。「将来の neural scoring 用に retain」とされていたが、その後 neural scoring は lex-cli の dictool に CLI 引数で context を渡す形でのみ実装され、lex-session からの利用は生まれていない (lex-session に neural 参照なし)
- **直近の変更でも消費者なし**: #267 (session epoch) 以降を含む現 main で確認済み

将来変換コンテキストが必要になった場合は、その時点で明示的な長さ上限付きで再導入すればよい。

## 変更内容

- `committed_context` フィールド・初期化・getter を削除 (lib.rs)
- push 箇所 7 件を削除: commit.rs ×2 / auto_commit.rs ×1 / key_handlers.rs ×3 / snippet_handler.rs ×1

ネット -28 行。挙動変化なし (書き込み専用バッファの除去のみ)。

## テスト

- [x] `cargo fmt --all --check` pass
- [x] `cargo clippy --workspace --all-features -- -D warnings` pass
- [x] `cargo test -p lex-session --features trace` — 79 passed, 0 failed
- [x] `cargo test --workspace --all-features` — 全 pass (lex-core 356, lex-session 79 ほか)

🤖 Generated with [Claude Code](https://claude.com/claude-code)