### PR TITLE
feat(core): log commit rank events for acceptance-rate tracking

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -409,7 +409,7 @@ decay = 1.0 / (1.0 + hours_elapsed / 168.0)
 
 ### コミットログ（診断用）
 
-確定イベントを JSONL で checkpoint と同じディレクトリ（`commit-log.jsonl`）に追記する（全セッション共有の Mutex で直列化）。identity な auto-commit（surface == reading）は学習はしないがログには載る（受容率の分母を欠かさないため）。1 行 = 1 確定: `t`（epoch 秒）/ `reading` / `surface` / `rank`（確定時の選択候補 index。0 = top-1 受容、>0 = 手動選択 = 変換ミスの一次signal）/ `top1`（rank>0 のときのみ、その時の top-1 surface）/ `auto`（auto-commit 由来のときのみ true）。ローカル専用の診断データで、lextool によるオフライン集計（実使用 top-1 受容率の推移、ミス頻度）に使う。履歴 `clear()` で一緒に削除される。書き込み失敗は警告ログのみ（確定経路を壊さない）。
+変換確定イベントを JSONL で checkpoint と同じディレクトリ（`commit-log.jsonl`）に追記する（全セッション共有の Mutex で直列化）。identity な auto-commit（surface == reading）は学習はしないがログには載る（受容率の分母を欠かさないため）。対象は候補リストからの変換確定のみで、変換判断を伴わない確定（生かなの overflow commit、ABC パススルー、snippet 展開）は含まない。1 行 = 1 変換確定: `t`（epoch 秒）/ `reading` / `surface` / `rank`（確定時の選択候補 index。0 = top-1 受容、>0 = 手動選択 = 変換ミスの一次signal）/ `top1`（rank>0 のときのみ、その時の top-1 surface）/ `auto`（auto-commit 由来のときのみ true）。ローカル専用の診断データで、lextool によるオフライン集計（実使用 top-1 受容率の推移、ミス頻度）に使う。履歴 `clear()` で一緒に削除される。書き込み失敗は警告ログのみ（確定経路を壊さない）。
 
 ## ユーザー辞書
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -409,7 +409,7 @@ decay = 1.0 / (1.0 + hours_elapsed / 168.0)
 
 ### コミットログ（診断用）
 
-確定イベントを JSONL で checkpoint と同じディレクトリ（`commit-log.jsonl`）に追記する。1 行 = 1 確定: `t`（epoch 秒）/ `reading` / `surface` / `rank`（確定時の選択候補 index。0 = top-1 受容、>0 = 手動選択 = 変換ミスの一次signal）/ `top1`（rank>0 のときのみ、その時の top-1 surface）/ `auto`（auto-commit 由来のときのみ true）。ローカル専用の診断データで、lextool によるオフライン集計（実使用 top-1 受容率の推移、ミス頻度）に使う。履歴 `clear()` で一緒に削除される。書き込み失敗は警告ログのみ（確定経路を壊さない）。
+確定イベントを JSONL で checkpoint と同じディレクトリ（`commit-log.jsonl`）に追記する（全セッション共有の Mutex で直列化）。identity な auto-commit（surface == reading）は学習はしないがログには載る（受容率の分母を欠かさないため）。1 行 = 1 確定: `t`（epoch 秒）/ `reading` / `surface` / `rank`（確定時の選択候補 index。0 = top-1 受容、>0 = 手動選択 = 変換ミスの一次signal）/ `top1`（rank>0 のときのみ、その時の top-1 surface）/ `auto`（auto-commit 由来のときのみ true）。ローカル専用の診断データで、lextool によるオフライン集計（実使用 top-1 受容率の推移、ミス頻度）に使う。履歴 `clear()` で一緒に削除される。書き込み失敗は警告ログのみ（確定経路を壊さない）。
 
 ## ユーザー辞書
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -407,6 +407,10 @@ decay = 1.0 / (1.0 + hours_elapsed / 168.0)
 
 容量超過時、`frequency × decay(last_used)` のスコアが低いエントリから削除。
 
