### PR TITLE
ci: run conversion accuracy tests with cached mozc snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       session: ${{ steps.filter.outputs.session }}
       ffi: ${{ steps.filter.outputs.ffi }}
       cli: ${{ steps.filter.outputs.cli }}
+      corpus: ${{ steps.filter.outputs.corpus }}
       swift: ${{ steps.filter.outputs.swift }}
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +44,9 @@ jobs:
               - 'engine/src/**'
             cli:
               - 'engine/crates/lex-cli/**'
+            corpus:
+              - 'engine/testcorpus/**'
+              - 'mise.toml'
             swift:
               - 'Sources/**'
               - 'Tests/**'
@@ -162,6 +166,79 @@ jobs:
           shared-key: engine
 
       - run: cd engine && cargo test -p lex-cli
+
+  # Conversion accuracy gate: builds the full dictionary (Mozc snapshot +
+  # bundled symbols/extras) and runs both accuracy corpora. The Mozc raw
+  # snapshot (~90MB of TSVs) is kept in the actions cache; the dictool fetch
+  # stamp (commit SHA + manifest, PR #266) decides on every run whether the
+  # cached snapshot is still current, repairs it, or re-downloads a new
+  # upstream snapshot — so a stale cache entry can never poison the dict.
+  # `needs: changes` only (not lint): a corpus-only change must not be
+  # skipped just because the Rust lint job didn't run.
+  accuracy:
+    needs: changes
+    if: >-
+      needs.changes.outputs.core == 'true' ||
+      needs.changes.outputs.cli == 'true' ||
+      needs.changes.outputs.corpus == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Separate shared-key: this job builds the release profile (dictool /
+      # lextool), which the debug-profile `engine` cache never contains.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine -> target
+          shared-key: accuracy
+
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      # Restore/save split keyed on the pinned upstream commit SHA (line 1 of
+      # dictool's .stamp): exactly one cache entry per upstream Mozc snapshot.
+      # The `key` never matches an existing entry directly — restore-keys
+      # picks up the newest snapshot — and the save step below only fires
+      # when the post-fetch SHA differs from what was restored (first run, or
+      # upstream moved). The stamp mechanism makes a stale restore safe:
+      # dictool verifies the restored snapshot against upstream on every run
+      # (fast path: one Commits API call) and transactionally re-downloads
+      # when it no longer matches, so a stale cache can never poison the dict.
+      - name: Restore Mozc dictionary snapshot
+        id: mozc-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: engine/data/mozc-raw
+          key: mozc-raw-
+          restore-keys: |
+            mozc-raw-
+
+      # GITHUB_TOKEN: Actions runners share the anonymous GitHub API quota
+      # (60 req/h per IP), which is effectively always exhausted. dictool
+      # attaches the token to api.github.com requests when set.
+      - name: Run accuracy corpus
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: mise run accuracy
+
+      - name: Run accuracy-history corpus
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: mise run accuracy-history
+
+      - name: Read fetched Mozc snapshot version
+        id: mozc-stamp
+        run: echo "key=mozc-raw-$(head -n1 engine/data/mozc-raw/.stamp)" >> "$GITHUB_OUTPUT"
+
+      - name: Save Mozc dictionary snapshot
+        if: steps.mozc-stamp.outputs.key != steps.mozc-restore.outputs.cache-matched-key
+        uses: actions/cache/save@v4
+        with:
+          path: engine/data/mozc-raw
+          key: ${{ steps.mozc-stamp.outputs.key }}
 
   audit:
     needs: changes

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -90,18 +90,32 @@ impl MozcSource {
         Ok(())
     }
 
+    /// GET an api.github.com URL and return the response body. Unlike the
+    /// raw-file downloads (`download_file`), API requests count against the
+    /// GitHub API rate limit — 60 req/h anonymous per IP, which is
+    /// effectively always exhausted on shared CI runner IPs — so when the
+    /// conventional `GITHUB_TOKEN` env var is set, it is attached as a
+    /// bearer token (5000 req/h). The token is deliberately NOT sent with
+    /// raw.githubusercontent.com downloads: they are not API-rate-limited,
+    /// and the credential should touch as few endpoints as possible.
+    fn api_get(url: &str) -> Result<String, DictSourceError> {
+        let mut req = ureq::get(url);
+        if let Some(auth) = github_auth_header(std::env::var("GITHUB_TOKEN").ok().as_deref()) {
+            req = req.header("Authorization", &auth);
+        }
+        req.call()
+            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?
+            .into_body()
+            .read_to_string()
+            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))
+    }
+
     /// Resolve the latest commit SHA of `master` via the GitHub Commits API.
     /// All raw-file downloads in a fetch run are pinned to this single SHA so
     /// the cached snapshot can never mix files from two upstream states.
     fn latest_commit_sha() -> Result<String, DictSourceError> {
         let url = format!("{MOZC_API_BASE}/commits/master");
-        let body = ureq::get(&url)
-            .call()
-            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?
-            .into_body()
-            .read_to_string()
-            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?;
-        parse_commit_sha(&body)
+        parse_commit_sha(&Self::api_get(&url)?)
     }
 
     /// List dictionary files via GitHub Contents API **pinned to `sha`** and
