### PR TITLE
feat(dict): Mozc スナップショットの決定論的 SHA ピン留め

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,9 @@ jobs:
         with:
           install: false
 
-      # Restore/save split keyed on the content of the pin file: exactly one
-      # cache entry per pinned Mozc snapshot. On an exact hit, dictool's
+      # Restore/save split keyed on the pinned SHA itself (not a hash of the
+      # whole pin file, so comment-only edits don't churn cache entries):
+      # exactly one cache entry per pinned Mozc snapshot. On an exact hit, dictool's
       # stamp check confirms the restored snapshot matches the pin without a
       # single network call. On a pin bump the exact key misses and
       # restore-keys falls back to the newest previous snapshot, which
@@ -212,12 +213,16 @@ jobs:
       # the stamp mechanism (PR #266) makes any stale restore safe. The save
       # step below only fires on that exact-key miss (first run, or the pin
       # changed).
+      - name: Read pinned Mozc SHA
+        id: mozc-pin
+        run: echo "sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
       - name: Restore Mozc dictionary snapshot
         id: mozc-restore
         uses: actions/cache/restore@v4
         with:
           path: engine/data/mozc-raw
-          key: mozc-raw-${{ hashFiles('engine/data/mozc-pin.txt') }}
+          key: mozc-raw-${{ steps.mozc-pin.outputs.sha }}
           restore-keys: |
             mozc-raw-
 
@@ -241,7 +246,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: engine/data/mozc-raw
-          key: mozc-raw-${{ hashFiles('engine/data/mozc-pin.txt') }}
+          key: mozc-raw-${{ steps.mozc-pin.outputs.sha }}
 
   audit:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,13 @@ jobs:
       # changed).
       - name: Read pinned Mozc SHA
         id: mozc-pin
-        run: echo "sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+        run: |
+          sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]' || true)
+          if [ -z "$sha" ]; then
+            echo "::error file=engine/data/mozc-pin.txt::no 40-hex SHA line found in the pin file" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Restore Mozc dictionary snapshot
         id: mozc-restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,9 @@ jobs:
       - name: Read pinned Mozc SHA
         id: mozc-pin
         run: |
-          sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]' || true)
+          # Lowercase to match dictool's pin normalization — a case-variant
+          # pin line must map to the same cache key.
+          sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' || true)
           if [ -z "$sha" ]; then
             echo "::error file=engine/data/mozc-pin.txt::no 40-hex SHA line found in the pin file" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
               - 'engine/crates/lex-cli/**'
             corpus:
               - 'engine/testcorpus/**'
+              - 'engine/data/mozc-pin.txt'
               - 'mise.toml'
             swift:
               - 'Sources/**'
@@ -168,11 +169,15 @@ jobs:
       - run: cd engine && cargo test -p lex-cli
 
   # Conversion accuracy gate: builds the full dictionary (Mozc snapshot +
-  # bundled symbols/extras) and runs both accuracy corpora. The Mozc raw
-  # snapshot (~90MB of TSVs) is kept in the actions cache; the dictool fetch
-  # stamp (commit SHA + manifest, PR #266) decides on every run whether the
-  # cached snapshot is still current, repairs it, or re-downloads a new
-  # upstream snapshot — so a stale cache entry can never poison the dict.
+  # bundled symbols/extras) and runs both accuracy corpora. The Mozc snapshot
+  # is pinned to the commit in engine/data/mozc-pin.txt (the corpus filter
+  # includes the pin file, so a pin bump re-runs this gate), which keeps the
+  # gate deterministic — upstream Mozc moving can never turn main red, and
+  # local `mise run accuracy` measures against the identical snapshot. The
+  # raw snapshot (~90MB of TSVs) is kept in the actions cache; the dictool
+  # fetch stamp (commit SHA + manifest, PR #266) decides on every run whether
+  # the cached snapshot matches the pin, repairs it, or transactionally
+  # re-downloads it — so a stale cache entry can never poison the dict.
   # `needs: changes` only (not lint): a corpus-only change must not be
   # skipped just because the Rust lint job didn't run.
   accuracy:
@@ -198,27 +203,29 @@ jobs:
         with:
           install: false
 
