### PR TITLE
fix(dict): recalibrate extras POS id and drifted cases for 2026-07 pin

### DIFF
--- a/engine/crates/lex-cli/src/dict_source/extras.rs
+++ b/engine/crates/lex-cli/src/dict_source/extras.rs
@@ -47,10 +47,15 @@ const DOMAINS: &[(&str, &str)] = &[
 /// homophones unless we explicitly want them to.
 const DEFAULT_COST: i16 = 5000;
 
-/// Default POS: 名詞,一般 (Mozc id 1852). Works for content nouns and
-/// brand-name proper nouns alike. Per-domain POS tuning is deferred — cost
-/// adjustment is sufficient for the MVP.
-const DEFAULT_POS: u16 = 1852;
+/// Default POS: 名詞,一般 (Mozc id 1851 in the pinned 2026-07 id.def; was
+/// 1852 before the snapshot renumbered ids — see #273). Works for content
+/// nouns and brand-name proper nouns alike. Per-domain POS tuning is
+/// deferred — cost adjustment is sufficient for the MVP.
+///
+/// NOTE: this id is only valid for the id.def snapshot pinned in
+/// `engine/data/mozc-pin.txt`. Re-verify on every pin bump (e.g.
+/// `grep '名詞,一般,\*,\*,\*,\*,\*$' data/mozc-raw/id.def`).
+const DEFAULT_POS: u16 = 1851;
 
 pub struct ExtrasSource;
 

--- a/engine/crates/lex-cli/src/dict_source/extras.rs
+++ b/engine/crates/lex-cli/src/dict_source/extras.rs
@@ -54,7 +54,8 @@ const DEFAULT_COST: i16 = 5000;
 ///
 /// NOTE: this id is only valid for the id.def snapshot pinned in
 /// `engine/data/mozc-pin.txt`. Re-verify on every pin bump (e.g.
-/// `grep '名詞,一般,\*,\*,\*,\*,\*$' data/mozc-raw/id.def`).
+/// `grep '名詞,一般,\*,\*,\*,\*,\*$' engine/data/mozc-raw/id.def` from the
+/// repo root).
 const DEFAULT_POS: u16 = 1851;
 
 pub struct ExtrasSource;

--- a/engine/crates/lex-cli/src/dict_source/extras/it.tsv
+++ b/engine/crates/lex-cli/src/dict_source/extras/it.tsv
@@ -5,9 +5,10 @@
 #   - cost: i16. Default 5000 (mid). Lower = higher rank.
 # Comment lines start with '#'. Blank lines are ignored.
 #
-# All entries use POS id 1852 (名詞,一般). When that's wrong (e.g. proper
-# nouns), tune via cost rather than POS for now — POS overrides are out of
-# scope for the curated layer.
+# All entries use the 名詞,一般 POS id (DEFAULT_POS in extras.rs — snapshot
+# dependent, see #273). When that's wrong (e.g. proper nouns), tune via cost
+# rather than POS for now — POS overrides are out of scope for the curated
+# layer.
 
 # --- 数学 / CS ---
 べきとう	冪等
@@ -19,3 +20,6 @@
 # --- 開発用語 (#261/#263 history-audit) ---
 ねすてっど	ネステッド
 みこみっと	未コミット
+# マシン: Mozc 既存 (cost 4241) だが 麻しん の mixed-script bonus に margin 79
+# で負ける (2026-07 pin, #273)。IT 用途では マシン が正なので cost-override
+ましん	マシン	3500

--- a/engine/testcorpus/accuracy-corpus.toml
+++ b/engine/testcorpus/accuracy-corpus.toml
@@ -273,7 +273,7 @@ category = "regression"
 tags = ["partial-hiragana"]
 skip = true
 issue = "#273"
-note = "した方がいい は PartialHiraganaRewriter で生成されるが history boost なしでは top-1 にならない。Mozc 2026-07 スナップショットで 下ほうが良い が top-1 に drift"
+note = "した方がいい は PartialHiraganaRewriter で生成されるが history boost なしでは top-1 にならない。2026-07 pin では 下ほうが良い (24981) が したほうが良い (26981) に viterbi で勝つ: 下(した)=名詞,接尾 word=20 + conn(下→ほうが)=0 が支配的で、script bonus 側 (Fix 4) では 2000 の gap を埋められない。辞書 curation (Fix 5) 案件"
 
 [[cases]]
 reading = "どれ"
@@ -459,9 +459,8 @@ reading = "しかかり"
 expected = "仕掛"
 category = "extras"
 tags = ["it", "business"]
-skip = true
 issue = "#273"
-note = "Mozc 2026-07 スナップショットで しか借り が top-1 に drift"
+note = "extras POS id 再校正 (#273): id.def 番号ズレで extras が 名詞,一般,あと (BOS 4843) に落ち しか借り に drift していた"
 
 [[cases]]
 reading = "たんじゃお"
@@ -474,9 +473,8 @@ reading = "ほわじゃお"
 expected = "花椒"
 category = "extras"
 tags = ["food", "domain-reading"]
-skip = true
 issue = "#273"
-note = "Mozc 2026-07 スナップショットで ホワジャオ が top-1 に drift (cost-conflict 校正が旧スナップショット前提)"
+note = "extras POS id 再校正 (#273) 前は ホワジャオ に drift していた"
 
 [[cases]]
 reading = "いっぽどう"
@@ -512,9 +510,16 @@ reading = "えいろく"
 expected = "永禄"
 category = "extras"
 tags = ["history", "era"]
-skip = true
 issue = "#273"
-note = "Mozc top-1 は 栄禄 (obscure)。Wikipedia corpus mining で発見。Mozc 2026-07 スナップショットで 栄禄 が再び top-1 に drift"
+note = "Mozc top-1 は 栄禄 (obscure)。Wikipedia corpus mining で発見。extras POS id 再校正 (#273) で再 fix"
+
+[[cases]]
+reading = "えんきょう"
+expected = "延享"
+category = "extras"
+tags = ["history", "era"]
+issue = "#273"
+note = "extras POS id 再校正 (#273) 前は 円強 (gibberish) が top-1 に drift していた regression ガード"
 
 [[cases]]
 reading = "じゅごい"
@@ -572,6 +577,14 @@ reading = "しんちょうぶんこ"
 expected = "新潮文庫"
 category = "extras"
 tags = ["culture", "publisher"]
+
+[[cases]]
+reading = "こうぶんどう"
+expected = "弘文堂"
+category = "extras"
+tags = ["culture", "publisher"]
+issue = "#273"
+note = "extras POS id 再校正 (#273) 前は 光文堂 が top-1 に drift していた regression ガード"
 
 [[cases]]
 reading = "かどかわにほんちめいだいじてん"
@@ -724,9 +737,8 @@ reading = "ましん"
 expected = "マシン"
 category = "loanword"
 tags = ["history-audit", "it"]
-skip = true
 issue = "#273"
-note = "麻しん が top-1 だった。katakana_penalty 5000→150 で fix (#261)。Mozc 2026-07 スナップショットのコスト変更で 麻しん に再 drift (tie-breaker 150 が旧コスト前提)"
+note = "麻しん が top-1 だった。katakana_penalty 5000→150 で fix (#261)。2026-07 pin で margin 79 に再逆転 → extras cost-override (マシン 3500) で再 fix (#273)。医療系複合語 (麻しんワクチン 等) は Mozc の複合語エントリで維持"
 
 [[cases]]
 reading = "えんじん"
@@ -1062,9 +1074,8 @@ issue = "#261"
 
 [[cases]]
 reading = "かっこ"
-expected = "カッコ"
+expected = "括弧"
 category = "loanword"
 tags = ["katakana-policy"]
-skip = true
 issue = "#273"
-note = "設計判断: 括弧 rank 2 を許容 (#261 Q1)。漢字が欲しい場合は履歴学習で flip。Mozc 2026-07 スナップショットのコスト変更で 括弧 が top-1 に drift"
+note = "設計判断ガード (#261 Q1): katakana_penalty はタイブレーカーに留め辞書序列に従う。旧 snapshot は カッコ、2026-07 pin は 括弧 が辞書優位 (margin 109) — 設計に従い expected を更新 (#273)。カタカナが欲しい場合は履歴学習で flip"


### PR DESCRIPTION
## Summary

#273 の再校正（max 診断エージェントによる実測ベース）。**最大の発見: extras 3 件の drift はコスト変動ではなく POS id の番号ズレ**でした。

### 根本原因

2026-07 pin の id.def で 名詞,一般 が **1852 → 1851** に renumber され、extras の `DEFAULT_POS = 1852` が「名詞,一般,あと」（語彙化クラス）に落ちていた。BOS 接続が +3777 悪化し、**全 extras エントリ**が一律に沈んでいた（コーパス外でも えんきょう→円強、こうぶんどう→光文堂 が silent drift していたのを発見 → regression ガードとして追加）。

### 変更

| ケース | 対応 |
|---|---|
| しかかり / ほわじゃお / えいろく | POS id 修正（1851）のみで復帰。margin 3400〜3700 |
| えんきょう / こうぶんどう | 同上 + regression ガード新設（silent drift していた） |
| ましん | extras cost-override `マシン 3500`。pin で margin 79 の再逆転 → override 後 margin 662。**麻しんワクチン / 麻しん風しん混合ワクチン は Mozc 複合語エントリで維持を実測確認** |
| かっこ | **expected を 括弧 に変更**（設計判断、後述） |
| したほうがいい | skip 継続。下(名詞,接尾 word=20)+conn=0 が viterbi 層で 2000 差 → script bonus 系では原理的に届かず、Fix 5（辞書 curation）案件と note に明記 |

- extras.rs に「POS id は pin 依存、bump 時に要再確認」の NOTE を追加

### 設計判断（レビューで確認ください）

1. **かっこ: カッコ→括弧**: #261 Q1 の決定は「penalty はタイブレーカーに留め、辞書に決めさせる」。旧 snapshot は カッコ 優位、新 pin は 括弧 優位（margin 109）— extras で カッコ を強制するのは設計への矛盾なので expected 側を辞書に合わせました。カタカナ好みは履歴学習が担当
2. **ましん override の collateral**: 単独・助詞接続の ましん は全文脈で マシン 化（IT 実利用に一致、history-audit の実測傾向）。医療複合語は無傷

### Accuracy before/after

| | before | after |
|---|---|---|
| accuracy | 101/101 pass, 33 skip (136 total 換算 101/0/33) | **108/108 pass, 0 fail, 28 skip** (136 total) |
| accuracy-history | 7/7 | 7/7 |

extras 全 47 読みの before/after 全数比較で、変化は意図した 6 件のみ（かんぽう→漢方 等の既存 cost-conflict 校正は維持）。

### Follow-up（別 issue 予定）

extras POS id を compile 時に id.def から動的解決する（pos_map 基盤あり）。pin bump 毎の手動確認を不要にし、silent drift を構造的に防ぐ。

Refs #273（したほうがいい が残るため close しない）

## Test plan

- [x] `mise run dict` → `mise run accuracy` 108/108 (0 fail) / `mise run accuracy-history` 7/7
- [x] extras 全読み before/after スイープ（変化 6 件のみ）、ましん 医療複合語 spot-check
- [x] `cargo fmt --check` / `clippy -D warnings` / `cargo test -p lex-cli` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)