@@ -110,14 +124,18 @@ impl MozcSource {
     /// The returned `download_url`s point at the same pinned SHA.
     fn list_remote_files(sha: &str) -> Result<Vec<(String, String)>, DictSourceError> {
         let url = format!("{MOZC_API_BASE}/contents/src/data/dictionary_oss?ref={sha}");
-        let body = ureq::get(&url)
-            .call()
-            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?
-            .into_body()
-            .read_to_string()
-            .map_err(|e| DictSourceError::Http(format!("{url}: {e}")))?;
-        parse_remote_files(&body)
+        parse_remote_files(&Self::api_get(&url)?)
     }
+}
+
+/// `Authorization` header value for GitHub API requests, derived from the
+/// raw `GITHUB_TOKEN` environment value. `None` (unset) and blank values —
+/// e.g. `GITHUB_TOKEN=""` in a CI step that clears it — mean "anonymous";
+/// surrounding whitespace is trimmed so a stray newline from `$(cmd)`
+/// substitution cannot corrupt the header.
+fn github_auth_header(token: Option<&str>) -> Option<String> {
+    let token = token?.trim();
+    (!token.is_empty()).then(|| format!("Bearer {token}"))
 }
 
 /// Removes the staged temp file on drop so error paths don't leak it. After
@@ -747,6 +765,25 @@ mod tests {
         // Right length, non-hex
         assert!(!is_valid_sha("0123456789abcdef0123456789abcdef0123456z"));
         assert!(!is_valid_sha("../../../../../../../../../../../../etc/x"));
+    }
+
+    #[test]
+    fn test_github_auth_header() {
+        // Unset → anonymous.
+        assert_eq!(github_auth_header(None), None);
+        // Blank / whitespace-only (e.g. `GITHUB_TOKEN=""` in CI) → anonymous.
+        assert_eq!(github_auth_header(Some("")), None);
+        assert_eq!(github_auth_header(Some("  \n")), None);
+        // Set → bearer token, with surrounding whitespace trimmed so a stray
+        // newline from shell substitution cannot corrupt the header.
+        assert_eq!(
+            github_auth_header(Some("ghs_abc123")).as_deref(),
+            Some("Bearer ghs_abc123")
+        );
+        assert_eq!(
+            github_auth_header(Some(" ghs_abc123\n")).as_deref(),
+            Some("Bearer ghs_abc123")
+        );
     }
 
     #[test]

--- a/engine/testcorpus/accuracy-corpus-history.toml
+++ b/engine/testcorpus/accuracy-corpus-history.toml
@@ -137,8 +137,8 @@ note = "1-char variance exclusion により baseline が質問した に改善; 
 [[cases]]
 reading = "おねがいします"
 expected = "お願いします"