-      # Restore/save split keyed on the pinned upstream commit SHA (line 1 of
-      # dictool's .stamp): exactly one cache entry per upstream Mozc snapshot.
-      # The `key` never matches an existing entry directly — restore-keys
-      # picks up the newest snapshot — and the save step below only fires
-      # when the post-fetch SHA differs from what was restored (first run, or
-      # upstream moved). The stamp mechanism makes a stale restore safe:
-      # dictool verifies the restored snapshot against upstream on every run
-      # (fast path: one Commits API call) and transactionally re-downloads
-      # when it no longer matches, so a stale cache can never poison the dict.
+      # Restore/save split keyed on the content of the pin file: exactly one
+      # cache entry per pinned Mozc snapshot. On an exact hit, dictool's
+      # stamp check confirms the restored snapshot matches the pin without a
+      # single network call. On a pin bump the exact key misses and
+      # restore-keys falls back to the newest previous snapshot, which
+      # dictool then transactionally replaces with the newly pinned one —
+      # the stamp mechanism (PR #266) makes any stale restore safe. The save
+      # step below only fires on that exact-key miss (first run, or the pin
+      # changed).
       - name: Restore Mozc dictionary snapshot
         id: mozc-restore
         uses: actions/cache/restore@v4
         with:
           path: engine/data/mozc-raw
-          key: mozc-raw-
+          key: mozc-raw-${{ hashFiles('engine/data/mozc-pin.txt') }}
           restore-keys: |
             mozc-raw-
 
       # GITHUB_TOKEN: Actions runners share the anonymous GitHub API quota
       # (60 req/h per IP), which is effectively always exhausted. dictool
-      # attaches the token to api.github.com requests when set.
+      # attaches the token to api.github.com requests when set. With the pin,
+      # the API is only consulted at all when the restored snapshot doesn't
+      # match the pin (Contents API listing for the re-download).
       - name: Run accuracy corpus
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -229,16 +236,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: mise run accuracy-history
 
-      - name: Read fetched Mozc snapshot version
-        id: mozc-stamp
-        run: echo "key=mozc-raw-$(head -n1 engine/data/mozc-raw/.stamp)" >> "$GITHUB_OUTPUT"
-
       - name: Save Mozc dictionary snapshot
