### PR TITLE
chore: migrate external PR review from Copilot to Codex

### DIFF
--- a/.claude/skills/external-converge/project.md
+++ b/.claude/skills/external-converge/project.md
@@ -1,0 +1,66 @@
+# /external-converge project overlay — lexime
+
+Loaded by `~/.claude/skills/external-converge/SKILL.md` (the full multi-round
+convergence loop) when invoked from this repo. Reviewer = **OpenAI Codex on
+ChatGPT Pro** (loop-affordable, no per-credit cost). For the routine
+single-pass, see `external-review/project.md` (same reviewer; `repo`,
+`build_verify`, `fix_discipline`, `classification_calibration` are defined
+there and apply unchanged in the loop — not restated here).
+
+## failure_modes
+
+No lexime-local loop incidents yet. The loop's defensive rules (Step 1
+pitfall gate, Step 4 TERMINAL stop, request-staleness gate, generator-layer /
+altitude check, pre-Ask written-lens attestation) were calibrated on elidex
+incidents — see `../../../../elidex/.claude/skills/external-converge/project.md`
+`failure_modes` for the incident log. They are enforced by the global
+SKILL.md regardless; record lexime-specific incidents here as they occur.
+
+Inherited from the Copilot era (reviewer-agnostic, still applies):
+
+- Severity miscalibration — reviewers inflate polish to IMPORTANT; apply the
+  one-sentence "what concretely breaks?" test strictly. Doc imprecision that
+  doesn't misdirect is MINOR.
+- Merge-on-stale is mechanically blocked by
+  `~/.claude/hooks/gh-pr-merge-head-guard.sh` (PreToolUse on `gh pr merge`;
+  override sentinel `# merge-stale-ok`) — it activates for any repo where
+  Codex has assessed the PR at least once, including this one.
+
+## wakeup_poll
+
+`300s` — poll cadence while waiting for Codex's review to land, **NOT a
+latency prediction**.
+
+Observed on elidex (user-confirmed 2026-06-21, #390): a single Codex review
+normally takes **~15 minutes** to land. So:
+
+- **~15 min is NORMAL, not stuck** — do not re-trigger or surface-as-slow at
+  ~14-15 min; the review is almost certainly still running, and re-triggering
+  interrupts/duplicates it.
+- **Surface / re-trigger threshold = ~25-30 min** of zero Codex activity on
+  head (no formal review, no marker-bearing issue-comment, no inline thread).
+  The generic SKILL.md "~15 min" sanity cap is too aggressive for this
+  reviewer.
+
+## reviewer
+
+- `bot_login`: `chatgpt-codex-connector[bot]` (REST form). **GraphQL
+  `reviewThreads` author.login is the BARE `chatgpt-codex-connector`** (no
+  `[bot]`) — the Step-1 fetch must normalize (strip `[bot]`) for GraphQL
+  comparisons or it false-negatives every inline finding (elidex
+  `#316`/`#337`).
+- `name`: Codex (OpenAI Codex Cloud, ChatGPT **Pro**)
+- `trigger`: `@codex review` (posted as a PR comment to re-trigger each round)
+- `assessed_commit_marker`: `Reviewed commit:` — appears in BOTH
+  formal-review bodies AND Codex's dry-verdict issue-comment, followed by
+  `` `<sha>` ``. Step 1 reads the latest assessed commit from this marker
+  across reviews + issue-comments (NOT the reviews API alone).
+- `dry_verdict_match`: `Didn't find any major issues` — posted as a **plain
+  PR issue-comment** (`Codex Review: Didn't find any major issues`), **not**
+  a formal review. A dry-verdict comment on the current head IS a dry round;
+  keying head-staleness on `pulls/{n}/reviews` alone false-stalls every dry
+  round (elidex `#322`/`#337`).
+
+The genuine Pro Codex is `chatgpt-codex-connector[bot]`; a bare
+`@codex[agent]` mention is a Copilot-billed impostor — do **not** use.
+Lenses reach Codex via `AGENTS.md` (`## Review guidelines`).

--- a/.claude/skills/external-converge/project.md
+++ b/.claude/skills/external-converge/project.md
@@ -61,6 +61,9 @@ normally takes **~15 minutes** to land. So:
   keying head-staleness on `pulls/{n}/reviews` alone false-stalls every dry
   round (elidex `#322`/`#337`).
 
-The genuine Pro Codex is `chatgpt-codex-connector[bot]`; a bare
-`@codex[agent]` mention is a Copilot-billed impostor — do **not** use.
-Lenses reach Codex via `AGENTS.md` (`## Review guidelines`).
+The genuine Pro Codex responds as `chatgpt-codex-connector[bot]`; `@codex`
+with a non-`review` instruction starts a Pro-billed Codex cloud task (fine —
+just not a review). The Copilot-billed `codex[agent]` SWE agent is a
+different product — if a responder is not `chatgpt-codex-connector[bot]`,
+stop and check billing (full caveat: `external-review/project.md`). Lenses
+reach Codex via `AGENTS.md` (`## Review guidelines`).

--- a/.claude/skills/external-review/project.md
+++ b/.claude/skills/external-review/project.md
@@ -1,0 +1,66 @@
+# /external-review project overlay — lexime
+
+Loaded by `~/.claude/skills/external-review/SKILL.md` (single-pass triage) when
+invoked from this repo. The multi-round loop variant's calibration
+(`wakeup_poll`, failure-mode inheritance) lives in
+`external-converge/project.md` (same reviewer).
+
+## repo
+
+`send/lexime`
+
+## build_verify
+
+`cd engine && cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace --all-features`
+
+Per CLAUDE.md「ビルド・テスト」. When a fix touches dictionary sources /
+connection costs / feature weights / rerankers, additionally run both
+accuracy gates and keep them green: `mise run accuracy && mise run
+accuracy-history` (skip 以外全 pass — CLAUDE.md § 変換精度テスト).
+Swift-side changes are gated by CI (`gh pr checks`), not locally.
+
+## fix_discipline
+
+No project-local review-axes skill (unlike elidex) — run SKILL.md's bare
+symptom-vs-root check per fix. lexime-specific bias:
+
+- Conversion-accuracy regressions are fixed at the *data/cost* root
+  (dictionary entry, connection cost, feature weight), not by special-casing
+  in conversion code.
+- When a reviewer-confirmed conversion miss is real, add a regression
+  corpus case (`engine/testcorpus/accuracy-corpus.toml`, regression
+  category) alongside the fix — CLAUDE.md § 運用ルール recommends it.
+
+## classification_calibration
+
+- Dev-tool performance findings (`dictool` subcommands, corpus-mining paths)
+  are **WONTFIX by policy** — resolve as "acceptable for runtime profile",
+  do not auto-fix. Runtime (IME hot-path) perf findings are real.
+- A new history-corpus case without `baseline` is IMPORTANT (CLAUDE.md rule),
+  not a nit.
+- An accuracy-corpus `skip` without an issue link is a real finding
+  (理由なし skip 禁止).
+
+## reviewer
+
+- `bot_login`: `chatgpt-codex-connector[bot]` (REST form). **GraphQL
+  `reviewThreads` author.login is the BARE `chatgpt-codex-connector`** (no
+  `[bot]`) — normalize (strip `[bot]`) for GraphQL comparisons or every
+  inline finding false-negatives (elidex `#316`/`#337`).
+- `name`: Codex (genuine OpenAI Codex Cloud, ChatGPT **Pro** —
+  loop-affordable, no per-credit cost; *not* GitHub Copilot credits)
+- `trigger`: `@codex review` (or Codex automatic review, enabled at
+  chatgpt.com/codex — ON for this repo since 2026-07-03)
+- `assessed_commit_marker`: `Reviewed commit:` — in BOTH formal-review bodies
+  AND the dry-verdict issue-comment, followed by `` `<sha>` ``; read the
+  latest assessed commit from this marker across reviews + issue-comments.
+- `dry_verdict_match`: `Didn't find any major issues` — Codex's no-findings
+  verdict, posted as a **plain PR issue-comment**, not a formal review. A
+  dry-verdict comment on head = clean pass; keying the head check on
+  `pulls/{n}/reviews` alone false-reports "stale review" (elidex
+  `#322`/`#337`).
+
+**Identity caveat**: only the `chatgpt-codex-connector[bot]` review is the
+genuine Pro Codex. A bare `@codex[agent]` mention routes to a GitHub-Copilot
+SWE agent (Copilot credits) — do **not** use it. Lenses reach Codex via
+`AGENTS.md` (`## Review guidelines`).

--- a/.claude/skills/external-review/project.md
+++ b/.claude/skills/external-review/project.md
@@ -60,7 +60,14 @@ symptom-vs-root check per fix. lexime-specific bias:
   `pulls/{n}/reviews` alone false-reports "stale review" (elidex
   `#322`/`#337`).
 
-**Identity caveat**: only the `chatgpt-codex-connector[bot]` review is the
-genuine Pro Codex. A bare `@codex[agent]` mention routes to a GitHub-Copilot
-SWE agent (Copilot credits) — do **not** use it. Lenses reach Codex via
-`AGENTS.md` (`## Review guidelines`).
+**Identity caveat**: the genuine Pro Codex responds as
+`chatgpt-codex-connector[bot]`. `@codex review` requests a review; `@codex`
+with any other instruction starts a Codex **cloud task** with the PR as
+context — both genuine and Pro-billed
+(developers.openai.com/codex/integrations/github). The thing to avoid is
+GitHub Copilot's separate SWE agent (`codex[agent]`, runs on
+`api.individual.githubcopilot.com`, Copilot credits) — on elidex it answered
+`@codex` mentions while the OpenAI connector was not yet installed
+(2026-06-06 billing incident). If a responder is not
+`chatgpt-codex-connector[bot]`, stop and check billing. Lenses reach Codex
+via `AGENTS.md` (`## Review guidelines`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+This repo's engineering rules, build commands, and workflow are in the
+**`CLAUDE.md`** at the repo root — read it first; it is the single source of
+truth. Do not restate or fork its rules here.
+
+## Review guidelines
+
+Codex reads this section for PR code review (it keys on the literal
+`## Review guidelines` heading). The local pre-push gate (Claude-based)
+already covers generic correctness and style, so a generic review adds
+little. Add value by applying lexime's *project-specific* lenses and flagging
+what a generic reviewer misses:
+
+- **Conversion-accuracy impact**: changes to dictionary sources
+  (`engine/data/`, `engine/crates/lex-cli/src/dict_source/`), connection
+  costs, feature weights (`engine/crates/lex-core/src/settings.rs`),
+  rerankers, or the Viterbi path must show before/after results of both
+  accuracy corpora (`mise run accuracy` / `mise run accuracy-history`) in the
+  PR description (CLAUDE.md § 変換精度テスト). Flag cost/weight changes that
+  lack that evidence.
+- **Corpus discipline**: an accuracy-corpus `skip` without an issue link is a
+  violation (理由なし skip 禁止); a new history-corpus case without a
+  `baseline` (expected result with no history) is a real defect, not a nit.
+- **FFI boundary (UniFFI)**: the Rust engine (`engine/`) reaches the Swift
+  frontend (`Sources/`) via UniFFI. Watch for panics that could cross the
+  boundary, blocking calls on the IMKit main thread, and callback
+  re-entrancy.
+- **Concurrency invariants**: history/learning state sits behind locks with a
+  known self-deadlock history (PR #237); lattice generation consistency is
+  epoch-based, including the watermark across FFI (PR #258-260 series). Flag
+  lock-order changes and epoch/generation regressions.
+- **Performance scope**: only the IME hot path (conversion, key handling)
+  is performance-sensitive. Dev-tool (`dictool`) performance nits are
+  acceptable-by-policy — do not raise them.
+- Prioritize conversion correctness and boundary safety over naming/style
+  nits.
+
+CLAUDE.md is the SSoT; this section deliberately does not duplicate its
+content.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ main に直接コミットしない。必ず以下の流れで作業する:
 
 このリポジトリ固有の運用ルール:
 
-- **Codex automatic review が全 PR に自動で付く** (chatgpt.com/codex 設定)。再レビューは PR コメント `@codex review` で依頼する。素の `@codex` mention は Copilot 課金の別 agent なので使わない
+- **Codex automatic review が全 PR に自動で付く** (chatgpt.com/codex 設定)。再レビューは PR コメント `@codex review` で依頼する。`review` 以外の `@codex <指示>` は Codex cloud task として実行される (同じ Pro 課金)。応答者の identity 確認は overlay の Identity caveat 参照
 - **CI 確認**: `gh pr checks {number}` で全チェック pass を確認
 - **マージ前にユーザー確認**: CI pass + レビュー対応完了後でも、`gh pr merge --merge --delete-branch` の前に必ずユーザーに確認を取る (`gh pr merge --auto` 禁止)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,13 @@ main に直接コミットしない。必ず以下の流れで作業する:
 
 ### PR レビュー対応フロー
 
-Copilot レビューは `/copilot-review` スキルで対応する。スキル側に手順 (GraphQL paginated `reviewThreads` での silent-zero 判定、severity calibration、scope-creep / convergence trigger 等) が記載されている。
+外部レビュー (OpenAI Codex) は routine PR は `/external-review` スキル (single-pass triage)、高 stakes / 高 blast-radius PR は `/external-converge` スキル (収束ループ) で対応する。reviewer の詳細 (bot 名、trigger、fetch の罠、latency) は `.claude/skills/external-review/project.md` / `.claude/skills/external-converge/project.md` の overlay に記載。Codex へのレビュー観点の供給は `AGENTS.md` の `## Review guidelines` 節 (pointer-only、SSoT は本ファイル)。
 
 このリポジトリ固有の運用ルール:
 
-- **初回 Copilot レビューはリポジトリ設定で自動リクエスト**。Claude が `requestReviews` を呼ぶのは収束ループ内の再レビュー依頼時のみ
+- **Codex automatic review が全 PR に自動で付く** (chatgpt.com/codex 設定)。再レビューは PR コメント `@codex review` で依頼する。素の `@codex` mention は Copilot 課金の別 agent なので使わない
 - **CI 確認**: `gh pr checks {number}` で全チェック pass を確認
-- **マージ前にユーザー確認**: CI pass + Copilot 収束 (TERMINAL) 後でも、`gh pr merge --merge --delete-branch` の前に必ずユーザーに確認を取る (`gh pr merge --auto` 禁止)
+- **マージ前にユーザー確認**: CI pass + レビュー対応完了後でも、`gh pr merge --merge --delete-branch` の前に必ずユーザーに確認を取る (`gh pr merge --auto` 禁止)
 
 ## コミット規約
 


### PR DESCRIPTION
## Summary

Copilot Pro 解約に伴い、非-Claude diversity reviewer を OpenAI Codex (`chatgpt-codex-connector[bot]`, ChatGPT Pro) へ移行する。elidex で確立した体制の lexime 適用。

- **AGENTS.md** (新規): Codex が読む `## Review guidelines`。pointer-only (SSoT は CLAUDE.md)。lexime 固有レンズ = 変換精度影響 (accuracy before/after 必須)、コーパス規律 (skip issue リンク / history `baseline`)、UniFFI 境界、並行性不変条件、perf スコープ (dictool は WONTFIX-by-policy)
- **`.claude/skills/external-{review,converge}/project.md`** (新規): グローバル `/external-review` / `/external-converge` スキル用 reviewer overlay。bot identity / GraphQL `[bot]` 正規化 / dry-verdict は issue-comment / `Reviewed commit:` marker / latency ~15min、`build_verify`、lexime 固有 classification calibration
- **CLAUDE.md**: PR レビュー対応フローを `/copilot-review` (スキル自体が既に廃止済) から `/external-review` + `/external-converge` に書き換え。Copilot 自動リクエスト前提を Codex automatic review に置換

## 前提 (実施済み・2026-07-03)

- Codex に send/lexime 接続 + automatic code review ON (chatgpt.com/codex)
- Codex 環境の agent network access = restricted allowlist (crates.io 系 + GitHub 系、GET/HEAD/OPTIONS)
- GitHub 側の Copilot auto-review request OFF

## Test plan

- [x] docs/config のみ、コード変更なし (CI の Rust/Swift ゲートに影響なし)
- [ ] この PR 自体に Codex automatic review が付くこと (= 移行の実地確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)