-baseline = "おねがいします"
+baseline = "お願いします"
 category = "regression"
 tags = ["history", "whole-path", "rewriter"]
-note = "学習済み お願いします が候補上位に出る。以前は history_rerank 後の KanjiVariantRewriter が boost 済みひらがなパスから漢字バリアントを量産し、その継承コストで お願いします を2ページ目に押し下げていた (pre_history_cost で修正)"
+note = "学習済み お願いします が候補上位に出る。以前は history_rerank 後の KanjiVariantRewriter が boost 済みひらがなパスから漢字バリアントを量産し、その継承コストで お願いします を2ページ目に押し下げていた (pre_history_cost で修正)。baseline は Mozc 2026-07 スナップショットのコスト変更で おねがいします → お願いします に変化 (#273)"
 pr = "#248"

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -271,7 +271,9 @@ reading = "したほうがいい"
 expected = "したほうが良い"
 category = "regression"
 tags = ["partial-hiragana"]
-note = "した方がいい は PartialHiraganaRewriter で生成されるが history boost なしでは top-1 にならない"
+skip = true
+issue = "#273"
+note = "した方がいい は PartialHiraganaRewriter で生成されるが history boost なしでは top-1 にならない。Mozc 2026-07 スナップショットで 下ほうが良い が top-1 に drift"
 
 [[cases]]
 reading = "どれ"
@@ -457,6 +459,9 @@ reading = "しかかり"
 expected = "仕掛"
 category = "extras"
 tags = ["it", "business"]
+skip = true
+issue = "#273"
+note = "Mozc 2026-07 スナップショットで しか借り が top-1 に drift"
 
 [[cases]]
 reading = "たんじゃお"
@@ -469,6 +474,9 @@ reading = "ほわじゃお"
 expected = "花椒"
 category = "extras"
 tags = ["food", "domain-reading"]
+skip = true
+issue = "#273"
+note = "Mozc 2026-07 スナップショットで ホワジャオ が top-1 に drift (cost-conflict 校正が旧スナップショット前提)"
 
 [[cases]]
 reading = "いっぽどう"
@@ -504,7 +512,9 @@ reading = "えいろく"
 expected = "永禄"
 category = "extras"
 tags = ["history", "era"]
-note = "Mozc top-1 は 栄禄 (obscure)。Wikipedia corpus mining で発見"
+skip = true
+issue = "#273"
+note = "Mozc top-1 は 栄禄 (obscure)。Wikipedia corpus mining で発見。Mozc 2026-07 スナップショットで 栄禄 が再び top-1 に drift"
 
 [[cases]]
 reading = "じゅごい"
@@ -714,8 +724,9 @@ reading = "ましん"
 expected = "マシン"
 category = "loanword"
 tags = ["history-audit", "it"]
-issue = "#261"
-note = "麻しん が top-1 だった。katakana_penalty 5000→150 で fix"
+skip = true
+issue = "#273"
+note = "麻しん が top-1 だった。katakana_penalty 5000→150 で fix (#261)。Mozc 2026-07 スナップショットのコスト変更で 麻しん に再 drift (tie-breaker 150 が旧コスト前提)"
 
 [[cases]]
 reading = "えんじん"
@@ -1054,5 +1065,6 @@ reading = "かっこ"
 expected = "カッコ"
 category = "loanword"
 tags = ["katakana-policy"]
-issue = "#261"
-note = "設計判断: 括弧 rank 2 を許容 (#261 Q1)。漢字が欲しい場合は履歴学習で flip"
+skip = true
+issue = "#273"
+note = "設計判断: 括弧 rank 2 を許容 (#261 Q1)。漢字が欲しい場合は履歴学習で flip。Mozc 2026-07 スナップショットのコスト変更で 括弧 が top-1 に drift"


### PR DESCRIPTION
## 概要