-        if: steps.mozc-stamp.outputs.key != steps.mozc-restore.outputs.cache-matched-key
+        if: steps.mozc-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: engine/data/mozc-raw
-          key: ${{ steps.mozc-stamp.outputs.key }}
+          key: mozc-raw-${{ hashFiles('engine/data/mozc-pin.txt') }}
 
   audit:
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ generated/
 
 # Dictionary data (downloaded / compiled)
 engine/data/*
+# ... except the in-repo Mozc snapshot pin (source of truth for fetch-dict-mozc)
+!engine/data/mozc-pin.txt
 # Neural model files
 /data/
 

--- a/engine/crates/lex-cli/src/bin/dictool.rs
+++ b/engine/crates/lex-cli/src/bin/dictool.rs
@@ -30,6 +30,11 @@ enum Command {
         /// Dictionary source
         #[arg(long, default_value = "mozc")]
         source: String,
+        /// Pin the snapshot to a full 40-hex commit SHA instead of resolving
+        /// the latest upstream commit (mozc only). The primary pin lives in
+        /// engine/data/mozc-pin.txt; `mise run fetch-dict-mozc` passes it here.
+        #[arg(long)]
+        sha: Option<String>,
         /// Output directory
         output_dir: String,
     },
@@ -283,8 +288,10 @@ fn main() {
 
     match cli.command {
         Command::Fetch {
-            source, output_dir, ..
-        } => dict_ops::fetch(&source, &output_dir),
+            source,
+            sha,
+            output_dir,
+        } => dict_ops::fetch(&source, &output_dir, sha.as_deref()),
         Command::Compile {
             source,
             input_dir,

--- a/engine/crates/lex-cli/src/commands/dict_ops.rs
+++ b/engine/crates/lex-cli/src/commands/dict_ops.rs
@@ -16,7 +16,11 @@ macro_rules! die {
     };
 }
 
-pub fn fetch(source_name: &str, output_dir: &str) {
+/// Fetch raw dictionary files. With `sha`, the snapshot is pinned to that
+/// exact upstream commit (`fetch_pinned` — only the mozc source supports
+/// this); without it, the source's default resolution applies (mozc: latest
+/// upstream master commit, used for explicit pin bumps).
+pub fn fetch(source_name: &str, output_dir: &str, sha: Option<&str>) {
     let output_dir = Path::new(output_dir);
     let dict_source = dict_source::from_name(source_name).unwrap_or_else(|| {
         eprintln!(
@@ -25,10 +29,11 @@ pub fn fetch(source_name: &str, output_dir: &str) {
         );
         process::exit(1);
     });
-    die!(
-        dict_source.fetch(output_dir),
-        "Error fetching dictionary: {}"
-    );
+    let result = match sha {
+        Some(sha) => dict_source.fetch_pinned(output_dir, sha),
+        None => dict_source.fetch(output_dir),
+    };
+    die!(result, "Error fetching dictionary: {}");
 }
 
 /// Cost offsets applied at dictionary compile time to eliminate reranker heuristics.

--- a/engine/crates/lex-cli/src/dict_source/mod.rs
+++ b/engine/crates/lex-cli/src/dict_source/mod.rs
@@ -38,6 +38,17 @@ pub trait DictSource {
 
     /// Download raw dictionary files into `dest`.
     fn fetch(&self, dest: &Path) -> Result<(), DictSourceError>;
+
+    /// Download raw dictionary files into `dest`, pinned to `sha` (a full
+    /// 40-hex commit SHA) instead of whatever upstream currently serves.
+    /// Only sources backed by a git remote can honor a commit pin, so the
+    /// default implementation rejects it — `dictool fetch --sha` on a
+    /// source that would silently ignore the pin must fail loudly.
+    fn fetch_pinned(&self, _dest: &Path, _sha: &str) -> Result<(), DictSourceError> {
+        Err(DictSourceError::Parse(
+            "this source does not support --sha (only 'mozc' does)".to_string(),
+        ))
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -157,4 +168,30 @@ pub fn from_name(name: &str) -> Option<Box<dyn DictSource>> {
         .iter()
         .find(|(n, _)| *n == name)
         .map(|(_, ctor)| ctor())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A source that doesn't override `fetch_pinned` must reject `--sha`
+    /// instead of silently fetching an unpinned snapshot — the caller asked
+    /// for determinism it cannot provide. `symbols` and `extras` are bundled
+    /// TSVs with no upstream commit to pin.
+    #[test]
+    fn test_fetch_pinned_rejected_by_default() {
+        for name in ["symbols", "extras"] {
+            let source = from_name(name).unwrap();
+            let err = source
+                .fetch_pinned(
+                    Path::new("/nonexistent"),
+                    "0123456789abcdef0123456789abcdef01234567",
+                )
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("--sha"),
+                "{name}: unexpected error {err}"
+            );
+        }
+    }
 }

--- a/engine/crates/lex-cli/src/dict_source/mozc.rs
+++ b/engine/crates/lex-cli/src/dict_source/mozc.rs
@@ -154,6 +154,37 @@ fn is_valid_sha(s: &str) -> bool {
     s.len() == 40 && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
+/// Resolve the commit SHA that every download in a fetch run is pinned to.
+///
+/// An explicit pin short-circuits: it is validated (`is_valid_sha`, after
+/// trimming stray whitespace a shell pipeline may append) and used as-is,
+/// and `resolve_latest` — the Commits API call in production — is **never
+/// invoked**. A pinned fetch must be deterministic: it must not depend on
+/// upstream's current state, must not spend API rate limit on it, and must
+/// not fail just because the Commits API is unreachable. The SHA is
+/// normalized to lowercase so stamp comparisons can't be defeated by case
+/// (GitHub returns lowercase; `is_valid_sha` accepts either).
+///
+/// Without a pin, `resolve_latest` decides — the classic "track upstream
+/// master" behavior used for explicit pin bumps.
+fn resolve_run_sha(
+    pinned: Option<&str>,
+    resolve_latest: impl FnOnce() -> Result<String, DictSourceError>,
+) -> Result<String, DictSourceError> {
+    match pinned {
+        Some(pin) => {
+            let pin = pin.trim();
+            if !is_valid_sha(pin) {
+                return Err(DictSourceError::Parse(format!(
+                    "pinned SHA must be a full 40-hex commit SHA, got {pin:?}"
+                )));
+            }
+            Ok(pin.to_ascii_lowercase())
+        }
+        None => resolve_latest(),
+    }
+}
+
 /// Extract and validate the commit SHA from a GitHub Commits API response.
 fn parse_commit_sha(json: &str) -> Result<String, DictSourceError> {
     let v: serde_json::Value = serde_json::from_str(json)
@@ -479,7 +510,9 @@ impl DictSource for MozcSource {
     /// Fetch the Mozc dictionary snapshot into `dest`. Same cache discipline
     /// as the SudachiDict fetcher (`candidates/sudachi.rs`, PR #242): **the
     /// stamp file must equal the resolved upstream version exactly**, here
-    /// the latest commit SHA of `google/mozc` master. Anything else (stamp
+    /// the run's pinned commit SHA of `google/mozc` — the explicit
+    /// `--sha` pin when given, the latest master commit otherwise
+    /// (`resolve_run_sha`). Anything else (stamp
     /// missing, legacy empty stamp, mismatched SHA — with or without leftover
     /// files) triggers a full re-download of the new snapshot into a
     /// `.staging` subdirectory, followed by a transactional swap
@@ -510,12 +543,34 @@ impl DictSource for MozcSource {
     /// Offline behavior: if the SHA can't be resolved but a cached snapshot
     /// exists (valid stamp — only written after a fully successful fetch) and
     /// its artifacts are still on disk, warn and keep using it; otherwise
-    /// fail.
+    /// fail. With an explicit pin, resolution cannot fail for network
+    /// reasons — the only resolve error is a malformed pin, which must be a
+    /// hard error: silently falling back to whatever snapshot happens to be
+    /// cached would defeat the very determinism the pin exists for. A pinned
+    /// fetch over a complete cache therefore touches the network *zero*
+    /// times (not even the one Commits API call of the unpinned fast path).
     ///
     /// The stamp records, after the SHA, the manifest of files this fetch
     /// downloaded; a later wipe deletes exactly those, so user-placed files
     /// in the cache dir survive version bumps.
     fn fetch(&self, dest: &Path) -> Result<(), DictSourceError> {
+        self.fetch_impl(dest, None)
+    }
+
+    /// Fetch pinned to an explicit commit SHA — see [`MozcSource::fetch`]
+    /// for the full cache discipline. The pin's primary source of truth is
+    /// `engine/data/mozc-pin.txt`, which `mise run fetch-dict-mozc` reads
+    /// and passes through `dictool fetch --sha`.
+    fn fetch_pinned(&self, dest: &Path, sha: &str) -> Result<(), DictSourceError> {
+        self.fetch_impl(dest, Some(sha))
+    }
+}
+
+impl MozcSource {
+    /// Shared implementation of [`DictSource::fetch`] (pinned = `None`,
+    /// track upstream master) and [`DictSource::fetch_pinned`] (pinned =
+    /// explicit SHA, deterministic snapshot).
+    fn fetch_impl(&self, dest: &Path, pinned: Option<&str>) -> Result<(), DictSourceError> {
         fs::create_dir_all(dest).map_err(DictSourceError::Io)?;
         let stamp_path = dest.join(".stamp");
         // Clear staging leftovers from an interrupted previous run up front.
@@ -527,8 +582,12 @@ impl DictSource for MozcSource {
         }
         let cached = read_stamp(&stamp_path);
 
-        let sha = match Self::latest_commit_sha() {
+        let sha = match resolve_run_sha(pinned, Self::latest_commit_sha) {
             Ok(sha) => sha,
+            // A malformed explicit pin is a hard error — the offline
+            // fallback below exists for network failures resolving
+            // "latest", not for overriding what the caller asked for.
+            Err(e) if pinned.is_some() => return Err(e),
             Err(e) => {
                 if let Some(st) = &cached {
                     // A stamp alone is not enough — verify the artifacts it
@@ -600,9 +659,10 @@ impl DictSource for MozcSource {
         // a transient listing/download failure leaves the old snapshot
         // working and offline-usable (Codex review R3 on PR #266: wiping
         // up front traded a working cache for any network hiccup).
+        let sha_kind = if pinned.is_some() { "pinned" } else { "latest" };
         if let Some(st) = &cached {
             eprintln!(
-                "Cache commit {} != latest {sha}; downloading new snapshot before replacing.",
+                "Cache commit {} != {sha_kind} {sha}; downloading new snapshot before replacing.",
                 st.sha
             );
         } else if any_fetched_file_exists(dest) {
@@ -765,6 +825,64 @@ mod tests {
         // Right length, non-hex
         assert!(!is_valid_sha("0123456789abcdef0123456789abcdef0123456z"));
         assert!(!is_valid_sha("../../../../../../../../../../../../etc/x"));
+    }
+
+    /// Pins the `--sha` contract: an explicit pin must be used as-is —
+    /// deterministically — without ever consulting the Commits API. The
+    /// panicking closure stands in for `latest_commit_sha`; if the pinned
+    /// path ever calls it, this test blows up.
+    #[test]
+    fn test_resolve_run_sha_pinned_never_calls_latest() {
+        let no_api = || -> Result<String, DictSourceError> {
+            panic!("Commits API must not be consulted when a pin is given")
+        };
+        assert_eq!(
+            resolve_run_sha(Some("7c1e06d39d6a8446e15a324700c48dcb00846039"), no_api).unwrap(),
+            "7c1e06d39d6a8446e15a324700c48dcb00846039"
+        );
+        // Surrounding whitespace (stray newline from `$(cmd)` substitution
+        // in the mise task) is trimmed; uppercase is normalized to the
+        // lowercase form GitHub uses, so stamp comparison stays exact-match.
+        assert_eq!(
+            resolve_run_sha(Some(" 7C1E06D39D6A8446E15A324700C48DCB00846039\n"), no_api).unwrap(),
+            "7c1e06d39d6a8446e15a324700c48dcb00846039"
+        );
+    }
+
+    /// A malformed pin is rejected up front (reusing the `is_valid_sha`
+    /// gate), still without touching the Commits API — the error must
+    /// surface the bad pin, not fall back to "latest" or a cached snapshot.
+    #[test]
+    fn test_resolve_run_sha_rejects_invalid_pin() {
+        let no_api = || -> Result<String, DictSourceError> {
+            panic!("Commits API must not be consulted when a pin is given")
+        };
+        for bad in [
+            "",
+            "  \n",
+            "7c1e06d3",                                  // abbreviated
+            "master",                                    // ref, not a SHA
+            "0123456789abcdef0123456789abcdef0123456z",  // non-hex
+            "0123456789abcdef0123456789abcdef012345678", // 41 chars
+            "../../../../../../../../../../../../etc/x", // traversal
+        ] {
+            assert!(
+                resolve_run_sha(Some(bad), no_api).is_err(),
+                "pin {bad:?} should be rejected"
+            );
+        }
+    }
+
+    /// Without a pin, resolution delegates to the latest-commit lookup —
+    /// both its success and its failure (which the caller's offline
+    /// fallback then handles) pass straight through.
+    #[test]
+    fn test_resolve_run_sha_unpinned_delegates_to_latest() {
+        let sha = "0123456789abcdef0123456789abcdef01234567";
+        assert_eq!(resolve_run_sha(None, || Ok(sha.to_string())).unwrap(), sha);
+        assert!(
+            resolve_run_sha(None, || Err(DictSourceError::Http("offline".to_string()))).is_err()
+        );
     }
 
     #[test]

--- a/engine/data/mozc-pin.txt
+++ b/engine/data/mozc-pin.txt
@@ -1,0 +1,21 @@
+# Mozc dictionary snapshot pin.
+#
+# The google/mozc commit SHA that `mise run fetch-dict-mozc` downloads
+# (via `dictool fetch --source mozc --sha <sha>`). Pinning in-repo keeps
+# conversion-quality measurements reproducible: local runs and the CI
+# accuracy job build the dictionary from the same upstream snapshot
+# instead of whatever master happens to be at fetch time (issue #273:
+# a 2026-02 local snapshot vs a 2026-07 CI snapshot diverged on 6
+# accuracy cases).
+#
+# Bump procedure (do all of this in ONE PR):
+#   1. Replace the SHA below with the new full 40-hex commit, e.g. the
+#      current master head from
+#      https://api.github.com/repos/google/mozc/commits/master
+#   2. Run `mise run accuracy` and `mise run accuracy-history` before and
+#      after the bump, and paste the before/after results into the PR.
+#   3. Fix or skip (+ issue link) any newly failing corpus cases in the
+#      same PR, so main never lands with a red accuracy gate.
+#
+# Format: the first non-comment, non-empty line is the pinned commit SHA.
+7c1e06d39d6a8446e15a324700c48dcb00846039

--- a/mise.toml
+++ b/mise.toml
@@ -42,15 +42,27 @@ echo "Generated Swift bindings in generated/"
 ls -la generated/
 """
 
+# Pinned to the commit in engine/data/mozc-pin.txt so local runs and the CI
+# accuracy job measure against the same upstream snapshot (issue #273). Bump
+# procedure lives in the pin file's header comment. To fetch an unpinned
+# (latest master) snapshot for a bump, run dictool fetch without --sha.
 [tasks.fetch-dict-mozc]
-description = "Download Mozc dictionary data"
+description = "Download Mozc dictionary data (pinned to engine/data/mozc-pin.txt)"
 sources = [
   "engine/crates/lex-cli/src/bin/dictool.rs",
   "engine/crates/lex-cli/src/dict_source/mod.rs",
   "engine/crates/lex-cli/src/dict_source/mozc.rs",
+  "engine/data/mozc-pin.txt",
 ]
 outputs = ["engine/data/mozc-raw/.stamp"]
-run = "cd engine && cargo run -p lex-cli --bin dictool -- fetch --source mozc data/mozc-raw"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+# A pin file without a SHA line yields sha="" (grep's exit code is masked),
+# which dictool then rejects with a clear "must be a full 40-hex SHA" error.
+sha=$(grep -v -e '^#' -e '^[[:space:]]*$' engine/data/mozc-pin.txt | head -n1 | tr -d '[:space:]' || true)
+cd engine && cargo run -p lex-cli --bin dictool -- fetch --source mozc --sha "$sha" data/mozc-raw
+"""
 
 [tasks.dict-mozc]
 description = "Compile binary dictionary from Mozc"

--- a/mise.toml
+++ b/mise.toml
@@ -58,9 +58,11 @@ outputs = ["engine/data/mozc-raw/.stamp"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-# A pin file without a SHA line yields sha="" (grep's exit code is masked),
-# which dictool then rejects with a clear "must be a full 40-hex SHA" error.
-sha=$(grep -v -e '^#' -e '^[[:space:]]*$' engine/data/mozc-pin.txt | head -n1 | tr -d '[:space:]' || true)
+# Extract the first 40-hex line (allowing surrounding whitespace) — comments
+# in any form and junk lines are excluded by construction. An absent SHA line
+# yields sha="" (grep's exit code is masked), which dictool then rejects with
+# a clear "must be a full 40-hex SHA" error.
+sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]' || true)
 cd engine && cargo run -p lex-cli --bin dictool -- fetch --source mozc --sha "$sha" data/mozc-raw
 """
 

--- a/mise.toml
+++ b/mise.toml
@@ -62,7 +62,7 @@ set -euo pipefail
 # in any form and junk lines are excluded by construction. An absent SHA line
 # yields sha="" (grep's exit code is masked), which dictool then rejects with
 # a clear "must be a full 40-hex SHA" error.
-sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]' || true)
+sha=$(grep -oE -m1 '^[[:space:]]*[0-9a-fA-F]{40}[[:space:]]*$' engine/data/mozc-pin.txt | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' || true)
 cd engine && cargo run -p lex-cli --bin dictool -- fetch --source mozc --sha "$sha" data/mozc-raw
 """
 


### PR DESCRIPTION
## 背景

#266 で Mozc fetch は commit SHA ピン + manifest stamp 化されたが、SHA の解決は常に「上流 master 最新」だった。このため:

1. CI の accuracy gate (#275) が上流 Mozc の更新のたびに drift で赤くなり得る
2. ローカルと CI で測定基盤が割れ、品質チューニングの before/after が環境依存になる (再現可能な測定は品質改善プログラムの前提)

実例: ローカル 2026-02 snapshot vs CI 2026-07 snapshot で accuracy 6 ケース差 (#273)。

## 変更内容

### ピンの一次ソース: `engine/data/mozc-pin.txt` (in-repo)

- 1 行 = 40-hex SHA、`#` コメント行可。冒頭コメントに **bump 手順** (SHA 更新 → `mise run accuracy` / `accuracy-history` で before/after 確認 → コーパス調整と同一 PR) を記載
- 初期値は現行 CI snapshot の `7c1e06d39d6a8446e15a324700c48dcb00846039` (2026-07-01, GitHub Commits API で完全 SHA を解決)
- `.gitignore` の `engine/data/*` に negation を追加してこのファイルだけ追跡

### `dictool fetch --sha <sha>` (mozc のみ)

- 新設の `resolve_run_sha(pinned, resolve_latest)` がピン経路を決定論化: 指定時は既存 `is_valid_sha` で 40-hex 検証(trim + lowercase 正規化)し、**Commits API を一切呼ばず** listing/download のピンにそのまま使う。未指定時は従来通り latest (明示的な pin bump 用)
- 不正なピンは offline fallback に落とさずハードエラー (キャッシュ済み snapshot への silent fallback はピンの決定論を壊すため)
- `DictSource` trait に `fetch_pinned` を追加。default 実装は明示的拒否 — ピンを黙って無視する source (`symbols` / `extras`) への `--sha` は fail loudly
- ピン + キャッシュ完全一致の fast path は**ネットワーク 0 回** (従来は毎回 Commits API 1 回)

### mise.toml

- `fetch-dict-mozc` が pin ファイルを読んで `--sha` を渡す。pin ファイルを `sources` に追加したので pin 変更で自動再 fetch

### ci.yml (accuracy ジョブ)

- キャッシュ key を `mozc-raw-<pinned SHA> (抽出した SHA を直接キーに使用。コメントのみの pin 編集でキャッシュが churn しない)` に変更 (exact hit → stamp 照合のみで再利用)。`restore-keys: mozc-raw-` の prefix fallback は維持 (pin bump 時は旧 snapshot を restore → dictool がトランザクショナルに差し替え)
- save 条件を `cache-hit != 'true'` に単純化 (stamp 読み出しステップは削除)
- `changes` の corpus filter に pin ファイルを追加 — pin bump PR で accuracy gate が必ず走る

## テスト

- `resolve_run_sha`: ピン指定時に Commits API クロージャが呼ばれないこと (panic closure で検証) / 不正ピン 7 種の拒否 / 未指定時の latest 委譲とエラー透過
- `fetch_pinned` default 拒否 (`symbols` / `extras`)

## 検証結果

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-features -- -D warnings` / `cargo test -p lex-cli` (68 passed)
- [x] 実 fetch: 一時ディレクトリに `--sha <pin>` で取得 → stamp 1 行目が pin と一致
- [x] 2 回目の fetch が fast path (`cache is up to date`、ダウンロードなし)
- [x] 不正 SHA (`deadbeef`) / 非 mozc source への `--sha` が明示エラーで fail
- [x] `mise run fetch-dict-mozc` が pin を読んで fetch、再実行は mise の staleness check でスキップ
- [x] `mise run accuracy`: **101/101 pass (skip 33)** — pin snapshot で全 pass
- [x] `mise run accuracy-history`: **7/7 pass**
- [x] ci.yml を ruby -ryaml で構文検証

Refs #273 (skip 中 6 ケースの再調整は別タスク)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