+### コミットログ（診断用）
+
+確定イベントを JSONL で checkpoint と同じディレクトリ（`commit-log.jsonl`）に追記する。1 行 = 1 確定: `t`（epoch 秒）/ `reading` / `surface` / `rank`（確定時の選択候補 index。0 = top-1 受容、>0 = 手動選択 = 変換ミスの一次signal）/ `top1`（rank>0 のときのみ、その時の top-1 surface）/ `auto`（auto-commit 由来のときのみ true）。ローカル専用の診断データで、lextool によるオフライン集計（実使用 top-1 受容率の推移、ミス頻度）に使う。履歴 `clear()` で一緒に削除される。書き込み失敗は警告ログのみ（確定経路を壊さない）。
+
 ## ユーザー辞書
 
 ユーザーが手動登録する単語辞書。`Dictionary` trait を実装し、`CompositeDictionary` のレイヤーとして統合。

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1098,6 +1098,7 @@ version = "0.1.0"
 dependencies = [
  "lex-core",
  "lex-session",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -38,6 +38,7 @@ neural = ["lex-core/neural"]
 lex-core = { path = "crates/lex-core" }
 lex-session = { path = "crates/lex-session" }
 uniffi = "0.29"
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -83,6 +83,9 @@ impl InputSession {
                 reading: committed_reading.clone(),
                 surface: committed_surface.clone(),
                 segments: seg_pairs,
+                rank: 0,
+                top1: None,
+                auto: true,
             });
         }
 

--- a/engine/crates/lex-session/src/auto_commit.rs
+++ b/engine/crates/lex-session/src/auto_commit.rs
@@ -77,17 +77,19 @@ impl InputSession {
             )
         };
 
-        // Record to history (comp() borrow is dropped)
-        if committed_surface != committed_reading {
-            self.history_records.push(LearningRecord::Committed {
-                reading: committed_reading.clone(),
-                surface: committed_surface.clone(),
-                segments: seg_pairs,
-                rank: 0,
-                top1: None,
-                auto: true,
-            });
-        }
+        // Record to history (comp() borrow is dropped). Identity commits
+        // (surface == reading) are still recorded for the commit log's
+        // acceptance denominator, but with learn = false so history never
+        // learns no-op mappings.
+        self.history_records.push(LearningRecord::Committed {
+            reading: committed_reading.clone(),
+            surface: committed_surface.clone(),
+            segments: seg_pairs,
+            rank: 0,
+            top1: None,
+            auto: true,
+            learn: committed_surface != committed_reading,
+        });
 
         // Remove committed reading from kana.
         // Safety: starts_with check above guarantees the byte offset is a valid

--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -75,6 +75,7 @@ impl InputSession {
             rank,
             top1,
             auto: false,
+            learn: true,
         });
     }
 

--- a/engine/crates/lex-session/src/commit.rs
+++ b/engine/crates/lex-session/src/commit.rs
@@ -58,11 +58,23 @@ impl InputSession {
         if self.history.is_none() {
             return;
         }
-        let segments = self.comp().find_matching_path(&surface);
+        let (segments, rank, top1) = {
+            let c = self.comp();
+            let rank = c.candidates.selected;
+            let top1 = if rank > 0 {
+                c.candidates.surfaces.first().cloned()
+            } else {
+                None
+            };
+            (c.find_matching_path(&surface), rank, top1)
+        };
         self.history_records.push(LearningRecord::Committed {
             reading,
             surface,
             segments,
+            rank,
+            top1,
+            auto: false,
         });
     }
 

--- a/engine/crates/lex-session/src/tests/basic.rs
+++ b/engine/crates/lex-session/src/tests/basic.rs
@@ -416,6 +416,49 @@ fn test_history_not_recorded_on_escape() {
     assert!(records.is_empty());
 }
 
+#[test]
+fn test_history_record_includes_rank_and_top1() {
+    let dict = make_test_dict();
+    let history = UserHistory::new();
+    let mut session = InputSession::new(dict.clone(), None, Some(Arc::new(RwLock::new(history))));
+
+    // Accepting top-1: rank 0, no top1, not auto
+    type_string(&mut session, "kyou");
+    session.handle_key(KeyEvent::Enter);
+    let records = session.take_history_records();
+    let LearningRecord::Committed {
+        rank, top1, auto, ..
+    } = &records[0]
+    else {
+        panic!("expected Committed record");
+    };
+    assert_eq!(*rank, 0);
+    assert!(top1.is_none());
+    assert!(!auto);
+
+    // Manual selection: rank reflects the picked index, top1 is recorded
+    type_string(&mut session, "kyou");
+    let expected_top1 = session.comp().candidates.surfaces[0].clone();
+    session.handle_key(KeyEvent::Space); // move selection to index 1
+    let expected_surface = session.comp().candidates.surfaces[1].clone();
+    session.handle_key(KeyEvent::Enter);
+    let records = session.take_history_records();
+    let LearningRecord::Committed {
+        rank,
+        top1,
+        surface,
+        auto,
+        ..
+    } = &records[0]
+    else {
+        panic!("expected Committed record");
+    };
+    assert_eq!(*rank, 1);
+    assert_eq!(top1.as_deref(), Some(expected_top1.as_str()));
+    assert_eq!(surface, &expected_surface);
+    assert!(!auto);
+}
+
 // --- Cyclic index ---
 
 #[test]