プロジェクトで最も重要な回帰スイートである変換精度テスト (`mise run accuracy` / `mise run accuracy-history`) を CI に組み込む。辞書ビルドに Mozc の fetch (~90MB) が必要なため見送られていたが、#266 で fetch が commit SHA ピン + `.stamp` (SHA + マニフェスト) 化されキャッシュが安全になったため導入する。

## 設計

### accuracy ジョブ (ubuntu-latest)

- **発火条件**: `core || cli || corpus` (changes フィルタに `corpus: engine/testcorpus/** + mise.toml` を追加)
- **`needs: changes` のみ** (lint に依存させない): corpus-only 変更では lint が skip され、needs 連鎖で accuracy まで skip されてしまうため
- **rust-cache**: release プロファイル (dictool / lextool) を使うため `shared-key: accuracy` を分離。debug 用 `engine` キャッシュとの相互汚染を避ける

### Mozc スナップショットのキャッシュ戦略

`actions/cache` の restore/save 分割で `engine/data/mozc-raw` をキャッシュする。

- **restore**: `restore-keys: mozc-raw-` prefix で最新エントリを復元
- **save**: 実行後に `.stamp` 1 行目の上流 commit SHA を読み、`mozc-raw-<sha>` キーで保存。**restore したキーと一致する場合は保存しない** → 上流スナップショットごとに 1 エントリのみで、毎 run ~90MB を保存してリポジトリの 10GB キャッシュ枠 (rust-cache 含む) を churn しない
- **stale restore の安全性**: dictool の stamp 機構 (#266) が毎回上流と照合する。最新なら Commits API 1 回の fast path で検証のみ、上流が動いていれば staging 経由でトランザクショナルに新スナップショットへ差し替え。古いキャッシュが辞書を汚染することはない
- **mise の staleness**: tar が復元する `.stamp` の mtime は保存時点 (checkout した sources より古い) ため、`fetch-dict-mozc` タスクは CI では常に実行され、dictool が検証を担う。`lexime.dict` / `lexime.conn` はキャッシュせず毎回 compile (数十秒)

### GitHub API rate limit 対応

fetch の Commits / Contents API は非認証 ureq で、Actions ランナーの共有 IP では匿名枠 (60 req/h/IP) が事実上常に枯渇している。対応として:

- **dictool 改修 (最小限)**: `GITHUB_TOKEN` 環境変数が設定されていれば `api.github.com` へのリクエストに `Authorization: Bearer` を付ける (5000 req/h)。`raw.githubusercontent.com` のダウンロードは API rate limit 対象外のため、資格情報は意図的に送らない。空値は匿名扱い・前後空白 trim。単体テスト追加
- CI ジョブは `GITHUB_TOKEN: ${{ github.token }}` を渡す
- 多重防御: 万一 rate limit に当たっても、キャッシュが完全なら dictool の offline fallback が警告付きでキャッシュを使用するため CI は落ちない

### コーパスの上流 drift 再調整 (副次的発見)

ローカルの mozc-raw は 2026-02-21 取得で、最新上流スナップショット (`7c1e06d3`) では辞書コスト・エントリ変更により **6 ケースが fail、history baseline 1 件がずれていた** (まさにこの CI が検出すべき事象)。CLAUDE.md の運用ルールに従い:

- 6 ケース (しかかり / ほわじゃお / えいろく / ましん / かっこ / したほうがいい) を skip + issue #273 リンクに変更。再調整は #273 で追跡
- おねがいします の baseline を お願いします に更新

## テストプラン

- [x] `mise run accuracy` — Pass 101 / Fail 0 / Skip 33 (pass rate 100%)
- [x] `mise run accuracy-history` — Pass 7 / Fail 0 (pass rate 100%)
- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo test -p lex-cli` (64 passed、`github_auth_header` の単体テスト含む)
- [x] ci.yml を ruby -ryaml で構文検証
- [ ] この PR 自体の CI で accuracy ジョブが発火し pass すること (cli + corpus 変更で発火条件を満たす)

🤖 Generated with [Claude Code](https://claude.com/claude-code)