### PR TITLE
feat(dict): resolve extras POS id dynamically from id.def at compile time

### DIFF
--- a/engine/crates/lex-cli/src/commands/dict_ops.rs
+++ b/engine/crates/lex-cli/src/commands/dict_ops.rs
@@ -62,10 +62,27 @@ pub fn compile(
         process::exit(1);
     }
 
+    // id.def drives both morpheme-role cost offsets and tag-based POS
+    // resolution (extras). Auto-detect in input_dir if --id-def is not
+    // specified.
+    let id_def_path = id_def.map(PathBuf::from).or_else(|| {
+        let auto = input_path.join("id.def");
+        if auto.is_file() {
+            eprintln!("Auto-detected id.def at {}", auto.display());
+            Some(auto)
+        } else {
+            None
+        }
+    });
+
     eprintln!("Source: {source_name}");
     let mut entries = die!(
         dict_source.parse_dir(input_path),
         "Error parsing dictionary: {}"
+    );
+    die!(
+        dict_source.resolve_pos_ids(&mut entries, id_def_path.as_deref()),
+        "Error resolving POS ids: {}"
     );
 
     // Parse extra sources up front, but defer merging until after id.def
@@ -86,24 +103,18 @@ pub fn compile(
             process::exit(1);
         }
         eprintln!("Extra source: {extra_name}");
-        let parsed = die!(
+        let mut parsed = die!(
             extra_src.parse_dir(extra_path),
             "Error parsing extra dictionary: {}"
+        );
+        die!(
+            extra_src.resolve_pos_ids(&mut parsed, id_def_path.as_deref()),
+            "Error resolving POS ids for '{extra_name}': {}"
         );
         extras.push((extra_name.clone(), parsed));
     }
 
     // Apply compile-time cost offsets based on morpheme roles.