--- a/engine/crates/lex-session/src/types/mod.rs
+++ b/engine/crates/lex-session/src/types/mod.rs
@@ -195,8 +195,8 @@ pub enum LearningRecord {
         /// 0 = the user accepted top-1; >0 = a manual pick, i.e. a
         /// conversion miss observable in the commit log.
         rank: usize,
-        /// Top-1 surface at commit time. Some only when rank > 0
-        /// (otherwise it equals `surface`).
+        /// Top-1 surface at commit time. Set to `Some` only when rank > 0
+        /// (otherwise the top-1 is `surface` itself).
         top1: Option<String>,
         /// True when produced by auto-commit (the user kept typing past a
         /// stable prefix, which implies acceptance of top-1).

--- a/engine/crates/lex-session/src/types/mod.rs
+++ b/engine/crates/lex-session/src/types/mod.rs
@@ -191,6 +191,16 @@ pub enum LearningRecord {
         /// Pre-segmented N-best path (if available and multi-segment).
         /// Used for sub-phrase unigram + bigram learning.
         segments: Option<Vec<(String, String)>>,
+        /// 0-based index of the selected candidate at commit time.
+        /// 0 = the user accepted top-1; >0 = a manual pick, i.e. a
+        /// conversion miss observable in the commit log.
+        rank: usize,
+        /// Top-1 surface at commit time. Some only when rank > 0
+        /// (otherwise it equals `surface`).
+        top1: Option<String>,
+        /// True when produced by auto-commit (the user kept typing past a
+        /// stable prefix, which implies acceptance of top-1).
+        auto: bool,
     },
     /// User requested deletion of history for this reading→surface.
     Deletion { segments: Vec<(String, String)> },

--- a/engine/crates/lex-session/src/types/mod.rs
+++ b/engine/crates/lex-session/src/types/mod.rs
@@ -201,6 +201,10 @@ pub enum LearningRecord {
         /// True when produced by auto-commit (the user kept typing past a
         /// stable prefix, which implies acceptance of top-1).
         auto: bool,
+        /// Whether this commit should update history learning. False for
+        /// identity auto-commits (surface == reading), which are logged for
+        /// acceptance-rate tracking but must not learn no-op mappings.
+        learn: bool,
     },
     /// User requested deletion of history for this reading→surface.
     Deletion { segments: Vec<(String, String)> },

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -98,6 +98,12 @@ struct CommitLog {
 impl CommitLog {
     fn append(&mut self, line: &str) -> std::io::Result<()> {
         if self.file.is_none() {
+            // Mirror HistoryWal::open_file: on a fresh install the first
+            // logged event can precede any WAL append, so the parent
+            // directory may not exist yet.
+            if let Some(parent) = self.path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
             self.file = Some(
                 std::fs::OpenOptions::new()
                     .create(true)
@@ -275,7 +281,9 @@ mod tests {
     #[test]
     fn test_commit_log_append_and_clear() {
         let dir = tempfile::tempdir().unwrap();
-        let cp = dir.path().join("history.lxud");
+        // Nested path that does not exist yet: the first append must create
+        // the parent directory (fresh-install case).
+        let cp = dir.path().join("nested").join("history.lxud");
         let hist = LexUserHistory::open(cp.display().to_string()).unwrap();
 
         hist.append_commit_log(r#"{"t":1,"reading":"きょう","surface":"今日","rank":0}"#);
@@ -283,7 +291,7 @@ mod tests {
             r#"{"t":2,"reading":"きょう","surface":"京","rank":2,"top1":"今日"}"#,
         );
 
-        let log_path = dir.path().join("commit-log.jsonl");
+        let log_path = dir.path().join("nested").join("commit-log.jsonl");
         let content = std::fs::read_to_string(&log_path).unwrap();
         assert_eq!(content.lines().count(), 2);
 

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -83,8 +83,36 @@ pub struct LexUserHistory {
     compacting: AtomicBool,
     /// Append-only JSONL log of commit events (rank, top-1 acceptance),
     /// stored next to the checkpoint. Local diagnostics only; mined offline
-    /// by lextool to track the real-world top-1 acceptance rate.
-    commit_log_path: PathBuf,
+    /// by lextool to track the real-world top-1 acceptance rate. The mutex
+    /// serializes appends across all sessions sharing this history so
+    /// concurrent commits cannot interleave partial lines.
+    commit_log: Mutex<CommitLog>,
+}
+
+/// Lazily-opened append handle for the commit log, mirroring HistoryWal.
+struct CommitLog {
+    path: PathBuf,
+    file: Option<std::fs::File>,
+}
+
+impl CommitLog {
+    fn append(&mut self, line: &str) -> std::io::Result<()> {
+        if self.file.is_none() {
+            self.file = Some(
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&self.path)?,
+            );
+        }
+        let f = self.file.as_mut().expect("file set by preceding lines");
+        // Single write_all per line (payload + newline in one buffer) so a
+        // line can never be split even if the file handle is shared.
+        let mut buf = Vec::with_capacity(line.len() + 1);
+        buf.extend_from_slice(line.as_bytes());
+        buf.push(b'\n');
+        f.write_all(&buf)
+    }
 }
 
 #[uniffi::export]
@@ -93,12 +121,15 @@ impl LexUserHistory {
     fn open(path: String) -> Result<Arc<Self>, LexError> {
         let cp = Path::new(&path);
         let (history, wal) = crate::user_history::wal::open_with_wal(cp)?;
-        let commit_log_path = cp.with_file_name("commit-log.jsonl");
+        let commit_log = CommitLog {
+            path: cp.with_file_name("commit-log.jsonl"),
+            file: None,
+        };
         Ok(Arc::new(Self {
             inner: Arc::new(RwLock::new(history)),
             wal: Mutex::new(wal),
             compacting: AtomicBool::new(false),
-            commit_log_path,
+            commit_log: Mutex::new(commit_log),
         }))
     }
 
@@ -116,6 +147,16 @@ impl LexUserHistory {
             })?;
             *h = UserHistory::new();
         }
+        // Drop the commit-log handle before removing the file so a later
+        // append reopens (re-creates) it instead of writing to an unlinked
+        // inode.
+        let commit_log_path = {
+            let mut log = self.commit_log.lock().map_err(|e| LexError::Io {
+                msg: format!("commit-log lock poisoned: {e}"),
+            })?;
+            log.file = None;
+            log.path.clone()
+        };
         let mut wal = self.wal.lock().map_err(|e| LexError::Io {
             msg: format!("WAL lock poisoned: {e}"),
         })?;
@@ -123,7 +164,7 @@ impl LexUserHistory {
         for path in [
             wal.wal_path(),
             wal.checkpoint_path(),
-            self.commit_log_path.as_path(),
+            commit_log_path.as_path(),
         ] {
             match std::fs::remove_file(path) {
                 Ok(()) => {}
@@ -151,17 +192,15 @@ impl LexUserHistory {
     /// Append one JSONL line to the commit log. Failures are logged and
     /// swallowed — diagnostics must never break the commit path.
     pub(super) fn append_commit_log(&self, line: &str) {
-        let open = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.commit_log_path);
-        match open {
-            Ok(mut f) => {
-                if let Err(e) = writeln!(f, "{line}") {
-                    warn!("commit-log append failed: {e}");
-                }
+        let mut log = match self.commit_log.lock() {
+            Ok(l) => l,
+            Err(e) => {
+                warn!("commit-log lock poisoned: {e}");
+                return;
             }
-            Err(e) => warn!("commit-log open failed: {e}"),
+        };
+        if let Err(e) = log.append(line) {
+            warn!("commit-log append failed: {e}");
         }
     }
 

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -80,6 +81,10 @@ pub struct LexUserHistory {
     pub(crate) inner: Arc<RwLock<UserHistory>>,
     wal: Mutex<HistoryWal>,
     compacting: AtomicBool,
+    /// Append-only JSONL log of commit events (rank, top-1 acceptance),
+    /// stored next to the checkpoint. Local diagnostics only; mined offline
+    /// by lextool to track the real-world top-1 acceptance rate.
+    commit_log_path: PathBuf,
 }
 
 #[uniffi::export]
@@ -88,10 +93,12 @@ impl LexUserHistory {
     fn open(path: String) -> Result<Arc<Self>, LexError> {
         let cp = Path::new(&path);
         let (history, wal) = crate::user_history::wal::open_with_wal(cp)?;
+        let commit_log_path = cp.with_file_name("commit-log.jsonl");
         Ok(Arc::new(Self {
             inner: Arc::new(RwLock::new(history)),
             wal: Mutex::new(wal),
             compacting: AtomicBool::new(false),
+            commit_log_path,
         }))
     }
 
@@ -113,7 +120,11 @@ impl LexUserHistory {
             msg: format!("WAL lock poisoned: {e}"),
         })?;
         wal.truncate_wal()?;
-        for path in [wal.wal_path(), wal.checkpoint_path()] {
+        for path in [
+            wal.wal_path(),
+            wal.checkpoint_path(),
+            self.commit_log_path.as_path(),
+        ] {
             match std::fs::remove_file(path) {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -134,6 +145,23 @@ impl LexUserHistory {
         };
         if let Err(e) = wal.append(segments, timestamp) {
             warn!("WAL append failed: {e}");
+        }
+    }
+
+    /// Append one JSONL line to the commit log. Failures are logged and
+    /// swallowed — diagnostics must never break the commit path.
+    pub(super) fn append_commit_log(&self, line: &str) {
+        let open = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.commit_log_path);
+        match open {
+            Ok(mut f) => {
+                if let Err(e) = writeln!(f, "{line}") {
+                    warn!("commit-log append failed: {e}");
+                }
+            }
+            Err(e) => warn!("commit-log open failed: {e}"),
         }
     }
 
@@ -204,6 +232,26 @@ impl LexUserHistory {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_commit_log_append_and_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let hist = LexUserHistory::open(cp.display().to_string()).unwrap();
+
+        hist.append_commit_log(r#"{"t":1,"reading":"きょう","surface":"今日","rank":0}"#);
+        hist.append_commit_log(
+            r#"{"t":2,"reading":"きょう","surface":"京","rank":2,"top1":"今日"}"#,
+        );
+
+        let log_path = dir.path().join("commit-log.jsonl");
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        assert_eq!(content.lines().count(), 2);
+
+        // clear() removes the commit log along with history files
+        hist.clear_impl().unwrap();
+        assert!(!log_path.exists(), "commit log should be removed by clear");
+    }
 
     #[test]
     fn test_clear_resets_history_and_removes_files() {

--- a/engine/src/api/session.rs
+++ b/engine/src/api/session.rs
@@ -247,13 +247,16 @@ impl LexSession {
                         rank,
                         top1,
                         auto,
+                        learn,
                     } => {
-                        let segs = vec![(reading.clone(), surface.clone())];
-                        hist.record_at(&segs, now);
-                        wal_entries.push(segs);
-                        if let Some(sub_segs) = segments {
-                            hist.record_at(sub_segs, now);
-                            wal_entries.push(sub_segs.clone());
+                        if *learn {
+                            let segs = vec![(reading.clone(), surface.clone())];
+                            hist.record_at(&segs, now);
+                            wal_entries.push(segs);
+                            if let Some(sub_segs) = segments {
+                                hist.record_at(sub_segs, now);
+                                wal_entries.push(sub_segs.clone());
+                            }
                         }
                         log_lines.push(commit_log_line(
                             now,

--- a/engine/src/api/session.rs
+++ b/engine/src/api/session.rs
@@ -236,6 +236,7 @@ impl LexSession {
         let now = crate::user_history::now_epoch();
         let mut wal_entries: Vec<Vec<(String, String)>> = Vec::new();
         let mut needs_compact = false;
+        let mut log_lines: Vec<String> = Vec::new();
         if let Ok(mut hist) = h.inner.write() {
             for r in records {
                 match r {
@@ -243,6 +244,9 @@ impl LexSession {
                         reading,
                         surface,
                         segments,
+                        rank,
+                        top1,
+                        auto,
                     } => {
                         let segs = vec![(reading.clone(), surface.clone())];
                         hist.record_at(&segs, now);
@@ -251,6 +255,14 @@ impl LexSession {
                             hist.record_at(sub_segs, now);
                             wal_entries.push(sub_segs.clone());
                         }
+                        log_lines.push(commit_log_line(
+                            now,
+                            reading,
+                            surface,
+                            *rank,
+                            top1.as_deref(),
+                            *auto,
+                        ));
                     }
                     LearningRecord::Deletion { segments } => {
                         if hist.remove_entries(segments) {
@@ -265,6 +277,9 @@ impl LexSession {
         for segments in &wal_entries {
             h.append_wal(segments, now);
         }
+        for line in &log_lines {
+            h.append_commit_log(line);
+        }
 
         // Phase 3: persist deletion immediately, or background compaction
         if needs_compact {
@@ -272,5 +287,54 @@ impl LexSession {
         } else {
             h.maybe_compact();
         }
+    }
+}
+
+/// Serialize one commit event as a JSONL line for the commit log.
+/// `top1` and `auto` are omitted at their defaults to keep lines lean.
+fn commit_log_line(
+    now: u64,
+    reading: &str,
+    surface: &str,
+    rank: usize,
+    top1: Option<&str>,
+    auto: bool,
+) -> String {
+    let mut obj = serde_json::json!({
+        "t": now,
+        "reading": reading,
+        "surface": surface,
+        "rank": rank,
+    });
+    if let Some(t1) = top1 {
+        obj["top1"] = serde_json::Value::String(t1.to_string());
+    }
+    if auto {
+        obj["auto"] = serde_json::Value::Bool(true);
+    }
+    obj.to_string()
+}
+
+#[cfg(test)]
+mod commit_log_tests {
+    use super::commit_log_line;
+
+    #[test]
+    fn test_commit_log_line_shape() {
+        // Manual pick: top1 present, auto omitted
+        let line = commit_log_line(42, "きょう", "京", 2, Some("今日"), false);
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["t"], 42);
+        assert_eq!(v["reading"], "きょう");
+        assert_eq!(v["surface"], "京");
+        assert_eq!(v["rank"], 2);
+        assert_eq!(v["top1"], "今日");
+        assert!(v.get("auto").is_none());
+
+        // Auto-commit acceptance: top1 omitted, auto present
+        let line = commit_log_line(42, "きょう", "今日", 0, None, true);
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert!(v.get("top1").is_none());
+        assert_eq!(v["auto"], true);
     }
 }


### PR DESCRIPTION
## Summary

変換品質改善プログラムの ②「commit 時 rank ロギング」。history-audit (#256) が過去の蓄積から掘るのに対し、これは**全確定イベントを分母付きで捕捉**し、「実使用 top-1 受容率」（audit 時点 82.3%）の推移測定と将来のミス自動発掘を可能にする。

- `LearningRecord::Committed` に **rank**（確定時の選択候補 index、0 = top-1 受容）/ **top1**（rank>0 のときのみ）/ **auto**（auto-commit 由来フラグ）を追加
- lex_engine が確定ごとに 1 行の JSONL を history checkpoint と同じディレクトリの `commit-log.jsonl` に追記
  - 例: `{"t":1751437200,"reading":"きょう","surface":"京","rank":2,"top1":"今日"}`
  - 書き込み失敗は警告のみ（確定経路を壊さない）
- **プライバシー**: history と同クラスのローカル専用データ。履歴 `clear()` で commit log も一緒に削除
- SPEC に形式を文書化

lextool 側の集計サブコマンド（受容率推移・ミス頻度）はデータが溜まってからの follow-up。

## Test plan

- [x] `cargo fmt` / `clippy -D warnings` / `cargo test --workspace --all-features` 全 pass
- [x] 新テスト 3 本: 手動選択で rank/top1 が記録される (lex-session) / JSONL 追記 + clear で削除 (lex_engine resources) / ログ行の形状 (top1/auto の省略規則)
- [x] `mise run accuracy` 107/107、`mise run accuracy-history` 7/7（変換ロジック無変更）
- [ ] マージ後 `mise run build && install && reload` で実機確認（commit-log.jsonl が生えて rank が記録されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)