-    // Auto-detect id.def in input_dir if --id-def is not specified.
-    let id_def_path = id_def.map(PathBuf::from).or_else(|| {
-        let auto = input_path.join("id.def");
-        if auto.is_file() {
-            eprintln!("Auto-detected id.def at {}", auto.display());
-            Some(auto)
-        } else {
-            None
-        }
-    });
     if let Some(id_def_path) = &id_def_path {
         let roles = die!(
             pos_map::morpheme_roles(id_def_path),

--- a/engine/crates/lex-cli/src/dict_source/extras.rs
+++ b/engine/crates/lex-cli/src/dict_source/extras.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use super::{is_hiragana, parse_dict_files, DictSource, DictSourceError, ParsedLine};
+use super::{is_hiragana, parse_dict_files, pos_map, DictSource, DictSourceError, ParsedLine};
 use lex_core::dict::DictEntry;
 
 /// Curated domain-specific vocabulary not covered by Mozc UT.
@@ -47,16 +47,22 @@ const DOMAINS: &[(&str, &str)] = &[
 /// homophones unless we explicitly want them to.
 const DEFAULT_COST: i16 = 5000;
 
-/// Default POS: 名詞,一般 (Mozc id 1851 in the pinned 2026-07 id.def; was
-/// 1852 before the snapshot renumbered ids — see #273). Works for content
-/// nouns and brand-name proper nouns alike. Per-domain POS tuning is
-/// deferred — cost adjustment is sufficient for the MVP.
+/// POS tag assigned to every extras entry: 名詞,一般 works for content nouns
+/// and brand-name proper nouns alike. Per-domain POS tuning is deferred —
+/// cost adjustment is sufficient for the MVP.
 ///
-/// NOTE: this id is only valid for the id.def snapshot pinned in
-/// `engine/data/mozc-pin.txt`. Re-verify on every pin bump (e.g.
-/// `grep '名詞,一般,\*,\*,\*,\*,\*$' engine/data/mozc-raw/id.def` from the
-/// repo root).
-const DEFAULT_POS: u16 = 1851;
+/// The numeric id for this tag is resolved from the pinned id.def at compile
+/// time by [`ExtrasSource::resolve_pos_ids`] — ids are line numbers in
+/// id.def, so hardcoding one silently degrades every extras entry when a pin
+/// bump renumbers them (#273: the old constant drifted onto 名詞,一般,あと
+/// and every entry paid a +3777 BOS-connection penalty; see #279).
+const DEFAULT_POS_TAG: &str = "名詞,一般,*,*,*,*,*";
+
+/// Placeholder POS id emitted by `parse_dir`, replaced by `resolve_pos_ids`.
+/// Deliberately out of id.def's range (~2700 ids) so an unresolved entry
+/// that somehow reaches a compiled dict fails loudly in conversion instead
+/// of blending in as a plausible POS.
+const POS_UNRESOLVED: u16 = u16::MAX;
 
 pub struct ExtrasSource;
 
@@ -96,12 +102,33 @@ impl DictSource for ExtrasSource {
                 Some(ParsedLine {
                     reading: reading.to_string(),
                     surface: surface.to_string(),
-                    left_id: DEFAULT_POS,
-                    right_id: DEFAULT_POS,
+                    left_id: POS_UNRESOLVED,
+                    right_id: POS_UNRESOLVED,
                     cost,
                 })
             },
         )
+    }
+
+    fn resolve_pos_ids(
+        &self,
+        entries: &mut HashMap<String, Vec<DictEntry>>,
+        id_def: Option<&Path>,
+    ) -> Result<(), DictSourceError> {
+        let id_def = id_def.ok_or_else(|| {
+            DictSourceError::Parse(
+                "extras requires id.def to resolve its POS id — pass --id-def or place id.def in the primary input dir".to_string(),
+            )
+        })?;
+        let pos = resolve_default_pos(id_def)?;
+        eprintln!("  extras POS id: {pos} ({DEFAULT_POS_TAG})");
+        for entry_list in entries.values_mut() {
+            for entry in entry_list.iter_mut() {
+                entry.left_id = pos;
+                entry.right_id = pos;
+            }
+        }
+        Ok(())
     }
 
     fn fetch(&self, dest: &Path) -> Result<(), DictSourceError> {
@@ -118,6 +145,18 @@ impl DictSource for ExtrasSource {
         );
         Ok(())
     }
+}
+
+/// Look up [`DEFAULT_POS_TAG`] in `id.def`. Fails when the tag is absent —
+/// a silent fallback here is exactly the drift #279 exists to prevent.
+fn resolve_default_pos(id_def_path: &Path) -> Result<u16, DictSourceError> {
+    let map = pos_map::parse_mozc_id_def(id_def_path)?;
+    map.get(DEFAULT_POS_TAG).copied().ok_or_else(|| {
+        DictSourceError::Parse(format!(
+            "'{DEFAULT_POS_TAG}' not found in {} — cannot assign the extras POS id",
+            id_def_path.display()
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -168,15 +207,92 @@ mod tests {
             .expect("こむろてつや must map to 小室哲哉");
         assert!(komuro.iter().any(|e| e.surface == "小室哲哉"));
 
-        // All entries use the default POS id.
+        // parse_dir alone leaves the POS unresolved; the compile pipeline
+        // always follows up with resolve_pos_ids.
         for entry_list in entries.values() {
             for entry in entry_list {
-                assert_eq!(entry.left_id, DEFAULT_POS);
-                assert_eq!(entry.right_id, DEFAULT_POS);
+                assert_eq!(entry.left_id, POS_UNRESOLVED);
+                assert_eq!(entry.right_id, POS_UNRESOLVED);
             }
         }
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Write a minimal id.def with the given lines and return its path.
+    fn write_id_def(dir_name: &str, lines: &[&str]) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(dir_name);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("id.def");
+        fs::write(&path, lines.join("\n")).unwrap();
+        path
+    }
+
+    #[test]
+    fn resolve_pos_ids_assigns_id_from_id_def() {
+        let id_def = write_id_def(
+            "lexime_test_extras_pos_ok",
+            &[
+                "0 BOS/EOS,*,*,*,*,*,*",
+                "1850 名詞,一般,*,*,*,*,あと",
+                "1851 名詞,一般,*,*,*,*,*",
+                "1852 名詞,サ変接続,*,*,*,*,*",
+            ],
+        );
+
+        let mut entries = HashMap::from([(
+            "べきとう".to_string(),
+            vec![DictEntry {
+                surface: "冪等".to_string(),
+                cost: 5000,
+                left_id: POS_UNRESOLVED,
+                right_id: POS_UNRESOLVED,
+            }],
+        )]);
+
+        ExtrasSource
+            .resolve_pos_ids(&mut entries, Some(&id_def))
+            .unwrap();
+        let entry = &entries["べきとう"][0];
+        assert_eq!(entry.left_id, 1851);
+        assert_eq!(entry.right_id, 1851);
+
+        fs::remove_dir_all(id_def.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn resolve_pos_ids_fails_without_id_def() {
+        let err = ExtrasSource
+            .resolve_pos_ids(&mut HashMap::new(), None)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("id.def"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_pos_ids_fails_when_tag_missing() {
+        // A vocab-specific 名詞,一般 row must NOT satisfy the generic tag —
+        // that near-miss is exactly the #273 degradation.
+        let id_def = write_id_def(
+            "lexime_test_extras_pos_missing",
+            &[
+                "0 BOS/EOS,*,*,*,*,*,*",
+                "1850 名詞,一般,*,*,*,*,あと",
+                "1852 名詞,サ変接続,*,*,*,*,*",
+            ],
+        );
+
+        let err = ExtrasSource
+            .resolve_pos_ids(&mut HashMap::new(), Some(&id_def))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains(DEFAULT_POS_TAG),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_dir_all(id_def.parent().unwrap()).ok();
     }
 
     #[test]

--- a/engine/crates/lex-cli/src/dict_source/extras/it.tsv
+++ b/engine/crates/lex-cli/src/dict_source/extras/it.tsv
@@ -5,10 +5,11 @@
 #   - cost: i16. Default 5000 (mid). Lower = higher rank.
 # Comment lines start with '#'. Blank lines are ignored.
 #
-# All entries use the 名詞,一般 POS id (DEFAULT_POS in extras.rs — snapshot
-# dependent, see #273). When that's wrong (e.g. proper nouns), tune via cost
-# rather than POS for now — POS overrides are out of scope for the curated
-# layer.
+# All entries use the 名詞,一般 POS id, resolved from the pinned id.def at
+# compile time (DEFAULT_POS_TAG in extras.rs — #279 made this dynamic after
+# a pin bump renumbered the previously hardcoded id, see #273). When that's
+# wrong (e.g. proper nouns), tune via cost rather than POS for now — POS
+# overrides are out of scope for the curated layer.
 
 # --- 数学 / CS ---
 べきとう	冪等

--- a/engine/crates/lex-cli/src/dict_source/mod.rs
+++ b/engine/crates/lex-cli/src/dict_source/mod.rs
@@ -49,6 +49,22 @@ pub trait DictSource {
             "this source does not support --sha (only 'mozc' does)".to_string(),
         ))
     }
+
+    /// Resolve POS ids that depend on the Mozc `id.def` in use. `compile`
+    /// calls this on every source's parsed entries, passing the same id.def
+    /// it uses for cost adjustments (`None` when compiling without one).
+    ///
+    /// Default: no-op — most sources carry explicit POS ids in their raw
+    /// files. Sources that assign a POS by tag (extras) override this to
+    /// resolve the tag against id.def, so a pin bump that renumbers ids
+    /// can't silently degrade their entries (#279).
+    fn resolve_pos_ids(
+        &self,
+        _entries: &mut HashMap<String, Vec<DictEntry>>,
+        _id_def: Option<&Path>,
+    ) -> Result<(), DictSourceError> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Closes #279

## 背景

extras 辞書レイヤーは 名詞,一般 の POS id をハードコードしていた (`DEFAULT_POS = 1851`)。この id は Mozc id.def の行番号なので、pin bump で renumber されると別の品詞クラスを指し、全 extras エントリが silent に劣化する。#273/#278 では 1852 が 名詞,一般,あと に落ち、全エントリが BOS 接続 +3777 を払っていた。

## 変更

- `DictSource` トレイトに `resolve_pos_ids(entries, id_def)` フックを追加（デフォルト no-op）。`dictool compile` が primary / extra 全ソースのパース直後に、cost 調整と同じ id.def を渡して呼ぶ
- `ExtrasSource` がこれを実装: `名詞,一般,*,*,*,*,*` を id.def から解決して全エントリに割り当てる。既存の `pos_map::parse_mozc_id_def` を利用（vocab-specific 行は対象外なので 名詞,一般,あと の near-miss は拾わない）
- **silent fallback 禁止**: id.def 未指定、または該当行が id.def にない場合は compile が明示的に fail
- `parse_dir` は placeholder として `u16::MAX` を出す — 万一未解決のまま dict に届いても実在 POS に紛れず、変換側で loudly に壊れる
- `DEFAULT_POS` 定数と extras.rs / it.tsv の「pin bump 時に手動確認」NOTE を動的解決の説明に置換
- 単体テスト追加: 解決成功 / id.def なしエラー / 該当行なし（vocab-specific near-miss のみ）エラー

## 検証

`mise run dict` のログで動的解決がハードコード値と一致することを確認:

```
extras POS id: 1851 (名詞,一般,*,*,*,*,*)
```

### accuracy before/after

| | before (main, #278 時点) | after |
|---|---|---|
| `mise run accuracy` | 136 total / 108 pass / 0 fail / 28 skip | 136 total / 108 pass / 0 fail / 28 skip |
| `mise run accuracy-history` | 7/7 pass | 7/7 pass |

regression ガード（えんきょう→延享、こうぶんどう→弘文堂、しかかり→仕掛、ほわじゃお→花椒、えいろく→永禄、ましん→マシン）はすべて pass（0 fail、skip リストに不在）。

`cargo fmt --check` / `cargo clippy -D warnings` / `cargo test --workspace --all-features` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
