### PR TITLE
feat(history): LXUD v2 PR2 — WAL-ahead write protocol (tombstone deletes, empty-checkpoint clear)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -389,18 +389,18 @@ decay = 1.0 / (1.0 + hours_elapsed / 168.0)
 | バリアント | 説明 |
 |---|---|
 | `Committed { reading, surface, segments }` | 確定時に生成。FFI 層が `UserHistory::record_at()` で whole-reading + sub-segments の 2 段階記録 |
-| `Deletion { segments }` | ForwardDelete 時に生成。FFI 層が `UserHistory::remove_entries()` でユニグラム・バイグラムを削除し、`force_compact()` で即座に永続化 |
+| `Deletion { segments }` | ForwardDelete 時に生成。FFI 層が WAL に `Tombstone` frame を append（毎回 `F_FULLFSYNC`）し、`UserHistory::remove_entries()` でメモリから削除、非同期スクラブ compaction で checkpoint から物理消去 |
 
 ### 個別削除
 
-候補選択中に Fn+Delete を押すと、選択中の候補に対応する学習エントリ（ユニグラム + バイグラム）を削除する。削除後は `force_compact()` で即座にチェックポイントを書き出し、WAL リプレイによる復活を防ぐ。`force_compact()` はバックグラウンドコンパクションとの競合を `compacting` ガードで直列化する。
+候補選択中に Fn+Delete を押すと、選択中の候補に対応する学習エントリ（ユニグラム + バイグラム）を削除する。削除は WAL に `Tombstone` frame を書き込んで（書き込み時に `F_FULLFSYNC`）耐久化し、replay 時に削除が再適用されるため WAL リプレイで復活しない。物理スクラブ（旧 checkpoint と過去 Committed frame に残る文字列の消去）は直後に非同期 compaction をスケジュールして行い、`scrub_pending` + `compact_gate`（Mutex）で直列化する。学習されていない候補の削除（no-op）には Tombstone を書かず `F_FULLFSYNC` を払わない。
 
 ### 保存（WAL + Checkpoint、LXUD v2）
 
 - **Checkpoint**: LXUD v2（32 バイト固定ヘッダ: マジック `LXUD` + version 2 + `applied_seq` + created_at + body_len + CRC32、body は bincode。CRC はヘッダ先頭 28 バイト + body を保護 — `applied_seq` は replay filter を駆動するため無防備な bit flip を許さない）。v1（マジック + version 1 + bincode）の reader を保持し、起動時に一回で v2 へ migration（元 v1 は `.v1.bak` へ best-effort 退避）
 - **WAL**: `user_history.lxud.wal`（8 バイトファイルヘッダ `LXWL` + version 2。フレーム形式: payload_len + CRC32(seq+payload) + seq + bincode(`WalRecord::Committed|Tombstone`)）
 - **seq**: WAL フレームは単調増加の連番を持ち、checkpoint ヘッダの `applied_seq` が「効果を含む最後の seq」を記録。replay は `seq > applied_seq` のフレームのみ適用するため、checkpoint 書き込みと WAL truncate の間でクラッシュしても二重適用が構造的に起きない
-- **書き込み**: 確定時に WAL append（Committed は 50 frame ごとに write barrier = `fcntl(F_BARRIERFSYNC)`）、閾値到達で background compaction（checkpoint を tmp + `sync_all` + rename + 親 dir fsync（best-effort・log-only）で書き出し + 条件付き WAL truncate）。compaction の排他は `compact_gate` (Mutex)、削除・障害後の即時要求は `scrub_pending` で直列化。Tombstone frame（削除の WAL 表現、書き込み時に毎回 `F_FULLFSYNC`）は reader を先行導入済みで、writer は次期変更で導入予定 — 現状の削除は `force_compact()`（同期 checkpoint 書き出し）による
+- **書き込み**: 確定時に WAL append（Committed は 50 frame ごとに write barrier = `fcntl(F_BARRIERFSYNC)`）、閾値到達で background compaction（checkpoint を tmp + `sync_all` + rename + 親 dir fsync（best-effort・log-only）で書き出し + 条件付き WAL truncate）。compaction の排他は `compact_gate` (Mutex)、削除・障害後の即時要求は `scrub_pending` で直列化。削除は `Tombstone` frame（削除の WAL 表現、書き込み時に毎回 `F_FULLFSYNC`）を append し、直後に非同期スクラブ compaction をスケジュールして物理消去する。全消去（`clear`）は空 checkpoint（`applied_seq` = 現 WAL 最大 seq）を先行書き込みしてコミットポイントとし、以後どのクラッシュ点でも空履歴に収束する（旧 WAL frame は全て skip される）
 - **場所**: `~/Library/Application Support/Lexime/user_history.lxud`
 - **起動時（エンジン経路）**: `recovery::open_recovering` — checkpoint ロード → WAL replay（evict なし + 事後 1 回）→ in-memory 復元。破損は `.corrupt-<epoch>` へ隔離（直近 3 個保持）して空で継続、WAL 末尾破損は last-good オフセットで物理修復。どのファイル状態でも起動は成功し学習は継続する（`OpenReport` に結果を記録。Err は EACCES 等の環境障害のみ）
 - **オフラインツール経路**: `UserHistory::open` / `open_with_wal` は無副作用・厳格エラーのまま（監査ツールが稼働中 IME のファイルを rename しない）

--- a/Sources/EngineContainer.swift
+++ b/Sources/EngineContainer.swift
@@ -129,7 +129,7 @@ final class EngineContainer {
                 failures.append(.historyDataLoss(detail: detail))
             } else if report.migratedFromV1 {
                 NSLog("Lexime: User history migrated from v1 (\(report.framesReplayed) frames)")
-            } else if report.walState != .clean && report.walState != .missing {
+            } else if !report.clean {
                 NSLog(
                     "Lexime: User history recovery events: checkpoint=\(report.checkpointState) wal=\(report.walState)"
                 )

--- a/Sources/EngineContainer.swift
+++ b/Sources/EngineContainer.swift
@@ -10,8 +10,12 @@ enum EngineInitFailure {
     /// Composite (system + user) dictionary creation failed;
     /// user dictionary entries are not reflected in conversion.
     case compositeDictionary(detail: String)
-    /// User history could not be opened (learning disabled).
+    /// User history could not be opened (learning disabled). Environmental
+    /// read failures only (e.g. permissions) — corruption no longer throws.
     case history(detail: String)
+    /// User history recovery quarantined corrupt data: learning is running,
+    /// but some past learning was lost (bytes preserved in `.corrupt-*`).
+    case historyDataLoss(detail: String)
     /// Custom settings.toml exists but failed to parse (defaults in effect).
     case customSettings(detail: String)
 }
@@ -110,6 +114,26 @@ final class EngineContainer {
         do {
             let h = try LexUserHistory.open(path: historyPath)
             NSLog("Lexime: User history loaded from %@", historyPath)
+            // Recovery report (§10): quarantine = user-visible data loss
+            // (learning keeps running); everything else is log-only (§8 ※1:
+            // tail repair is the expected power-loss residue, migration is
+            // routine).
+            let report = h.openReport()
+            if report.dataLossSuspected {
+                var detail =
+                    "checkpoint: \(report.checkpointState), wal: \(report.walState)"
+                if !report.quarantinedPaths.isEmpty {
+                    detail += ", quarantined: \(report.quarantinedPaths.joined(separator: ", "))"
+                }
+                NSLog("Lexime: User history recovered with data loss (%@)", detail)
+                failures.append(.historyDataLoss(detail: detail))
+            } else if report.migratedFromV1 {
+                NSLog("Lexime: User history migrated from v1 (\(report.framesReplayed) frames)")
+            } else if report.walState != .clean && report.walState != .missing {
+                NSLog(
+                    "Lexime: User history recovery events: checkpoint=\(report.checkpointState) wal=\(report.walState)"
+                )
+            }
             history = h
         } catch {
             NSLog("Lexime: Failed to open user history at %@: %@", historyPath, "\(error)")

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -198,6 +198,10 @@ class LeximeInputController: IMKInputController {
             return NSLocalizedString(
                 "⚠️ 学習履歴の読み込みに失敗",
                 comment: "Degraded status: user history failed")
+        case .historyDataLoss:
+            return NSLocalizedString(
+                "⚠️ 学習履歴の一部を復旧できませんでした（学習は継続中）",
+                comment: "Degraded status: user history partially lost, learning continues")
         case .customSettings:
             return NSLocalizedString(
                 "⚠️ 設定ファイルの読み込みに失敗（デフォルト設定で動作中）",

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -154,7 +154,8 @@ struct DeveloperSettingsView: View {
     private func resetAll() {
         NSLog("Lexime: Resetting all settings and history")
 
-        // 1. Clear learning history via engine (closes WAL handle + deletes files)
+        // 1. Clear learning history via engine (empty-checkpoint protocol; a
+        //    partial physical failure is logged and scrubbed at next startup)
         do {
             try engineControl.clearHistory()
             NSLog("Lexime: History cleared")

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -30,6 +30,7 @@ struct DeveloperSettingsView: View {
     @State private var settingsText = ""
     @State private var needsRestart = false
     @State private var showResetConfirm = false
+    @State private var resetError: String?
 
     private let supportDir: String
     private let engineControl: EngineControlService
@@ -121,6 +122,14 @@ struct DeveloperSettingsView: View {
         } message: {
             Text("設定ファイル（settings.toml, romaji.toml）と学習履歴を削除して再起動します。この操作は取り消せません。")
         }
+        .alert("初期化エラー", isPresented: Binding(
+            get: { resetError != nil },
+            set: { if !$0 { resetError = nil } }
+        )) {
+            Button("OK") { resetError = nil }
+        } message: {
+            Text(resetError ?? "")
+        }
     }
 
     // MARK: - Components
@@ -153,14 +162,19 @@ struct DeveloperSettingsView: View {
 
     private func resetAll() {
         NSLog("Lexime: Resetting all settings and history")
+        var problems: [String] = []
 
-        // 1. Clear learning history via engine (empty-checkpoint protocol; a
-        //    partial physical failure is logged and scrubbed at next startup)
+        // 1. Clear learning history via engine (empty-checkpoint protocol).
+        //    clear_impl scrubs the checkpoint, WAL, and commit-log and returns
+        //    an error only if some physical scrub could not complete. Surface
+        //    it instead of restarting as if the wipe were done — an incomplete
+        //    privacy wipe must never be silent.
         do {
             try engineControl.clearHistory()
             NSLog("Lexime: History cleared")
         } catch {
             NSLog("Lexime: Failed to clear history: %@", "\(error)")
+            problems.append("学習履歴: \(error)")
         }
 
         // 2. Delete config files
@@ -173,11 +187,20 @@ struct DeveloperSettingsView: View {
                     NSLog("Lexime: Deleted %@", path)
                 } catch {
                     NSLog("Lexime: Failed to delete %@: %@", path, "\(error)")
+                    problems.append("\(name): \(error)")
                 }
             }
         }
 
-        // 3. Restart
+        // 3. Restart only on a fully successful wipe; otherwise surface the
+        //    partial failure so the user knows data may remain, rather than
+        //    silently restarting into a state they believe is clean.
+        guard problems.isEmpty else {
+            resetError =
+                "初期化の一部に失敗しました。データが残っている可能性があります。\n\n"
+                + problems.joined(separator: "\n")
+            return
+        }
         NSLog("Lexime: Restarting after reset")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             // IME processes are managed by launchd; exit(0) triggers automatic restart.

--- a/engine/crates/lex-core/src/user_history/mod.rs
+++ b/engine/crates/lex-core/src/user_history/mod.rs
@@ -146,6 +146,32 @@ impl UserHistory {
     /// Apply one WAL record and advance `applied_seq`. Does not evict —
     /// replay applies many frames and evicts once afterwards.
     pub fn apply(&mut self, record: &wal::WalRecord, seq: u64) {
+        self.apply_effect(record);
+        self.advance_applied_seq(seq);
+    }
+
+    /// Apply a batch of records and settle capacity once (§5.2). A record's
+    /// `seq` is `None` when its frame never reached the WAL (append
+    /// failure): the effect still applies, but coverage must not advance —
+    /// a checkpoint claiming a frame that cannot replay would let the
+    /// conditional truncation destroy learning.
+    pub fn apply_batch(&mut self, records: &[(wal::WalRecord, Option<u64>)]) {
+        let mut any_committed = false;
+        for (record, seq) in records {
+            self.apply_effect(record);
+            if let Some(seq) = seq {
+                self.advance_applied_seq(*seq);
+            }
+            any_committed |= matches!(record, wal::WalRecord::Committed { .. });
+        }
+        // Deletions only shrink the maps; skip the O(entries) capacity scan
+        // unless something grew.
+        if any_committed {
+            self.evict();
+        }
+    }
+
+    fn apply_effect(&mut self, record: &wal::WalRecord) {
         match record {
             wal::WalRecord::Committed {
                 segments,
@@ -155,7 +181,6 @@ impl UserHistory {
                 self.remove_entries(segments);
             }
         }
-        self.advance_applied_seq(seq);
     }
 
     /// Record a confirmed conversion: list of (reading, surface) segments.
@@ -291,33 +316,25 @@ impl UserHistory {
     }
 
     /// Whether any unigram/bigram entry exists for these segments — exactly
-    /// the set [`Self::remove_entries`] would touch. Lets the engine skip
-    /// writing a Tombstone (and its F_FULLFSYNC on the key-processing
-    /// thread) for a no-op deletion, e.g. pruning a dictionary-only
-    /// candidate that was never learned.
+    /// the set [`Self::remove_entries`] would touch (the equivalence is
+    /// pinned by a test). Lets the engine skip writing a Tombstone (and its
+    /// F_FULLFSYNC on the key-processing thread) for a no-op deletion, e.g.
+    /// pruning a dictionary-only candidate that was never learned. The
+    /// bigram probe scans keys linearly: the per-prev-surface maps are
+    /// small, and it avoids allocating a `(String, String)` key inside the
+    /// wal-mutex critical section.
     pub fn contains_entries(&self, segments: &[(String, String)]) -> bool {
-        for (reading, surface) in segments {
-            if self
-                .unigrams
+        segments.iter().any(|(reading, surface)| {
+            self.unigrams
                 .get(reading)
                 .is_some_and(|inner| inner.contains_key(surface))
-            {
-                return true;
-            }
-        }
-        for pair in segments.windows(2) {
-            let (_, prev_surface) = &pair[0];
-            let (next_reading, next_surface) = &pair[1];
-            let key = (next_reading.clone(), next_surface.clone());
-            if self
-                .bigrams
-                .get(prev_surface)
-                .is_some_and(|inner| inner.contains_key(&key))
-            {
-                return true;
-            }
-        }
-        false
+        }) || segments.windows(2).any(|pair| {
+            self.bigrams.get(&pair[0].1).is_some_and(|inner| {
+                inner
+                    .keys()
+                    .any(|(r, s)| *r == pair[1].0 && *s == pair[1].1)
+            })
+        })
     }
 
     /// Remove history entries for the given segments.
@@ -350,10 +367,10 @@ impl UserHistory {
         removed
     }
 
-    /// Evict lowest-score entries when exceeding capacity. Public for the
-    /// engine's batched apply path (§5.2): apply a whole batch of records,
-    /// then settle capacity once — replay does the same (§5.1-4).
-    pub fn evict(&mut self) {
+    /// Evict lowest-score entries when exceeding capacity. Batch paths
+    /// ([`Self::apply_batch`], replay) apply many records and settle
+    /// capacity once afterwards.
+    fn evict(&mut self) {
         let s = settings();
         let now = now_epoch();
         evict_map(&mut self.unigrams, s.history.max_unigrams, now);

--- a/engine/crates/lex-core/src/user_history/mod.rs
+++ b/engine/crates/lex-core/src/user_history/mod.rs
@@ -290,6 +290,36 @@ impl UserHistory {
         with_boost.iter().map(|(_, _, e)| (*e).clone()).collect()
     }
 
+    /// Whether any unigram/bigram entry exists for these segments — exactly
+    /// the set [`Self::remove_entries`] would touch. Lets the engine skip
+    /// writing a Tombstone (and its F_FULLFSYNC on the key-processing
+    /// thread) for a no-op deletion, e.g. pruning a dictionary-only
+    /// candidate that was never learned.
+    pub fn contains_entries(&self, segments: &[(String, String)]) -> bool {
+        for (reading, surface) in segments {
+            if self
+                .unigrams
+                .get(reading)
+                .is_some_and(|inner| inner.contains_key(surface))
+            {
+                return true;
+            }
+        }
+        for pair in segments.windows(2) {
+            let (_, prev_surface) = &pair[0];
+            let (next_reading, next_surface) = &pair[1];
+            let key = (next_reading.clone(), next_surface.clone());
+            if self
+                .bigrams
+                .get(prev_surface)
+                .is_some_and(|inner| inner.contains_key(&key))
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Remove history entries for the given segments.
     /// Returns true if any entries were actually removed.
     pub fn remove_entries(&mut self, segments: &[(String, String)]) -> bool {
@@ -320,8 +350,10 @@ impl UserHistory {
         removed
     }
 
-    /// Evict lowest-score entries when exceeding capacity.
-    fn evict(&mut self) {
+    /// Evict lowest-score entries when exceeding capacity. Public for the
+    /// engine's batched apply path (§5.2): apply a whole batch of records,
+    /// then settle capacity once — replay does the same (§5.1-4).
+    pub fn evict(&mut self) {
         let s = settings();
         let now = now_epoch();
         evict_map(&mut self.unigrams, s.history.max_unigrams, now);

--- a/engine/crates/lex-core/src/user_history/recovery.rs
+++ b/engine/crates/lex-core/src/user_history/recovery.rs
@@ -29,6 +29,13 @@ use super::UserHistory;
 /// How many quarantined (`.corrupt-*`) files to retain per history family.
 const QUARANTINE_KEEP: usize = 3;
 
+/// GC horizon for the v1 migration backup (`.v1.bak`), ~90 days. Its value
+/// as a manual rescue hatch (downgrade / migration bug) concentrates right
+/// after migration; a time-based GC keeps cleanup independent of release
+/// cadence (no "remove in version N+2" bookkeeping). `clear()` removes it
+/// immediately regardless (privacy wipe).
+const V1_BACKUP_TTL_SECS: u64 = 90 * 24 * 60 * 60;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum CheckpointState {
     /// Read successfully (v2).
@@ -305,16 +312,47 @@ pub fn open_recovering(
     // data_loss_suspected() keys off the quarantine *states*, not the path
     // list: quarantine() can succeed via the remove-file fallback without
     // recording a path, and that case still needs an early re-checkpoint.
+    // frames_skipped: every skipped frame is already covered by the
+    // checkpoint, so the whole file is truncation-eligible — this is the
+    // residue of a crash between checkpoint write and truncation, or of a
+    // clear whose truncation failed. The latter makes this a privacy
+    // backstop: a clear's leftover input strings are scrubbed on the next
+    // startup even if the post-clear heal never ran (e.g. the reset flow
+    // restarts the process immediately).
     report.compaction_recommended = report.migrated_from_v1
         || report.data_loss_suspected()
         || (report.checkpoint_state == CheckpointState::Missing && report.frames_replayed > 0)
+        || report.frames_skipped > 0
         || wal.needs_compact()
         || wal.is_frozen();
 
-    // --- 5. quarantine rotation ---
+    // --- 5. quarantine rotation + v1-backup GC ---
     rotate_quarantined(checkpoint_path);
+    gc_v1_backup(checkpoint_path);
 
     Ok((history, wal, report))
+}
+
+/// Best-effort removal of an expired `.v1.bak` (see [`V1_BACKUP_TTL_SECS`]).
+/// A backup written by this very startup has a fresh mtime and survives.
+fn gc_v1_backup(checkpoint_path: &Path) {
+    let path = v1_backup_path(checkpoint_path);
+    let Ok(meta) = fs::metadata(&path) else {
+        return;
+    };
+    let Ok(modified) = meta.modified() else {
+        return;
+    };
+    let age = std::time::SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default();
+    if age.as_secs() <= V1_BACKUP_TTL_SECS {
+        return;
+    }
+    match fs::remove_file(&path) {
+        Ok(()) => info!("removed expired v1 checkpoint backup {}", path.display()),
+        Err(e) => warn!("failed to remove expired v1 backup {}: {e}", path.display()),
+    }
 }
 
 /// Path of the best-effort v1 checkpoint backup (`<name>.v1.bak`).

--- a/engine/crates/lex-core/src/user_history/recovery.rs
+++ b/engine/crates/lex-core/src/user_history/recovery.rs
@@ -82,6 +82,10 @@ pub struct OpenReport {
     pub frames_replayed: u64,
     pub frames_skipped: u64,
     pub quarantined_paths: Vec<PathBuf>,
+    /// A replayed Tombstone left deleted strings in the old checkpoint /
+    /// earlier frames unscrubbed — feeds `compaction_recommended` (§5.4).
+    /// Not surfaced over UniFFI; an internal startup-scrub signal.
+    pub replayed_deletion: bool,
     /// Startup-compaction hint (§5.1-6): recovery results should be
     /// checkpointed early so the next startup is clean. Consumed in PR2.
     pub compaction_recommended: bool,
@@ -119,6 +123,7 @@ pub fn open_recovering(
         frames_replayed: 0,
         frames_skipped: 0,
         quarantined_paths: Vec::new(),
+        replayed_deletion: false,
         compaction_recommended: false,
     };
 
@@ -214,6 +219,7 @@ pub fn open_recovering(
                     let scan = scan_v2(&data, &mut history);
                     report.frames_replayed = scan.frames_applied;
                     report.frames_skipped = scan.frames_skipped;
+                    report.replayed_deletion = scan.replayed_deletion;
                     // wal_bytes reflects the on-disk size, so start from the
                     // valid-prefix length only when the repair below actually
                     // shrinks the file to it.
@@ -319,10 +325,17 @@ pub fn open_recovering(
     // backstop: a clear's leftover input strings are scrubbed on the next
     // startup even if the post-clear heal never ran (e.g. the reset flow
     // restarts the process immediately).
+    // replayed_deletion: the delete-residue counterpart of frames_skipped.
+    // A crash between a Tombstone append and its async scrub leaves the
+    // deleted strings in the old checkpoint (and earlier frames); on restart
+    // the Tombstone replays (deletion correct) but nothing is skipped, so
+    // without this signal no scrub would run until an unrelated compaction,
+    // leaving the input on disk indefinitely.
     report.compaction_recommended = report.migrated_from_v1
         || report.data_loss_suspected()
         || (report.checkpoint_state == CheckpointState::Missing && report.frames_replayed > 0)
         || report.frames_skipped > 0
+        || report.replayed_deletion
         || wal.needs_compact()
         || wal.is_frozen();
 

--- a/engine/crates/lex-core/src/user_history/tests.rs
+++ b/engine/crates/lex-core/src/user_history/tests.rs
@@ -568,3 +568,50 @@ fn test_remove_entries_preserves_other_entries() {
     // "京" should still exist
     assert!(h.unigram_boost("きょう", "京", now_epoch()) > 0);
 }
+
+#[test]
+fn test_contains_entries_matches_remove_entries() {
+    // The engine's no-op Tombstone skip relies on contains_entries being
+    // true exactly when remove_entries would remove something — this test
+    // pins the equivalence the doc comment claims.
+    let probes: Vec<Vec<(String, String)>> = vec![
+        vec![("きょう".into(), "今日".into())],
+        vec![("きょう".into(), "京".into())], // learned reading, other surface
+        vec![("なし".into(), "無し".into())], // never learned
+        vec![
+            ("あす".into(), "明日".into()),
+            ("いく".into(), "行く".into()),
+        ],
+        vec![
+            ("あす".into(), "明日".into()),
+            ("かう".into(), "買う".into()),
+        ], // bigram absent
+    ];
+    let build = || {
+        let mut h = UserHistory::new();
+        h.record(&[("きょう".into(), "今日".into())]);
+        h.record(&[
+            ("あす".into(), "明日".into()),
+            ("いく".into(), "行く".into()),
+        ]);
+        h
+    };
+    for probe in &probes {
+        let h = build();
+        let mut remover = h.clone();
+        assert_eq!(
+            h.contains_entries(probe),
+            remover.remove_entries(probe),
+            "contains/remove diverged for {probe:?}"
+        );
+    }
+    // Bigram-only presence (unigrams gone, bigram remains) must count.
+    let mut h = build();
+    h.unigrams.clear();
+    let probe = vec![
+        ("あす".to_string(), "明日".to_string()),
+        ("いく".to_string(), "行く".to_string()),
+    ];
+    assert!(h.contains_entries(&probe));
+    assert!(h.remove_entries(&probe));
+}

--- a/engine/crates/lex-core/src/user_history/tests_recovery.rs
+++ b/engine/crates/lex-core/src/user_history/tests_recovery.rs
@@ -1216,6 +1216,156 @@ fn append_write_failure_freezes_until_truncate() {
     assert!(!wal.is_frozen());
 }
 
+// ---------------------------------------------------------------------------
+// T6: syscall ordering / mid-write failure (WalIo seam, design §11)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum IoOp {
+    Append,
+    Barrier,
+    Full,
+    Truncate,
+}
+
+/// Records the WalIo call order; optionally fails sync_full.
+struct OrderIo {
+    ops: std::sync::Arc<std::sync::Mutex<Vec<IoOp>>>,
+    fail_full: bool,
+}
+
+impl super::wal::WalIo for OrderIo {
+    fn append(&mut self, _buf: &[u8]) -> std::io::Result<()> {
+        self.ops.lock().unwrap().push(IoOp::Append);
+        Ok(())
+    }
+    fn sync_barrier(&mut self) -> std::io::Result<()> {
+        self.ops.lock().unwrap().push(IoOp::Barrier);
+        Ok(())
+    }
+    fn sync_full(&mut self) -> std::io::Result<()> {
+        if self.fail_full {
+            return Err(std::io::Error::other("injected full-sync failure"));
+        }
+        self.ops.lock().unwrap().push(IoOp::Full);
+        Ok(())
+    }
+    fn truncate_to_header(&mut self) -> std::io::Result<()> {
+        self.ops.lock().unwrap().push(IoOp::Truncate);
+        Ok(())
+    }
+}
+
+fn tombstone(pair: (&str, &str)) -> WalRecord {
+    WalRecord::Tombstone {
+        segments: seg(pair),
+        timestamp: T0,
+    }
+}
+
+#[test]
+fn t6_tombstone_full_sync_follows_write_before_return() {
+    // §5.4/§6: a Tombstone's durability contract is a full flush after the
+    // frame write, before append_record returns — the deletion must not be
+    // resurrectable once the user's gesture completes.
+    let f = fx();
+    let ops = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let io = OrderIo {
+        ops: std::sync::Arc::clone(&ops),
+        fail_full: false,
+    };
+    let mut wal = HistoryWal::with_io(&f.cp, Box::new(io));
+    wal.append_record(&tombstone(A)).unwrap();
+    assert_eq!(
+        *ops.lock().unwrap(),
+        vec![IoOp::Append, IoOp::Full],
+        "tombstone must be written, then fully flushed, before returning"
+    );
+}
+
+#[test]
+fn t6_tombstone_sync_failure_carries_seq_and_does_not_freeze() {
+    // The frame is validly on disk; only its flush failed. The caller must
+    // receive the real seq (covering the frame keeps conditional truncation
+    // live) and the WAL must stay appendable.
+    let f = fx();
+    let ops = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let io = OrderIo {
+        ops: std::sync::Arc::clone(&ops),
+        fail_full: true,
+    };
+    let mut wal = HistoryWal::with_io(&f.cp, Box::new(io));
+    match wal.append_record(&tombstone(A)) {
+        Err(super::wal::AppendError::SyncFailed { seq, .. }) => assert_eq!(seq, 1),
+        other => panic!("expected SyncFailed, got {other:?}"),
+    }
+    assert!(!wal.is_frozen(), "a sync failure must not freeze the WAL");
+    assert_eq!(wal.entry_count(), 1, "the frame is in the file");
+    assert_eq!(wal.last_appended_seq(), 1);
+    // The next append still works and gets the next seq.
+    assert_eq!(wal.append(&seg(B), T0 + 1).unwrap(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// T7 (core side): clear-protocol crash residue (§5.5)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn t7_clear_residue_empty_checkpoint_covers_leftover_wal() {
+    // Crash between §5.5 step 3 (empty checkpoint committed) and step 5
+    // (WAL truncation): the empty checkpoint's applied_seq equals the
+    // highest on-disk seq, so every leftover frame replays as a skip and
+    // the history converges to empty — the resurrection window is zero.
+    let f = fx();
+    let mut wal = HistoryWal::new(&f.cp);
+    for (i, p) in [A, B, C].iter().enumerate() {
+        wal.append(&seg(*p), T0 + i as u64).unwrap();
+    }
+    let mut empty = UserHistory::new();
+    empty.advance_applied_seq(wal.last_appended_seq());
+    empty.save(&f.cp).unwrap();
+    drop(wal);
+
+    let (h, mut wal, report) = open_recovering(&f.cp).unwrap();
+    assert_contents(&h, &[], &[A, B, C]);
+    assert_eq!(report.frames_replayed, 0);
+    assert_eq!(
+        report.frames_skipped, 3,
+        "all frames covered by the empty cp"
+    );
+    assert_eq!(report.checkpoint_state, CheckpointState::Loaded);
+    // Privacy backstop: the leftover (covered) frames still hold input
+    // strings; startup compaction truncates them away.
+    assert!(report.compaction_recommended);
+    // Numbering continues past the cleared generation (§3).
+    assert_eq!(wal.append(&seg(D), T0 + 10).unwrap(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// v1 backup GC (time-based, §9 decision)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v1_backup_expires_after_ttl() {
+    let f = fx();
+    UserHistory::new().save(&f.cp).unwrap();
+    let bak = v1_backup_path(&f.cp);
+
+    // Fresh backup survives startup.
+    fs::write(&bak, b"v1 bytes").unwrap();
+    open_recovering(&f.cp).unwrap();
+    assert!(bak.exists(), "fresh backup must survive");
+
+    // Backdate past the 90-day TTL: the next startup removes it.
+    let old = std::time::SystemTime::now() - std::time::Duration::from_secs(91 * 24 * 60 * 60);
+    let file = fs::OpenOptions::new().write(true).open(&bak).unwrap();
+    file.set_times(fs::FileTimes::new().set_modified(old))
+        .unwrap();
+    drop(file);
+    open_recovering(&f.cp).unwrap();
+    assert!(!bak.exists(), "expired backup must be GCed");
+}
+
 #[test]
 fn remove_recovery_artifacts_wipes_backup_and_quarantine() {
     let f = fx();

--- a/engine/crates/lex-core/src/user_history/tests_recovery.rs
+++ b/engine/crates/lex-core/src/user_history/tests_recovery.rs
@@ -845,6 +845,43 @@ fn tombstone_replay_removes_entries() {
 }
 
 #[test]
+fn replayed_tombstone_recommends_startup_scrub() {
+    // A crash between a Tombstone append and its async scrub: the loaded
+    // checkpoint still contains the deleted strings and the WAL carries an
+    // uncovered Tombstone. Replay applies the deletion but skips nothing
+    // (frames_skipped == 0), so the startup scrub must be driven by the
+    // replayed-deletion signal — otherwise the deleted input lingers in the
+    // old checkpoint until an unrelated compaction (§5.4 privacy).
+    let f = fx();
+    // Checkpoint (applied_seq = 0) that still contains A.
+    let mut h = UserHistory::new();
+    h.record_at(&seg(A), T0);
+    h.save(&f.cp).unwrap();
+    // WAL with an uncovered Tombstone (seq 1 > applied_seq 0).
+    let mut wal = HistoryWal::new(&f.cp);
+    wal.append_record(&WalRecord::Tombstone {
+        segments: seg(A),
+        timestamp: T0 + 1,
+    })
+    .unwrap();
+    drop(wal);
+
+    let (h, _, report) = open_recovering(&f.cp).unwrap();
+    assert_contents(&h, &[], &[A]); // deletion applied
+    assert_eq!(report.checkpoint_state, CheckpointState::Loaded);
+    assert_eq!(report.frames_replayed, 1);
+    assert_eq!(report.frames_skipped, 0);
+    assert!(
+        report.replayed_deletion,
+        "a replayed tombstone was observed"
+    );
+    assert!(
+        report.compaction_recommended,
+        "delete-residue must schedule a startup scrub even with no skipped frames"
+    );
+}
+
+#[test]
 fn truncate_covered_requires_checkpoint_coverage() {
     let f = fx();
     let mut wal = HistoryWal::new(&f.cp);

--- a/engine/crates/lex-core/src/user_history/wal.rs
+++ b/engine/crates/lex-core/src/user_history/wal.rs
@@ -69,6 +69,41 @@ pub enum WalRecord {
     },
 }
 
+/// Why an append failed. The two variants leave the file in different
+/// states, and callers must treat the assigned seq differently:
+///
+/// - `Io`: the frame never (fully) reached the file. The WAL freezes and
+///   the seq is consumed as a gap — the in-memory effect must be applied
+///   without advancing `applied_seq` (the frame cannot replay).
+/// - `SyncFailed`: the frame is validly appended and readable; only its
+///   durability flush failed (the Tombstone contract). Callers must apply
+///   with the carried `seq`: leaving a frame that is on disk uncovered
+///   would hold `applied_seq < last_appended_seq` open indefinitely, and
+///   `truncate_covered` would never run again until an unrelated append.
+///   Replaying a Tombstone after a checkpoint that already contains the
+///   deletion is idempotent, so covering it is safe.
+#[derive(Debug)]
+pub enum AppendError {
+    Io(io::Error),
+    SyncFailed { seq: u64, source: io::Error },
+}
+
+impl std::fmt::Display for AppendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppendError::Io(e) => write!(f, "WAL append failed: {e}"),
+            AppendError::SyncFailed { seq, source } => {
+                write!(
+                    f,
+                    "WAL frame {seq} appended but durability sync failed: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for AppendError {}
+
 /// v1 WAL entry (headerless file of `length + crc32(payload) + payload`
 /// frames). Retained for the migration reader and test fixtures.
 #[derive(Serialize, Deserialize)]
@@ -395,7 +430,11 @@ impl HistoryWal {
     }
 
     /// Append a Committed record. Returns the assigned sequence number.
-    pub fn append(&mut self, segments: &[(String, String)], timestamp: u64) -> io::Result<u64> {
+    pub fn append(
+        &mut self,
+        segments: &[(String, String)],
+        timestamp: u64,
+    ) -> Result<u64, AppendError> {
         self.append_record(&WalRecord::Committed {
             segments: segments.to_vec(),
             timestamp,
@@ -409,29 +448,29 @@ impl HistoryWal {
     /// resurrects even across power loss. Committed frames take a write
     /// barrier every [`BARRIER_EVERY_FRAMES`] frames instead.
     ///
-    /// Failure semantics:
-    /// - `Err` before the frame write: nothing on disk; the assigned seq is
+    /// Failure semantics (see [`AppendError`] for the caller contract):
+    /// - `Io` before the frame write: nothing on disk; the assigned seq is
     ///   consumed (gaps are legal, §3, replay only warns).
-    /// - Frame write failure: a partial frame may sit at the tail, and any
-    ///   later append would land after unreadable bytes and be lost to
-    ///   replay (problem A at runtime) — so the WAL freezes until a
+    /// - Frame write failure (`Io`): a partial frame may sit at the tail,
+    ///   and any later append would land after unreadable bytes and be lost
+    ///   to replay (problem A at runtime) — so the WAL freezes until a
     ///   truncation (post-checkpoint) re-establishes appendable form.
     /// - Committed barrier failure: logged, still `Ok` — the frame is in
     ///   the file (callers must count it as covered or a crash would
     ///   double-apply it); only the power-loss window widens.
-    /// - Tombstone `sync_full` failure: `Err`, because the immediate
+    /// - Tombstone `sync_full` failure: `SyncFailed`, because the immediate
     ///   durability is the operation's contract. The frame remains appended
-    ///   and uncovered, which is safe: re-applying a Tombstone on replay is
-    ///   idempotent.
-    pub fn append_record(&mut self, record: &WalRecord) -> io::Result<u64> {
+    ///   and must be covered by the caller (variant docs).
+    pub fn append_record(&mut self, record: &WalRecord) -> Result<u64, AppendError> {
         if self.frozen {
-            return Err(io::Error::other(
+            return Err(AppendError::Io(io::Error::other(
                 "WAL file is not in appendable v2 form (pending compaction)",
-            ));
+            )));
         }
-        let payload = bincode::serialize(record).map_err(io::Error::other)?;
+        let payload =
+            bincode::serialize(record).map_err(|e| AppendError::Io(io::Error::other(e)))?;
         let payload_len = u32::try_from(payload.len())
-            .map_err(|_| io::Error::other("WAL entry too large (>4 GiB)"))?;
+            .map_err(|_| AppendError::Io(io::Error::other("WAL entry too large (>4 GiB)")))?;
         let seq = self.next_seq;
         self.next_seq += 1;
 
@@ -452,7 +491,7 @@ impl HistoryWal {
         frame.extend_from_slice(&payload);
         if let Err(e) = self.io.append(&frame) {
             self.frozen = true;
-            return Err(e);
+            return Err(AppendError::Io(e));
         }
 
         self.last_appended_seq = seq;
@@ -463,8 +502,11 @@ impl HistoryWal {
             WalRecord::Tombstone { .. } => {
                 // Reset only after a successful flush: on Err the counter
                 // stays saturated so the next append retries a sync instead
-                // of deferring it a full interval.
-                self.io.sync_full()?;
+                // of deferring it a full interval. The file is NOT frozen:
+                // the frame itself is valid and readable.
+                if let Err(source) = self.io.sync_full() {
+                    return Err(AppendError::SyncFailed { seq, source });
+                }
                 self.frames_since_barrier = 0;
             }
             WalRecord::Committed { .. } => {
@@ -521,6 +563,14 @@ impl HistoryWal {
         self.entry_count
     }
 
+    /// Highest seq physically present in the file (0 when header-only).
+    /// A checkpoint whose `applied_seq` reaches this value covers every
+    /// frame on disk — the clear protocol (§5.5) stamps its empty
+    /// checkpoint with it so all leftover frames replay as skips.
+    pub fn last_appended_seq(&self) -> u64 {
+        self.last_appended_seq
+    }
+
     /// Whether appends are currently rejected (see `frozen` field docs).
     pub fn is_frozen(&self) -> bool {
         self.frozen
@@ -563,7 +613,11 @@ impl HistoryWal {
         self.adopt_scan(0, WAL_HEADER_LEN as u64, 0, applied_seq);
     }
 
-    pub(super) fn freeze(&mut self) {
+    /// Mark the on-disk file as not being in appendable v2 form (see the
+    /// `frozen` field docs). Used by recovery when a repair fails, and by
+    /// the engine's clear when its truncation fails: appends must not land
+    /// after bytes replay cannot read.
+    pub fn freeze(&mut self) {
         self.frozen = true;
     }
 }

--- a/engine/crates/lex-core/src/user_history/wal.rs
+++ b/engine/crates/lex-core/src/user_history/wal.rs
@@ -658,6 +658,12 @@ pub(super) struct V2Scan {
     /// Scan stopped before EOF: corrupt CRC, truncated frame, undecodable
     /// payload, or non-monotonic seq.
     pub(super) truncated_tail: bool,
+    /// A `Tombstone` was among the replayed frames. Its deleted strings
+    /// still sit in the old checkpoint (and earlier Committed frames), so
+    /// recovery must schedule a scrub even when nothing was skipped — the
+    /// startup privacy backstop for a crash between a delete and its async
+    /// scrub (§5.4).
+    pub(super) replayed_deletion: bool,
 }
 
 /// Scan v2 frames, applying `seq > applied_seq` frames into `history`
@@ -670,6 +676,7 @@ pub(super) fn scan_v2(data: &[u8], history: &mut UserHistory) -> V2Scan {
         last_good_end: WAL_HEADER_LEN,
         max_seq: 0,
         truncated_tail: false,
+        replayed_deletion: false,
     };
     let applied_seq = history.applied_seq();
     let mut pos = WAL_HEADER_LEN;
@@ -722,6 +729,9 @@ pub(super) fn scan_v2(data: &[u8], history: &mut UserHistory) -> V2Scan {
                 .deserialize::<WalRecord>(&data[pos + FRAME_HEADER_LEN..end])
             {
                 Ok(record) => {
+                    if matches!(record, WalRecord::Tombstone { .. }) {
+                        scan.replayed_deletion = true;
+                    }
                     history.apply(&record, seq);
                     scan.frames_applied += 1;
                 }

--- a/engine/crates/lex-core/src/user_history/wal.rs
+++ b/engine/crates/lex-core/src/user_history/wal.rs
@@ -416,6 +416,9 @@ impl HistoryWal {
     }
 
     /// Append a Committed record. Returns the assigned sequence number.
+    /// Test-only convenience wrapper; production appends go through the
+    /// canonical [`Self::append_record`] from `apply_records`.
+    #[cfg(test)]
     pub fn append(
         &mut self,
         segments: &[(String, String)],

--- a/engine/crates/lex-core/src/user_history/wal.rs
+++ b/engine/crates/lex-core/src/user_history/wal.rs
@@ -82,27 +82,13 @@ pub enum WalRecord {
 ///   `truncate_covered` would never run again until an unrelated append.
 ///   Replaying a Tombstone after a checkpoint that already contains the
 ///   deletion is idempotent, so covering it is safe.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum AppendError {
-    Io(io::Error),
+    #[error("WAL append failed: {0}")]
+    Io(#[from] io::Error),
+    #[error("WAL frame {seq} appended but durability sync failed: {source}")]
     SyncFailed { seq: u64, source: io::Error },
 }
-
-impl std::fmt::Display for AppendError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AppendError::Io(e) => write!(f, "WAL append failed: {e}"),
-            AppendError::SyncFailed { seq, source } => {
-                write!(
-                    f,
-                    "WAL frame {seq} appended but durability sync failed: {source}"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for AppendError {}
 
 /// v1 WAL entry (headerless file of `length + crc32(payload) + payload`
 /// frames). Retained for the migration reader and test fixtures.
@@ -463,14 +449,14 @@ impl HistoryWal {
     ///   and must be covered by the caller (variant docs).
     pub fn append_record(&mut self, record: &WalRecord) -> Result<u64, AppendError> {
         if self.frozen {
-            return Err(AppendError::Io(io::Error::other(
+            return Err(io::Error::other(
                 "WAL file is not in appendable v2 form (pending compaction)",
-            )));
+            )
+            .into());
         }
-        let payload =
-            bincode::serialize(record).map_err(|e| AppendError::Io(io::Error::other(e)))?;
+        let payload = bincode::serialize(record).map_err(io::Error::other)?;
         let payload_len = u32::try_from(payload.len())
-            .map_err(|_| AppendError::Io(io::Error::other("WAL entry too large (>4 GiB)")))?;
+            .map_err(|_| io::Error::other("WAL entry too large (>4 GiB)"))?;
         let seq = self.next_seq;
         self.next_seq += 1;
 

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -812,6 +812,7 @@ mod tests {
                 frames_replayed: 0,
                 frames_skipped: 0,
                 quarantined_paths: Vec::new(),
+                replayed_deletion: false,
                 compaction_recommended: false,
             },
         })

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -282,11 +282,6 @@ impl LexUserHistory {
     fn open_report(&self) -> LexHistoryOpenReport {
         (&self.report).into()
     }
-
-    /// Clear all learning history (in-memory + WAL + checkpoint files).
-    fn clear(self: Arc<Self>) -> Result<(), LexError> {
-        self.clear_impl()
-    }
 }
 
 impl LexUserHistory {
@@ -382,7 +377,9 @@ impl LexUserHistory {
                     // scheduled below persists it in full.
                     Err(AppendError::SyncFailed { seq, source }) => {
                         warn!("tombstone durability sync failed (checkpoint fallback): {source}");
-                        scrub = true;
+                        // SyncFailed only arises from a Tombstone append, and a
+                        // real (non-no-op) Tombstone already set `scrub` above.
+                        debug_assert!(scrub, "SyncFailed implies a scrubbing Tombstone");
                         sequenced.push((record, Some(seq)));
                     }
                     // Frame not on disk: memory still applies — a confirmed
@@ -481,8 +478,21 @@ impl LexUserHistory {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => {
-                warn!("clear: commit-log removal failed: {e}");
-                deferred.get_or_insert(e.into());
+                // A privacy wipe must not leave input strings on disk, and
+                // the commit-log — unlike the WAL — has no startup scrub
+                // backstop (recovery never touches it). If it can't be
+                // unlinked (an external reader holds the inode, or the
+                // parent dir isn't writable), truncate it to zero instead:
+                // unlink needs parent-dir write while truncation needs only
+                // file write, so it can succeed where unlink can't, and
+                // zero-length scrubbing matches the WAL's own clear (§0
+                // excludes physical byte erasure). Only a failure of *both*
+                // is deferred and surfaced.
+                warn!("clear: commit-log removal failed ({e}); truncating to scrub");
+                if let Err(trunc) = std::fs::File::create(&commit_log_path) {
+                    warn!("clear: commit-log truncation also failed: {trunc}");
+                    deferred.get_or_insert(e.into());
+                }
             }
         }
         // Privacy wipe: quarantined bytes and the v1 migration backup must

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -350,6 +350,10 @@ impl LexUserHistory {
         //   truncation restores appendable form (heal), and the entry-count
         //   threshold can no longer reach it.
         let mut scrub = false;
+        // A Tombstone whose WAL durability failed (SyncFailed or Io): the
+        // deletion must be checkpointed synchronously before returning (§5.4),
+        // not left to an async scrub that a crash could preempt.
+        let mut durability_failed = false;
         let mut needs_threshold_compact = false;
         if !wal_records.is_empty() {
             let mut wal = lock_recover(&self.wal);
@@ -376,10 +380,18 @@ impl LexUserHistory {
                     // deletion's durability (§5.4): the scrub compaction
                     // scheduled below persists it in full.
                     Err(AppendError::SyncFailed { seq, source }) => {
-                        warn!("tombstone durability sync failed (checkpoint fallback): {source}");
+                        warn!(
+                            "tombstone durability sync failed (synchronous checkpoint fallback): {source}"
+                        );
                         // SyncFailed only arises from a Tombstone append, and a
                         // real (non-no-op) Tombstone already set `scrub` above.
                         debug_assert!(scrub, "SyncFailed implies a scrubbing Tombstone");
+                        // The frame is on disk (process-crash safe via replay)
+                        // but its F_FULLFSYNC failed, reopening the power-loss
+                        // window the Tombstone contract closes. Persist the
+                        // deletion synchronously below rather than resurrect it
+                        // if the async scrub is preempted.
+                        durability_failed = true;
                         sequenced.push((record, Some(seq)));
                     }
                     // Frame not on disk: memory still applies — a confirmed
@@ -392,6 +404,14 @@ impl LexUserHistory {
                     Err(e @ AppendError::Io(_)) => {
                         warn!("{e}");
                         scrub = true;
+                        // A Tombstone whose frame never reached disk has no
+                        // durable representation at all (memory-only): persist
+                        // the deletion synchronously below (privacy), not just
+                        // via the async heal a re-learnable Committed loss can
+                        // wait for.
+                        if matches!(record, WalRecord::Tombstone { .. }) {
+                            durability_failed = true;
+                        }
                         sequenced.push((record, None));
                     }
                 }
@@ -406,7 +426,16 @@ impl LexUserHistory {
             self.append_commit_log(line);
         }
 
-        if scrub {
+        if durability_failed {
+            // A Tombstone could not be made durable through the WAL. Write
+            // the checkpoint synchronously before returning so the deletion
+            // survives a crash instead of resurrecting if an async scrub is
+            // preempted — v1 force_compact's synchronous intent, kept as a
+            // failure-only fallback (§5.4). Only the rare failing-disk path
+            // pays this key-thread cost; every healthy delete stays async.
+            self.scrub_pending.store(true, Ordering::SeqCst);
+            self.run_gated_compact();
+        } else if scrub {
             self.spawn_compact();
         } else if needs_threshold_compact {
             self.spawn_threshold_compact();
@@ -573,6 +602,19 @@ impl LexUserHistory {
         }
     }
 
+    /// Acquire the gate and run one compaction if a scrub is still pending,
+    /// posting an async follow-up when frames landed after the snapshot.
+    /// Shared by [`Self::spawn_compact`] (async) and the synchronous
+    /// durability-failure fallback in [`Self::apply_records`] (§5.4). The
+    /// caller posts `scrub_pending` first so a concurrent gated run can
+    /// absorb the request.
+    fn run_gated_compact(self: &Arc<Self>) {
+        let _gate = self.lock_gate();
+        if self.scrub_pending.swap(false, Ordering::SeqCst) && self.run_compact_impl() {
+            self.spawn_compact();
+        }
+    }
+
     /// Post a compaction request that must run with a snapshot no older
     /// than now (startup recovery, WAL-append-failure healing) and park a
     /// worker on the gate until it can run. If an intervening gated run —
@@ -584,12 +626,7 @@ impl LexUserHistory {
         let this = Arc::clone(self);
         if let Err(e) = std::thread::Builder::new()
             .name("lexime-history-compact".into())
-            .spawn(move || {
-                let _gate = this.lock_gate();
-                if this.scrub_pending.swap(false, Ordering::SeqCst) && this.run_compact_impl() {
-                    this.spawn_compact();
-                }
-            })
+            .spawn(move || this.run_gated_compact())
         {
             // scrub_pending stays posted; the next request (or the next
             // gated run's consume) picks it up.
@@ -1076,10 +1113,56 @@ mod tests {
             "tombstone must be covered by its real seq despite the sync failure"
         );
         assert!(!lock_recover(&hist.wal).is_frozen());
-        // Checkpoint fallback: the scrub compaction persists the deletion.
-        wait_until(
-            || lock_recover(&hist.wal).entry_count() == 0,
-            "scrub compaction after sync failure",
+        // §5.4: because the tombstone's WAL durability failed, the checkpoint
+        // is written SYNCHRONOUSLY before apply_records returns (no wait for a
+        // background thread) — the deletion cannot resurrect if a crash
+        // preempts an async scrub.
+        assert_eq!(
+            lock_recover(&hist.wal).entry_count(),
+            0,
+            "durability-failed tombstone must checkpoint synchronously, not via async scrub"
+        );
+        drop(hist);
+        let hist2 = open_hist(&cp);
+        assert!(
+            learned(&hist2, "きょう").is_empty(),
+            "synchronously-checkpointed deletion survives reopen"
+        );
+    }
+
+    #[test]
+    fn test_tombstone_append_failure_checkpoints_synchronously() {
+        // Io on a tombstone append: the frame never reaches disk, so memory
+        // is the only copy of the deletion. It must be checkpointed
+        // synchronously before returning — a crash before an async scrub
+        // would otherwise resurrect the deleted entry from the old checkpoint.
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let fail_appends = Arc::new(AtomicBool::new(false));
+        let hist = hist_with_io(
+            &cp,
+            Box::new(FlakyIo {
+                fail_appends: Arc::clone(&fail_appends),
+                truncates: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }),
+        );
+
+        hist.apply_records(&[committed("きょう", "今日")]);
+        hist.run_compact(); // the entry now lives in the checkpoint
+        assert!(cp.exists());
+
+        // The tombstone's frame fails to append (frozen WAL, memory-only delete).
+        fail_appends.store(true, Ordering::SeqCst);
+        hist.apply_records(&[deletion("きょう", "今日")]);
+        assert!(learned(&hist, "きょう").is_empty(), "memory delete runs");
+
+        // Synchronous durability: reopening immediately (no wait for a
+        // background scrub) must not resurrect the deletion.
+        drop(hist);
+        let hist2 = open_hist(&cp);
+        assert!(
+            learned(&hist2, "きょう").is_empty(),
+            "durability-failed tombstone is checkpointed before return, not resurrected"
         );
     }
 

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -1,16 +1,46 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use tracing::warn;
 
 use crate::dict::connection::ConnectionMatrix;
 use crate::dict::{CompositeDictionary, Dictionary, TrieDictionary};
-use crate::user_history::wal::HistoryWal;
+use crate::session::LearningRecord;
+use crate::user_history::recovery::{CheckpointState, OpenReport, WalState};
+use crate::user_history::wal::{AppendError, HistoryWal, WalRecord};
 use crate::user_history::UserHistory;
 
 use super::{LexError, LexUserDictionary};
+
+// ---------------------------------------------------------------------------
+// Poison recovery
+//
+// The history locks recover through poisoning rather than panicking or
+// bailing (apply_records is reached synchronously from every handle_key /
+// commit, so an unwrap here would surface a panic at the FFI boundary on
+// every subsequent keystroke). Recovery is sound for these locks
+// specifically:
+// - `wal`: seq assignment is monotonic and the file is append-only; a
+//   panicking holder can at worst leave a torn frame, which replay's tail
+//   repair already handles.
+// - `inner`: mutations are WAL-ahead (§5.2) — whatever half-state a panic
+//   left behind, a restart replays the durable frames and self-heals.
+//   `advance_applied_seq` is a monotonic max and cannot corrupt further.
+// ---------------------------------------------------------------------------
+
+fn lock_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+fn read_recover<T>(l: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    l.read().unwrap_or_else(PoisonError::into_inner)
+}
+
+fn write_recover<T>(l: &RwLock<T>) -> RwLockWriteGuard<'_, T> {
+    l.write().unwrap_or_else(PoisonError::into_inner)
+}
 
 #[derive(uniffi::Object)]
 pub struct LexDictionary {
@@ -100,6 +130,78 @@ pub struct LexUserHistory {
     /// serializes appends across all sessions sharing this history so
     /// concurrent commits cannot interleave partial lines.
     commit_log: Mutex<CommitLog>,
+    /// What recovery found and did at open time (§10). Served to Swift via
+    /// `open_report()` for the degraded-state menu (data loss) and NSLog
+    /// (benign events).
+    report: OpenReport,
+}
+
+/// UniFFI mirror of [`CheckpointState`].
+#[derive(uniffi::Enum, Clone, Copy, Debug)]
+pub enum LexHistoryCheckpointState {
+    Loaded,
+    Migrated,
+    Missing,
+    Quarantined,
+}
+
+/// UniFFI mirror of [`WalState`].
+#[derive(uniffi::Enum, Clone, Copy, Debug)]
+pub enum LexHistoryWalState {
+    Clean,
+    Missing,
+    TailRepaired,
+    Quarantined,
+    LegacyDiscarded,
+    Reinitialized,
+    RepairFailed,
+}
+
+/// What `open` found and did (§10). `data_loss_suspected` carries the §8
+/// visibility rule (only whole-file quarantine is user-visible) so Swift
+/// does not re-implement the policy.
+#[derive(uniffi::Record)]
+pub struct LexHistoryOpenReport {
+    pub checkpoint_state: LexHistoryCheckpointState,
+    pub wal_state: LexHistoryWalState,
+    pub migrated_from_v1: bool,
+    pub frames_replayed: u64,
+    pub frames_skipped: u64,
+    pub quarantined_paths: Vec<String>,
+    pub data_loss_suspected: bool,
+}
+
+impl From<&OpenReport> for LexHistoryOpenReport {
+    fn from(r: &OpenReport) -> Self {
+        Self {
+            checkpoint_state: match r.checkpoint_state {
+                CheckpointState::Loaded => LexHistoryCheckpointState::Loaded,
+                CheckpointState::Migrated => LexHistoryCheckpointState::Migrated,
+                CheckpointState::Missing => LexHistoryCheckpointState::Missing,
+                CheckpointState::Quarantined => LexHistoryCheckpointState::Quarantined,
+            },
+            wal_state: match r.wal_state {
+                WalState::Clean => LexHistoryWalState::Clean,
+                WalState::Missing => LexHistoryWalState::Missing,
+                WalState::TailRepaired => LexHistoryWalState::TailRepaired,
+                WalState::Quarantined => LexHistoryWalState::Quarantined,
+                WalState::LegacyDiscarded => LexHistoryWalState::LegacyDiscarded,
+                WalState::Reinitialized => LexHistoryWalState::Reinitialized,
+                WalState::RepairFailed => LexHistoryWalState::RepairFailed,
+            },
+            migrated_from_v1: r.migrated_from_v1,
+            frames_replayed: r.frames_replayed,
+            frames_skipped: r.frames_skipped,
+            // Lossy on purpose: display-only, and a non-UTF-8 path must not
+            // panic at the FFI boundary.
+            quarantined_paths: r
+                .quarantined_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+            data_loss_suspected: r.data_loss_suspected(),
+        }
+    }
 }
 
 /// Lazily-opened append handle for the commit log, mirroring HistoryWal.
@@ -141,8 +243,8 @@ impl LexUserHistory {
         let cp = Path::new(&path);
         // Recovery-mode open: corruption is quarantined instead of failing
         // startup, so learning never silently stops. Err = environmental
-        // read failure only (EACCES etc.). PR2 surfaces the report to Swift;
-        // until then it is logged here.
+        // read failure only (EACCES etc.). Swift consumes the report via
+        // `open_report()`; the logs here cover headless/CLI contexts.
         let (history, wal, report) = crate::user_history::recovery::open_recovering(cp)?;
         if report.data_loss_suspected() {
             warn!("user history recovered with suspected data loss: {report:?}");
@@ -153,12 +255,14 @@ impl LexUserHistory {
             path: cp.with_file_name("commit-log.jsonl"),
             file: None,
         };
+        let compaction_recommended = report.compaction_recommended;
         let this = Arc::new(Self {
             inner: Arc::new(RwLock::new(history)),
             wal: Mutex::new(wal),
             compact_gate: Mutex::new(()),
             scrub_pending: AtomicBool::new(false),
             commit_log: Mutex::new(commit_log),
+            report,
         });
         // Startup compaction (§5.1-6): checkpoint recovery results early so
         // the next startup is clean. This is also the heal path for a
@@ -166,31 +270,247 @@ impl LexUserHistory {
         // checkpoint covers memory, so the truncation that follows it
         // restores appendable v2 form — without this, appends would keep
         // failing and threshold-based compaction would never trigger.
-        if report.compaction_recommended {
+        if compaction_recommended {
             this.spawn_compact();
         }
         Ok(this)
     }
 
+    /// What recovery found and did at open time (§10).
+    fn open_report(&self) -> LexHistoryOpenReport {
+        (&self.report).into()
+    }
+
     /// Clear all learning history (in-memory + WAL + checkpoint files).
-    fn clear(&self) -> Result<(), LexError> {
+    fn clear(self: Arc<Self>) -> Result<(), LexError> {
         self.clear_impl()
     }
 }
 
 impl LexUserHistory {
-    pub(super) fn clear_impl(&self) -> Result<(), LexError> {
+    /// Apply a batch of learning records (§5.2): WAL append first
+    /// (write-ahead), then the in-memory apply — both in one critical
+    /// section under the wal mutex (§4).
+    ///
+    /// The coupling is what makes `applied_seq = S` mean "every frame ≤ S
+    /// is applied": uncoupled, two sessions could append seq 5 then 6,
+    /// apply 6 first, and a snapshot taken at that instant would claim
+    /// coverage of 5 while lacking its effect — the conditional truncation
+    /// (§5.3) would then destroy frame 5. Crash consequences: "on the WAL
+    /// but not in memory" self-heals via restart replay; the v1 direction
+    /// (in memory but not on the WAL = loss) is structurally gone.
+    pub(super) fn apply_records(self: &Arc<Self>, records: &[LearningRecord]) {
+        let now = crate::user_history::now_epoch();
+        let mut wal_records: Vec<WalRecord> = Vec::new();
+        let mut log_lines: Vec<String> = Vec::new();
+        for r in records {
+            match r {
+                LearningRecord::Committed {
+                    reading,
+                    surface,
+                    segments,
+                    rank,
+                    top1,
+                    auto,
+                    learn,
+                } => {
+                    if *learn {
+                        wal_records.push(WalRecord::Committed {
+                            segments: vec![(reading.clone(), surface.clone())],
+                            timestamp: now,
+                        });
+                        if let Some(sub_segs) = segments {
+                            wal_records.push(WalRecord::Committed {
+                                segments: sub_segs.clone(),
+                                timestamp: now,
+                            });
+                        }
+                    }
+                    log_lines.push(commit_log_line(
+                        now,
+                        reading,
+                        surface,
+                        *rank,
+                        top1.as_deref(),
+                        *auto,
+                    ));
+                }
+                LearningRecord::Deletion { segments } => {
+                    wal_records.push(WalRecord::Tombstone {
+                        segments: segments.clone(),
+                        timestamp: now,
+                    });
+                }
+            }
+        }
+
+        let mut tombstone_written = false;
+        let mut append_failed = false;
+        if !wal_records.is_empty() {
+            let mut wal = lock_recover(&self.wal);
+            let mut sequenced: Vec<(WalRecord, u64)> = Vec::with_capacity(wal_records.len());
+            for record in wal_records {
+                if let WalRecord::Tombstone { segments, .. } = &record {
+                    // No-op deletion: pruning a candidate that was never
+                    // learned (the common ForwardDelete case) must not cost
+                    // a key-thread F_FULLFSYNC. Check-then-append is
+                    // race-free because every history mutation runs under
+                    // the wal mutex we hold (wal -> inner is the §4 order).
+                    if !read_recover(&self.inner).contains_entries(segments) {
+                        continue;
+                    }
+                }
+                match wal.append_record(&record) {
+                    Ok(seq) => {
+                        if matches!(record, WalRecord::Tombstone { .. }) {
+                            tombstone_written = true;
+                        }
+                        sequenced.push((record, seq));
+                    }
+                    // Frame on disk, durability unconfirmed: apply with the
+                    // real seq — leaving an on-disk frame uncovered would
+                    // stall conditional truncation indefinitely (AppendError
+                    // docs) — and fall back to the checkpoint for the
+                    // deletion's durability (§5.4): the scrub compaction
+                    // scheduled below persists it in full.
+                    Err(AppendError::SyncFailed { seq, source }) => {
+                        warn!("tombstone durability sync failed (checkpoint fallback): {source}");
+                        tombstone_written = true;
+                        append_failed = true;
+                        sequenced.push((record, seq));
+                    }
+                    // Frame not on disk: memory still applies — a confirmed
+                    // conversion that stops boosting is an immediate quality
+                    // regression (§5.2) — but applied_seq must not advance
+                    // (seq 0 is a no-op for the monotonic max). The next
+                    // checkpoint is a full snapshot, so a recovered disk
+                    // picks the effect up; the frame's absence makes
+                    // double-apply impossible.
+                    Err(e @ AppendError::Io(_)) => {
+                        warn!("{e}");
+                        append_failed = true;
+                        sequenced.push((record, 0));
+                    }
+                }
+            }
+            if !sequenced.is_empty() {
+                let mut hist = write_recover(&self.inner);
+                for (record, seq) in &sequenced {
+                    hist.apply(record, *seq);
+                }
+                // Batched apply settles capacity once, like replay (§5.1-4).
+                hist.evict();
+            }
+        }
+
+        for line in &log_lines {
+            self.append_commit_log(line);
+        }
+
+        // Tombstone: schedule the physical scrub (§5.4) — the deleted
+        // strings still sit in the old checkpoint and in past Committed
+        // frames until a compaction rewrites the checkpoint and truncates
+        // the WAL. Append failure: the WAL may be frozen; only a
+        // post-checkpoint truncation restores appendable form (heal), and
+        // the entry-count threshold can no longer reach it.
+        if tombstone_written || append_failed {
+            self.spawn_compact();
+        } else {
+            self.maybe_compact();
+        }
+    }
+
+    /// §5.5 clear: empty-checkpoint-first. The empty checkpoint (stamped
+    /// with the highest on-disk seq) is the commit point — once its rename
+    /// lands, every leftover frame replays as a skip and any crash
+    /// converges to an empty history. The v1 file-deletion protocol passed
+    /// through "checkpoint missing + WAL non-empty", a state replay can
+    /// resurrect.
+    pub(super) fn clear_impl(self: &Arc<Self>) -> Result<(), LexError> {
         // Park until any in-flight compaction finishes (§5.5 step 1): a
         // compactor that cloned a pre-clear snapshot must not save it after
-        // the files are removed, or the privacy wipe would be undone.
-        // Holding the gate also blocks new compactions for the duration.
+        // the wipe, or the wipe would be undone. Holding the gate also
+        // blocks new compactions for the duration.
         let _gate = self.lock_gate();
-        // Clearing supersedes requests posted so far: it truncates the WAL
-        // (unfreezing it) and empties memory. A heal posted mid-clear parks
-        // on the gate and runs after release, checkpointing the (empty)
-        // post-clear state — harmless.
+        // The wal mutex blocks concurrent apply_records for the whole
+        // protocol. inner is taken only for the memory reset below — the
+        // checkpoint write needs no lock on it (it serializes an empty
+        // history), so conversion reads stay unblocked during the I/O.
+        let mut wal = lock_recover(&self.wal);
+
+        // Commit point. On Err nothing has changed — including
+        // scrub_pending, so a pre-clear Tombstone's scrub request stays
+        // posted for the next compaction.
+        let mut empty = UserHistory::new();
+        empty.advance_applied_seq(wal.last_appended_seq());
+        empty.save(wal.checkpoint_path())?;
+
+        // Consumed only after the commit point: the wipe supersedes every
+        // scrub request posted so far.
         self.scrub_pending.store(false, Ordering::SeqCst);
-        self.clear_locked()
+
+        // Physical deletions below are deferred-error: the logical clear is
+        // committed, so every step runs (the memory reset especially —
+        // bailing before it would let the next compaction re-persist the
+        // pre-clear state from memory), and the first failure is surfaced
+        // at the end.
+        let mut deferred: Option<LexError> = None;
+
+        if let Err(e) = wal.truncate_wal() {
+            // The old frames remain on disk. They replay as skips (covered
+            // by the empty checkpoint), but a privacy wipe must not
+            // silently leave input strings behind — freeze appends (file
+            // state unknown) and surface the failure.
+            warn!("clear: WAL truncation failed: {e}");
+            wal.freeze();
+            deferred = Some(e.into());
+        }
+
+        {
+            let mut h = write_recover(&self.inner);
+            // applied_seq carries over (§5.5 step 5); next_seq in the wal
+            // continues its numbering (§3).
+            *h = empty;
+        }
+
+        // Drop the commit-log handle before removing the file so a later
+        // append reopens (re-creates) it instead of writing to an unlinked
+        // inode.
+        let commit_log_path = {
+            let mut log = lock_recover(&self.commit_log);
+            log.file = None;
+            log.path.clone()
+        };
+        match std::fs::remove_file(&commit_log_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                warn!("clear: commit-log removal failed: {e}");
+                deferred.get_or_insert(e.into());
+            }
+        }
+        // Privacy wipe: quarantined bytes and the v1 migration backup must
+        // not survive a clear.
+        if let Err(e) =
+            crate::user_history::recovery::remove_recovery_artifacts(wal.checkpoint_path())
+        {
+            warn!("clear: recovery-artifact removal failed: {e}");
+            deferred.get_or_insert(e.into());
+        }
+        drop(wal);
+
+        match deferred {
+            None => Ok(()),
+            Some(e) => {
+                // Partial physical failure: the logical clear is done
+                // (memory and checkpoint are empty) but some bytes remain.
+                // Post a heal — the compaction re-truncates the frozen WAL
+                // against the empty state — and surface the error so the
+                // UI can say the wipe is incomplete (never silent).
+                self.spawn_compact();
+                Err(e)
+            }
+        }
     }
 
     /// Acquire the compaction gate, recovering through poisoning: the gate
@@ -199,97 +519,6 @@ impl LexUserHistory {
         self.compact_gate
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    fn clear_locked(&self) -> Result<(), LexError> {
-        {
-            let mut h = self.inner.write().map_err(|e| LexError::Io {
-                msg: format!("history write lock poisoned: {e}"),
-            })?;
-            *h = UserHistory::new();
-        }
-        // Drop the commit-log handle before removing the file so a later
-        // append reopens (re-creates) it instead of writing to an unlinked
-        // inode.
-        let commit_log_path = {
-            let mut log = self.commit_log.lock().map_err(|e| LexError::Io {
-                msg: format!("commit-log lock poisoned: {e}"),
-            })?;
-            log.file = None;
-            log.path.clone()
-        };
-        let mut wal = self.wal.lock().map_err(|e| LexError::Io {
-            msg: format!("WAL lock poisoned: {e}"),
-        })?;
-        wal.truncate_wal()?;
-        for path in [
-            wal.wal_path(),
-            wal.checkpoint_path(),
-            commit_log_path.as_path(),
-        ] {
-            match std::fs::remove_file(path) {
-                Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => return Err(e.into()),
-            }
-        }
-        // Privacy wipe: quarantined bytes and the v1 migration backup must
-        // not survive a clear.
-        crate::user_history::recovery::remove_recovery_artifacts(wal.checkpoint_path())?;
-        Ok(())
-    }
-
-    /// Append a WAL entry. Does not block on compaction.
-    pub(super) fn append_wal(self: &Arc<Self>, segments: &[(String, String)], timestamp: u64) {
-        let failed = {
-            let mut wal = match self.wal.lock() {
-                Ok(w) => w,
-                Err(e) => {
-                    warn!("WAL lock poisoned: {e}");
-                    return;
-                }
-            };
-            match wal.append(segments, timestamp) {
-                Ok(seq) => {
-                    // Advance applied_seq while still holding the wal mutex
-                    // (lock order: wal -> inner). The in-memory effect of this
-                    // frame was applied in record_history phase 1, so once the
-                    // frame is on disk a checkpoint snapshot may claim coverage
-                    // of `seq`. A snapshot racing between phase 1 and here only
-                    // under-reports applied_seq — the safe direction (bounded
-                    // re-apply after a crash, never loss).
-                    match self.inner.write() {
-                        Ok(mut h) => h.advance_applied_seq(seq),
-                        // Recover through the poison: advance_applied_seq is
-                        // a monotonic u64 max, safe regardless of the state
-                        // the panicking holder left behind — and a stale
-                        // applied_seq would let a later checkpoint under-
-                        // report coverage (restart replay then re-applies
-                        // its frames).
-                        Err(poisoned) => {
-                            warn!("history write lock poisoned; advancing applied_seq anyway");
-                            poisoned.into_inner().advance_applied_seq(seq);
-                        }
-                    }
-                    false
-                }
-                // Memory keeps the record (§5.2): the next checkpoint is a full
-                // snapshot, so a recovered disk picks it up; the frame's absence
-                // makes double-apply impossible.
-                Err(e) => {
-                    warn!("WAL append failed: {e}");
-                    true
-                }
-            }
-        };
-        // An append failure freezes the WAL (partial frame at the tail);
-        // only a post-checkpoint truncation restores appendable form, and
-        // the entry-count threshold can no longer reach it. Post a heal
-        // request (checkpoint writes may still fail under a persistent disk
-        // problem — the next record's failure re-posts).
-        if failed {
-            self.spawn_compact();
-        }
     }
 
     /// Append one JSONL line to the commit log. Failures are logged and
@@ -309,11 +538,7 @@ impl LexUserHistory {
 
     /// Spawn background compaction if threshold is reached.
     pub(super) fn maybe_compact(self: &Arc<Self>) {
-        let needs = match self.wal.lock() {
-            Ok(wal) => wal.needs_compact(),
-            Err(_) => false,
-        };
-        if !needs {
+        if !lock_recover(&self.wal).needs_compact() {
             return;
         }
         // §4: threshold compactions skip when one is in flight — the
@@ -337,7 +562,7 @@ impl LexUserHistory {
                 };
                 // This run's snapshot covers heal requests posted so far.
                 this.scrub_pending.store(false, Ordering::SeqCst);
-                if this.run_compact_impl(true) {
+                if this.run_compact_impl() {
                     this.spawn_compact();
                 }
             })
@@ -359,7 +584,7 @@ impl LexUserHistory {
             .name("lexime-history-compact".into())
             .spawn(move || {
                 let _gate = this.lock_gate();
-                if this.scrub_pending.swap(false, Ordering::SeqCst) && this.run_compact_impl(true) {
+                if this.scrub_pending.swap(false, Ordering::SeqCst) && this.run_compact_impl() {
                     this.spawn_compact();
                 }
             })
@@ -370,45 +595,18 @@ impl LexUserHistory {
         }
     }
 
-    /// Force an immediate compaction (used after history deletion to
-    /// persist changes). Parks until any in-flight compaction finishes,
-    /// then truncates unconditionally: leaving a racing Committed frame for
-    /// the just-deleted entry uncovered in the WAL would let the next
-    /// replay resurrect the deleted learning. Destroying an uncovered frame
-    /// instead loses at most that racing commit (v1 semantics; the
-    /// structural fix is PR2's Tombstone frames, which make the
-    /// delete-after-commit ordering durable in the WAL itself).
-    pub(super) fn force_compact(&self) {
-        let _gate = self.lock_gate();
-        // This full-snapshot run covers heal requests posted so far.
-        self.scrub_pending.store(false, Ordering::SeqCst);
-        self.run_compact_impl(false);
-    }
-
     #[cfg(test)]
     fn run_compact(&self) {
-        self.run_compact_impl(true);
+        self.run_compact_impl();
     }
 
     /// Returns whether a follow-up pass is warranted: frames were appended
     /// after this run's snapshot, so the covered-only truncation was
     /// skipped.
-    fn run_compact_impl(&self, covered_only: bool) -> bool {
+    fn run_compact_impl(&self) -> bool {
         // 1. Clone history under read lock (brief)
-        let snapshot = match self.inner.read() {
-            Ok(h) => h.clone(),
-            Err(e) => {
-                warn!("history read lock failed during compaction: {e}");
-                return false;
-            }
-        };
-        let cp_path = match self.wal.lock() {
-            Ok(wal) => wal.checkpoint_path().to_path_buf(),
-            Err(e) => {
-                warn!("WAL lock poisoned during compaction: {e}");
-                return false;
-            }
-        };
+        let snapshot = read_recover(&self.inner).clone();
+        let cp_path = lock_recover(&self.wal).checkpoint_path().to_path_buf();
 
         // 2. Write checkpoint (no locks held, slow I/O)
         if let Err(e) = snapshot.save(&cp_path) {
@@ -418,48 +616,149 @@ impl LexUserHistory {
 
         // 3. Truncate WAL (brief lock) — conditionally (§5.3): only frames
         // provably covered by the durable checkpoint (seq <= applied_seq at
-        // snapshot time) may be destroyed. The deletion path truncates
-        // unconditionally (see force_compact).
-        let mut wal = match self.wal.lock() {
-            Ok(w) => w,
+        // snapshot time) may be destroyed.
+        let mut wal = lock_recover(&self.wal);
+        match wal.truncate_covered(snapshot.applied_seq()) {
+            Ok(true) => false,
+            Ok(false) => {
+                // Frames landed after our snapshot: request a follow-up
+                // pass (§5.3 step 5), which keeps the §5.4 scrub prompt. A
+                // Tombstone racing this run's checkpoint write would
+                // otherwise leave the deleted strings — its own frame plus
+                // the old Committed frames — on disk until the next
+                // threshold compaction. Correctness is unaffected either
+                // way (WAL-ahead means a snapshot can never contain
+                // unsequenced effects, so a skipped truncation only costs
+                // file bytes); convergence holds because every skip means
+                // "frames landed after the snapshot" and the follow-up's
+                // snapshot covers them (SyncFailed tombstones carry their
+                // real seq, so no on-disk frame stays uncovered forever).
+                true
+            }
             Err(e) => {
-                warn!("WAL lock poisoned; skipping truncation after checkpoint: {e}");
-                return false;
-            }
-        };
-        if covered_only {
-            match wal.truncate_covered(snapshot.applied_seq()) {
-                Ok(true) => false,
-                Ok(false) => {
-                    // Frames landed after our snapshot: request a follow-up
-                    // pass (§5.3 step 5). A commit whose in-memory effect
-                    // raced into this checkpoint before its frame was
-                    // sequenced would otherwise stay replayable until the
-                    // next threshold compaction; the follow-up's snapshot
-                    // carries the advanced applied_seq and covers it. This
-                    // narrows the residual double-apply to a crash between
-                    // the two passes — the structural fix (WAL-ahead
-                    // ordering under the wal mutex, so snapshots can never
-                    // contain unsequenced effects) lands in PR2.
-                    true
-                }
-                Err(e) => {
-                    warn!("WAL truncate failed: {e}");
-                    false
-                }
-            }
-        } else {
-            if let Err(e) = wal.truncate_wal() {
                 warn!("WAL truncate failed: {e}");
+                false
             }
-            false
         }
     }
+}
+
+/// Serialize one commit event as a JSONL line for the commit log.
+/// `top1` and `auto` are omitted at their defaults to keep lines lean.
+fn commit_log_line(
+    now: u64,
+    reading: &str,
+    surface: &str,
+    rank: usize,
+    top1: Option<&str>,
+    auto: bool,
+) -> String {
+    let mut obj = serde_json::json!({
+        "t": now,
+        "reading": reading,
+        "surface": surface,
+        "rank": rank,
+    });
+    if let Some(t1) = top1 {
+        obj["top1"] = serde_json::Value::String(t1.to_string());
+    }
+    if auto {
+        obj["auto"] = serde_json::Value::Bool(true);
+    }
+    obj.to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn open_hist(cp: &Path) -> Arc<LexUserHistory> {
+        LexUserHistory::open(cp.display().to_string()).unwrap()
+    }
+
+    fn committed(reading: &str, surface: &str) -> LearningRecord {
+        LearningRecord::Committed {
+            reading: reading.to_string(),
+            surface: surface.to_string(),
+            segments: None,
+            rank: 0,
+            top1: None,
+            auto: false,
+            learn: true,
+        }
+    }
+
+    fn deletion(reading: &str, surface: &str) -> LearningRecord {
+        LearningRecord::Deletion {
+            segments: vec![(reading.to_string(), surface.to_string())],
+        }
+    }
+
+    fn learned(hist: &LexUserHistory, reading: &str) -> Vec<String> {
+        let now = crate::user_history::now_epoch();
+        read_recover(&hist.inner)
+            .learned_surfaces(reading, now)
+            .into_iter()
+            .map(|(s, _)| s)
+            .collect()
+    }
+
+    /// Wait for an async (compaction-thread) condition, with a deadline.
+    fn wait_until(mut cond: impl FnMut() -> bool, what: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !cond() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timeout waiting for {what}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }
+
+    /// Construct a LexUserHistory over a mock WalIo (fault injection).
+    fn hist_with_io(
+        cp: &Path,
+        io: Box<dyn crate::user_history::wal::WalIo>,
+    ) -> Arc<LexUserHistory> {
+        Arc::new(LexUserHistory {
+            inner: Arc::new(RwLock::new(UserHistory::new())),
+            wal: Mutex::new(HistoryWal::with_io(cp, io)),
+            compact_gate: Mutex::new(()),
+            scrub_pending: AtomicBool::new(false),
+            commit_log: Mutex::new(CommitLog {
+                path: cp.with_file_name("commit-log.jsonl"),
+                file: None,
+            }),
+            report: OpenReport {
+                checkpoint_state: CheckpointState::Missing,
+                wal_state: WalState::Missing,
+                migrated_from_v1: false,
+                frames_replayed: 0,
+                frames_skipped: 0,
+                quarantined_paths: Vec::new(),
+                compaction_recommended: false,
+            },
+        })
+    }
+
+    #[test]
+    fn test_commit_log_line_shape() {
+        // Manual pick: top1 present, auto omitted
+        let line = commit_log_line(42, "きょう", "京", 2, Some("今日"), false);
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["t"], 42);
+        assert_eq!(v["reading"], "きょう");
+        assert_eq!(v["surface"], "京");
+        assert_eq!(v["rank"], 2);
+        assert_eq!(v["top1"], "今日");
+        assert!(v.get("auto").is_none());
+
+        // Auto-commit acceptance: top1 omitted, auto present
+        let line = commit_log_line(42, "きょう", "今日", 0, None, true);
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert!(v.get("top1").is_none());
+        assert_eq!(v["auto"], true);
+    }
 
     #[test]
     fn test_commit_log_append_and_clear() {
@@ -467,7 +766,7 @@ mod tests {
         // Nested path that does not exist yet: the first append must create
         // the parent directory (fresh-install case).
         let cp = dir.path().join("nested").join("history.lxud");
-        let hist = LexUserHistory::open(cp.display().to_string()).unwrap();
+        let hist = open_hist(&cp);
 
         hist.append_commit_log(r#"{"t":1,"reading":"きょう","surface":"今日","rank":0}"#);
         hist.append_commit_log(
@@ -478,83 +777,407 @@ mod tests {
         let content = std::fs::read_to_string(&log_path).unwrap();
         assert_eq!(content.lines().count(), 2);
 
-        // clear() removes the commit log along with history files
+        // clear() removes the commit log along with history data
         hist.clear_impl().unwrap();
         assert!(!log_path.exists(), "commit log should be removed by clear");
     }
 
     #[test]
-    fn test_force_compact_truncates_uncovered_frames() {
+    fn test_apply_records_wal_ahead_and_durable() {
         let dir = tempfile::tempdir().unwrap();
         let cp = dir.path().join("history.lxud");
-        let hist = LexUserHistory::open(cp.display().to_string()).unwrap();
+        let hist = open_hist(&cp);
 
-        // Covered frame: the normal path advances applied_seq
-        hist.append_wal(&[("きょう".into(), "今日".into())], 1000);
-        // Uncovered frame: append directly without advancing applied_seq,
-        // modeling a commit racing the compaction snapshot
-        hist.wal
-            .lock()
-            .unwrap()
-            .append(&[("あす".into(), "明日".into())], 1001)
-            .unwrap();
+        hist.apply_records(&[committed("きょう", "今日")]);
+        assert_eq!(learned(&hist, "きょう"), vec!["今日".to_string()]);
+        {
+            let wal = lock_recover(&hist.wal);
+            assert_eq!(wal.entry_count(), 1);
+            assert_eq!(
+                read_recover(&hist.inner).applied_seq(),
+                wal.last_appended_seq(),
+                "coupled append+apply must leave applied_seq covering the file"
+            );
+        }
 
-        // Background-style compaction must skip truncation (uncovered frame
-        // would be destroyed while absent from the checkpoint)
-        hist.run_compact();
-        assert_eq!(
-            hist.wal.lock().unwrap().entry_count(),
-            2,
-            "covered-only truncation must be skipped"
-        );
-
-        // Deletion-path compaction truncates unconditionally so a deleted
-        // entry can never be resurrected by an uncovered replayable frame
-        hist.force_compact();
-        assert_eq!(hist.wal.lock().unwrap().entry_count(), 0);
+        // The frame alone (no checkpoint yet) reconstructs the state.
+        drop(hist);
+        let hist2 = open_hist(&cp);
+        assert_eq!(learned(&hist2, "きょう"), vec!["今日".to_string()]);
     }
 
     #[test]
-    fn test_clear_resets_history_and_removes_files() {
+    fn test_noop_deletion_writes_no_tombstone() {
         let dir = tempfile::tempdir().unwrap();
         let cp = dir.path().join("history.lxud");
+        let hist = open_hist(&cp);
 
-        // Open, record some entries, and trigger a checkpoint write
-        let hist = LexUserHistory::open(cp.display().to_string()).unwrap();
-        hist.append_wal(&[("きょう".into(), "今日".into())], 1000);
-        hist.inner
-            .write()
-            .unwrap()
-            .record_at(&[("きょう".to_string(), "今日".to_string())], 1000);
-        // Force checkpoint so files exist on disk
+        // Deleting a never-learned pair (dictionary candidate pruning) must
+        // not write a frame — that would cost a key-thread F_FULLFSYNC per
+        // ForwardDelete.
+        hist.apply_records(&[deletion("きょう", "今日")]);
+        assert_eq!(lock_recover(&hist.wal).entry_count(), 0);
+        assert!(
+            !hist.scrub_pending.load(Ordering::SeqCst),
+            "no scrub needed for a no-op deletion"
+        );
+    }
+
+    #[test]
+    fn test_deletion_scrubs_checkpoint_and_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let hist = open_hist(&cp);
+
+        hist.apply_records(&[committed("きょう", "今日")]);
+        // Persist the entry into a checkpoint so the scrub has something to
+        // rewrite.
         hist.run_compact();
+        assert!(cp.exists());
 
-        let wal_path = hist.wal.lock().unwrap().wal_path().to_path_buf();
-        let cp_path = hist.wal.lock().unwrap().checkpoint_path().to_path_buf();
-        assert!(cp_path.exists(), "checkpoint should exist before clear");
+        hist.apply_records(&[deletion("きょう", "今日")]);
+        assert!(
+            learned(&hist, "きょう").is_empty(),
+            "memory delete is immediate"
+        );
 
-        // Clear and verify
+        // The posted scrub compaction rewrites the checkpoint and truncates
+        // the WAL (tombstone included) in the background.
+        wait_until(
+            || lock_recover(&hist.wal).entry_count() == 0,
+            "scrub compaction to truncate the WAL",
+        );
+
+        // Nothing on disk resurrects the deletion.
+        drop(hist);
+        let hist2 = open_hist(&cp);
+        assert!(
+            learned(&hist2, "きょう").is_empty(),
+            "deletion survives reopen"
+        );
+    }
+
+    #[test]
+    fn test_tombstone_deletes_before_scrub_after_crash() {
+        // Crash between the tombstone append and the scrub compaction: the
+        // checkpoint still contains the entry, the WAL carries the
+        // tombstone. Replay must apply the deletion.
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        {
+            // Build the crash state directly (no background threads): a
+            // checkpoint containing the entry + a WAL holding only the
+            // tombstone frame.
+            let mut h = UserHistory::new();
+            h.record_at(&[("きょう".to_string(), "今日".to_string())], 1000);
+            let mut wal = HistoryWal::new(&cp);
+            let seq = wal
+                .append_record(&crate::user_history::wal::WalRecord::Tombstone {
+                    segments: vec![("きょう".to_string(), "今日".to_string())],
+                    timestamp: 1001,
+                })
+                .unwrap();
+            assert_eq!(seq, 1);
+            h.save(&cp).unwrap(); // applied_seq = 0 < 1: tombstone uncovered
+        }
+        let hist = open_hist(&cp);
+        assert!(
+            learned(&hist, "きょう").is_empty(),
+            "uncovered tombstone must replay as a deletion"
+        );
+    }
+
+    #[test]
+    fn test_clear_leaves_empty_checkpoint_and_header_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let hist = open_hist(&cp);
+
+        hist.apply_records(&[committed("きょう", "今日")]);
+        hist.run_compact();
+        let wal_path = lock_recover(&hist.wal).wal_path().to_path_buf();
+        assert!(cp.exists(), "checkpoint should exist before clear");
+
         hist.clear_impl().unwrap();
 
-        // In-memory history should be empty
-        let h = hist.inner.read().unwrap();
         assert!(
-            h.learned_surfaces("きょう", 2000).is_empty(),
+            learned(&hist, "きょう").is_empty(),
             "in-memory history should be empty after clear"
         );
-        drop(h);
+        // §5.5: clear leaves an empty checkpoint + header-only WAL — never
+        // the resurrectable "checkpoint missing + WAL non-empty" state.
+        assert!(cp.exists(), "empty checkpoint remains (commit point)");
+        assert!(wal_path.exists(), "header-only WAL remains");
+        assert_eq!(lock_recover(&hist.wal).entry_count(), 0);
 
-        // Files should be removed
-        assert!(!cp_path.exists(), "checkpoint file should be deleted");
-        assert!(!wal_path.exists(), "WAL file should be deleted");
-
-        // Re-opening from the same path should yield empty history
+        // Post-clear learning still works and survives reopen.
+        hist.apply_records(&[committed("あす", "明日")]);
         drop(hist);
-        let hist2 = LexUserHistory::open(cp.display().to_string()).unwrap();
-        let h2 = hist2.inner.read().unwrap();
+        let hist2 = open_hist(&cp);
         assert!(
-            h2.learned_surfaces("きょう", 2000).is_empty(),
-            "reopened history should be empty"
+            learned(&hist2, "きょう").is_empty(),
+            "cleared data stays gone"
         );
+        assert_eq!(learned(&hist2, "あす"), vec!["明日".to_string()]);
+    }
+
+    #[test]
+    fn test_clear_supersedes_in_flight_compaction() {
+        // T7: a compaction racing clear must not save its pre-clear
+        // snapshot after the wipe. The gate serializes them: whichever
+        // order the OS picks, the final on-disk state is empty.
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let hist = open_hist(&cp);
+
+        for i in 0..50 {
+            hist.apply_records(&[committed(&format!("よみ{i}"), &format!("面{i}"))]);
+        }
+        // Post gated compaction requests that will race the clear.
+        for _ in 0..4 {
+            hist.spawn_compact();
+        }
+        hist.clear_impl().unwrap();
+
+        // Any parked compactor that runs after clear snapshots the empty
+        // state; give stragglers time to finish, then verify emptiness
+        // holds on disk.
+        wait_until(
+            || {
+                let gate = hist.lock_gate();
+                drop(gate);
+                let (h, _wal) =
+                    crate::user_history::wal::open_with_wal(&cp).expect("reopen after clear");
+                h.learned_surfaces("よみ0", u64::MAX).is_empty() && h.unigrams().next().is_none()
+            },
+            "post-clear disk state to settle empty",
+        );
+        assert!(
+            learned(&hist, "よみ0").is_empty(),
+            "no resurrection in memory"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // T6 (engine side): append-failure fallbacks over a mock WalIo
+    // -----------------------------------------------------------------------
+
+    /// WalIo whose appends fail while `fail_appends` is set; truncation
+    /// heals it (mirroring a disk that recovered).
+    struct FlakyIo {
+        fail_appends: Arc<AtomicBool>,
+        truncates: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl crate::user_history::wal::WalIo for FlakyIo {
+        fn append(&mut self, _buf: &[u8]) -> std::io::Result<()> {
+            if self.fail_appends.load(Ordering::SeqCst) {
+                return Err(std::io::Error::other("injected append failure"));
+            }
+            Ok(())
+        }
+        fn sync_barrier(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn sync_full(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn truncate_to_header(&mut self) -> std::io::Result<()> {
+            self.truncates
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_append_failure_keeps_memory_and_heals() {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let fail_appends = Arc::new(AtomicBool::new(true));
+        let truncates = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hist = hist_with_io(
+            &cp,
+            Box::new(FlakyIo {
+                fail_appends: Arc::clone(&fail_appends),
+                truncates: Arc::clone(&truncates),
+            }),
+        );
+
+        hist.apply_records(&[committed("きょう", "今日")]);
+
+        // §5.2: memory keeps the record (immediate quality), applied_seq
+        // does not advance (the frame cannot replay), the WAL freezes, and
+        // a heal is posted.
+        assert_eq!(learned(&hist, "きょう"), vec!["今日".to_string()]);
+        assert_eq!(read_recover(&hist.inner).applied_seq(), 0);
+        assert!(lock_recover(&hist.wal).is_frozen());
+
+        // The healing compaction checkpoints memory (covering the effect)
+        // and re-truncates the WAL back to appendable form.
+        fail_appends.store(false, Ordering::SeqCst);
+        wait_until(
+            || !lock_recover(&hist.wal).is_frozen(),
+            "heal compaction to unfreeze the WAL",
+        );
+        assert!(cp.exists(), "healed checkpoint persists the effect");
+        assert!(truncates.load(std::sync::atomic::Ordering::SeqCst) >= 1);
+
+        // Nothing was lost: reopen from disk sees the entry (via checkpoint).
+        drop(hist);
+        let hist2 = open_hist(&cp);
+        assert_eq!(learned(&hist2, "きょう"), vec!["今日".to_string()]);
+    }
+
+    /// WalIo whose sync_full fails once (tombstone durability failure).
+    struct SyncFailOnceIo {
+        failed: bool,
+    }
+
+    impl crate::user_history::wal::WalIo for SyncFailOnceIo {
+        fn append(&mut self, _buf: &[u8]) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn sync_barrier(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn sync_full(&mut self) -> std::io::Result<()> {
+            if !self.failed {
+                self.failed = true;
+                return Err(std::io::Error::other("injected sync failure"));
+            }
+            Ok(())
+        }
+        fn truncate_to_header(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_tombstone_sync_failure_applies_with_real_seq() {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let hist = hist_with_io(&cp, Box::new(SyncFailOnceIo { failed: false }));
+
+        hist.apply_records(&[committed("きょう", "今日")]);
+        let commit_seq = lock_recover(&hist.wal).last_appended_seq();
+        hist.apply_records(&[deletion("きょう", "今日")]);
+
+        // The frame is on disk (mock append succeeded); the failed flush
+        // must not leave it uncovered, or conditional truncation would
+        // stall until an unrelated append.
+        assert!(
+            learned(&hist, "きょう").is_empty(),
+            "memory delete still runs"
+        );
+        assert!(
+            read_recover(&hist.inner).applied_seq() > commit_seq,
+            "tombstone must be covered by its real seq despite the sync failure"
+        );
+        assert!(!lock_recover(&hist.wal).is_frozen());
+        // Checkpoint fallback: the scrub compaction persists the deletion.
+        wait_until(
+            || lock_recover(&hist.wal).entry_count() == 0,
+            "scrub compaction after sync failure",
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_failure_skips_truncation() {
+        // T6 ordering: the WAL may only be truncated after a covering
+        // checkpoint is durable. A failed checkpoint write must leave the
+        // frames in place.
+        let dir = tempfile::tempdir().unwrap();
+        // Parent of the checkpoint path is a *file*: save() cannot create it.
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"x").unwrap();
+        let cp = blocker.join("history.lxud");
+        let truncates = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hist = hist_with_io(
+            &cp,
+            Box::new(FlakyIo {
+                fail_appends: Arc::new(AtomicBool::new(false)),
+                truncates: Arc::clone(&truncates),
+            }),
+        );
+
+        hist.apply_records(&[committed("きょう", "今日")]);
+        assert_eq!(lock_recover(&hist.wal).entry_count(), 1);
+        hist.run_compact();
+        assert_eq!(
+            truncates.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "no truncation without a durable checkpoint"
+        );
+        assert_eq!(lock_recover(&hist.wal).entry_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // T8: concurrency smoke — records × compactions × tombstones, then
+    // (checkpoint + WAL replay) == memory. Non-deterministic by nature; the
+    // deterministic guarantees live in the T2/T6/T7 tests.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_concurrent_smoke_disk_matches_memory() {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let hist = open_hist(&cp);
+
+        const WRITERS: usize = 4;
+        const BATCHES: usize = 100;
+        let mut handles = Vec::new();
+        for w in 0..WRITERS {
+            let hist = Arc::clone(&hist);
+            handles.push(std::thread::spawn(move || {
+                for i in 0..BATCHES {
+                    let reading = format!("よみ{w}-{i}");
+                    let surface = format!("面{w}-{i}");
+                    hist.apply_records(&[committed(&reading, &surface)]);
+                    if i % 10 == 3 {
+                        // Delete an entry another iteration just learned
+                        // (sometimes a no-op — both paths exercised).
+                        let target = format!("よみ{w}-{}", i - 1);
+                        let target_surface = format!("面{w}-{}", i - 1);
+                        hist.apply_records(&[deletion(&target, &target_surface)]);
+                    }
+                    if i % 25 == 7 {
+                        hist.spawn_compact();
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Quiesce: the gate is free only when no compaction is running;
+        // parked ones finish before our acquisition returns.
+        loop {
+            let gate = hist.lock_gate();
+            if !hist.scrub_pending.load(Ordering::SeqCst) {
+                // Holding the gate: no compaction can start; writers are
+                // done, so the disk state is stable. Reconstruct and diff.
+                let (disk, _wal) =
+                    crate::user_history::wal::open_with_wal(&cp).expect("strict reopen");
+                let mem = read_recover(&hist.inner);
+                let collect = |h: &UserHistory| {
+                    let mut v: Vec<(String, String, u32)> = h
+                        .unigrams()
+                        .map(|(r, s, e)| (r.to_string(), s.to_string(), e.frequency))
+                        .collect();
+                    v.sort();
+                    v
+                };
+                assert_eq!(
+                    collect(&disk),
+                    collect(&mem),
+                    "checkpoint + WAL replay must equal the in-memory state"
+                );
+                drop(gate);
+                break;
+            }
+            drop(gate);
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
     }
 }

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -1112,6 +1112,88 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // §14-2: manual latency profile of the coupled critical section.
+    // Run with:
+    //   cargo test --release -p lex_engine profile_apply_records \
+    //     -- --ignored --nocapture
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[ignore = "manual profiling (§14-2): run with --release --ignored --nocapture"]
+    fn profile_apply_records_lock_hold() {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("history.lxud");
+        let hist = open_hist(&cp);
+
+        // Realistic capacity: ~20k unigram entries.
+        {
+            let mut h = write_recover(&hist.inner);
+            for i in 0..20_000 {
+                h.record_at(&[(format!("よみ{i}"), format!("面{i}"))], 1000 + i as u64);
+            }
+        }
+
+        // Contending conversion reads (the §14-2 concern: inner.read vs the
+        // wal->inner write section).
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut readers = Vec::new();
+        for _ in 0..2 {
+            let hist = Arc::clone(&hist);
+            let stop = Arc::clone(&stop);
+            readers.push(std::thread::spawn(move || {
+                let mut n = 0u64;
+                while !stop.load(Ordering::Relaxed) {
+                    let h = read_recover(&hist.inner);
+                    n += h.learned_surfaces("よみ100", 2000).len() as u64;
+                    drop(h);
+                }
+                n
+            }));
+        }
+
+        let percentile = |sorted: &[std::time::Duration], p: f64| {
+            sorted[((sorted.len() as f64 - 1.0) * p) as usize]
+        };
+
+        // Committed path (includes the every-50 F_BARRIERFSYNC).
+        let mut durs = Vec::with_capacity(1000);
+        for i in 0..1000 {
+            let rec = committed(&format!("けいそく{i}"), &format!("計測{i}"));
+            let t = std::time::Instant::now();
+            hist.apply_records(&[rec]);
+            durs.push(t.elapsed());
+        }
+        durs.sort();
+        println!(
+            "apply_records Committed (20k entries, 2 readers): p50={:?} p95={:?} p99={:?} max={:?}",
+            percentile(&durs, 0.50),
+            percentile(&durs, 0.95),
+            percentile(&durs, 0.99),
+            durs.last().unwrap(),
+        );
+
+        // Tombstone path (per-gesture F_FULLFSYNC).
+        let mut tdurs = Vec::with_capacity(20);
+        for i in 0..20 {
+            let rec = deletion(&format!("けいそく{i}"), &format!("計測{i}"));
+            let t = std::time::Instant::now();
+            hist.apply_records(&[rec]);
+            tdurs.push(t.elapsed());
+        }
+        tdurs.sort();
+        println!(
+            "apply_records Tombstone (F_FULLFSYNC): p50={:?} max={:?}",
+            percentile(&tdurs, 0.50),
+            tdurs.last().unwrap(),
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        for r in readers {
+            r.join().unwrap();
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // T8: concurrency smoke — records × compactions × tombstones, then
     // (checkpoint + WAL replay) == memory. Non-deterministic by nature; the
     // deterministic guarantees live in the T2/T6/T7 tests.

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -593,25 +593,37 @@ impl LexUserHistory {
                 };
                 // This run's snapshot covers heal requests posted so far.
                 this.scrub_pending.store(false, Ordering::SeqCst);
-                if this.run_compact_impl() {
-                    this.spawn_compact();
-                }
+                let outcome = this.run_compact_impl();
+                this.after_compact(outcome);
             })
         {
             warn!("failed to spawn compaction thread: {e}");
         }
     }
 
-    /// Acquire the gate and run one compaction if a scrub is still pending,
-    /// posting an async follow-up when frames landed after the snapshot.
-    /// Shared by [`Self::spawn_compact`] (async) and the synchronous
-    /// durability-failure fallback in [`Self::apply_records`] (§5.4). The
-    /// caller posts `scrub_pending` first so a concurrent gated run can
-    /// absorb the request.
+    /// React to a [`run_compact_impl`](Self::run_compact_impl) outcome: chain
+    /// a follow-up for reclaimable frames, or re-post the scrub if the
+    /// checkpoint did not become durable so a later trigger retries it —
+    /// never silently dropping a delete that is only in memory (or an
+    /// unconfirmed WAL frame).
+    fn after_compact(self: &Arc<Self>, outcome: CompactOutcome) {
+        match outcome {
+            CompactOutcome::Done => {}
+            CompactOutcome::FollowUp => self.spawn_compact(),
+            CompactOutcome::Failed => self.scrub_pending.store(true, Ordering::SeqCst),
+        }
+    }
+
+    /// Acquire the gate and run one compaction if a scrub is still pending
+    /// (see [`Self::after_compact`] for outcome handling). Shared by
+    /// [`Self::spawn_compact`] (async) and the synchronous durability-failure
+    /// fallback in [`Self::apply_records`] (§5.4). The caller posts
+    /// `scrub_pending` first so a concurrent gated run can absorb the request.
     fn run_gated_compact(self: &Arc<Self>) {
         let _gate = self.lock_gate();
-        if self.scrub_pending.swap(false, Ordering::SeqCst) && self.run_compact_impl() {
-            self.spawn_compact();
+        if self.scrub_pending.swap(false, Ordering::SeqCst) {
+            let outcome = self.run_compact_impl();
+            self.after_compact(outcome);
         }
     }
 
@@ -635,14 +647,14 @@ impl LexUserHistory {
     }
 
     #[cfg(test)]
-    fn run_compact(&self) {
-        self.run_compact_impl();
+    fn run_compact(&self) -> CompactOutcome {
+        self.run_compact_impl()
     }
 
-    /// Returns whether a follow-up pass is warranted: frames were appended
-    /// after this run's snapshot, so the covered-only truncation was
-    /// skipped.
-    fn run_compact_impl(&self) -> bool {
+    /// Write a checkpoint and conditionally truncate the WAL, reporting
+    /// whether the checkpoint became durable and whether a follow-up is
+    /// warranted (see [`CompactOutcome`]).
+    fn run_compact_impl(&self) -> CompactOutcome {
         // 1. Clone history under read lock (brief)
         let snapshot = read_recover(&self.inner).clone();
         let cp_path = lock_recover(&self.wal).checkpoint_path().to_path_buf();
@@ -650,7 +662,7 @@ impl LexUserHistory {
         // 2. Write checkpoint (no locks held, slow I/O)
         if let Err(e) = snapshot.save(&cp_path) {
             warn!("checkpoint write failed: {e}");
-            return false;
+            return CompactOutcome::Failed;
         }
 
         // 3. Truncate WAL (brief lock) — conditionally (§5.3): only frames
@@ -658,7 +670,7 @@ impl LexUserHistory {
         // snapshot time) may be destroyed.
         let mut wal = lock_recover(&self.wal);
         match wal.truncate_covered(snapshot.applied_seq()) {
-            Ok(true) => false,
+            Ok(true) => CompactOutcome::Done,
             Ok(false) => {
                 // Frames landed after our snapshot: request a follow-up
                 // pass (§5.3 step 5), which keeps the §5.4 scrub prompt. A
@@ -672,14 +684,39 @@ impl LexUserHistory {
                 // "frames landed after the snapshot" and the follow-up's
                 // snapshot covers them (SyncFailed tombstones carry their
                 // real seq, so no on-disk frame stays uncovered forever).
-                true
+                CompactOutcome::FollowUp
             }
             Err(e) => {
+                // The checkpoint IS durable (save succeeded), so the deletion
+                // is persisted; only the physical WAL scrub is deferred. The
+                // leftover frames are covered (replay skips them) and the
+                // next threshold/startup compaction retries the truncation —
+                // re-posting here would risk a tight loop on a stuck disk.
                 warn!("WAL truncate failed: {e}");
-                false
+                CompactOutcome::Done
             }
         }
     }
+}
+
+/// Outcome of a single [`LexUserHistory::run_compact_impl`] pass, so callers
+/// can tell a durable checkpoint from a failed write. The boolean this
+/// replaced conflated "done" with "save failed", letting the durability-
+/// failure path (§5.4) consume the pending scrub and return without any
+/// durable checkpoint or guaranteed retry.
+enum CompactOutcome {
+    /// Durable checkpoint written and the WAL truncated to cover it. A failed
+    /// *truncation* also lands here: the checkpoint is durable (the deletion
+    /// is persisted); the leftover covered frames are reclaimed by the next
+    /// threshold/startup compaction (the `frames_skipped` backstop).
+    Done,
+    /// Durable checkpoint written, but frames landed after the snapshot so the
+    /// covered-only truncation was skipped — a follow-up pass reclaims them
+    /// once writes settle.
+    FollowUp,
+    /// The checkpoint write failed, so nothing became durable. The scrub is
+    /// unmet and must stay pending for a later retry.
+    Failed,
 }
 
 /// Serialize one commit event as a JSONL line for the commit log.
@@ -870,8 +907,12 @@ mod tests {
 
         hist.apply_records(&[committed("きょう", "今日")]);
         // Persist the entry into a checkpoint so the scrub has something to
-        // rewrite.
-        hist.run_compact();
+        // rewrite. A quiescent compaction writes a durable checkpoint and
+        // truncates the covered frames (CompactOutcome::Done).
+        assert!(
+            matches!(hist.run_compact(), CompactOutcome::Done),
+            "quiescent compaction should report a durable, truncated checkpoint"
+        );
         assert!(cp.exists());
 
         hist.apply_records(&[deletion("きょう", "今日")]);
@@ -1163,6 +1204,34 @@ mod tests {
         assert!(
             learned(&hist2, "きょう").is_empty(),
             "durability-failed tombstone is checkpointed before return, not resurrected"
+        );
+    }
+
+    #[test]
+    fn test_durability_failure_with_failed_checkpoint_keeps_scrub_pending() {
+        // R2: if the synchronous durability checkpoint ALSO fails (stuck
+        // disk), the scrub must stay pending so a later compaction / startup
+        // retries it — the deletion must not be silently dropped with the
+        // pending flag consumed.
+        let dir = tempfile::tempdir().unwrap();
+        // Parent of the checkpoint is a *file*: save() can never create it.
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"x").unwrap();
+        let cp = blocker.join("history.lxud");
+        let hist = hist_with_io(&cp, Box::new(SyncFailOnceIo { failed: false }));
+
+        // Learn, then delete: the tombstone's sync_full fails (SyncFailed)
+        // AND the synchronous checkpoint save fails (blocked parent).
+        hist.apply_records(&[committed("きょう", "今日")]);
+        hist.apply_records(&[deletion("きょう", "今日")]);
+
+        assert!(
+            learned(&hist, "きょう").is_empty(),
+            "memory delete still runs"
+        );
+        assert!(
+            hist.scrub_pending.load(Ordering::SeqCst),
+            "a failed durability checkpoint must keep the scrub pending for retry"
         );
     }
 

--- a/engine/src/api/resources.rs
+++ b/engine/src/api/resources.rs
@@ -157,9 +157,10 @@ pub enum LexHistoryWalState {
     RepairFailed,
 }
 
-/// What `open` found and did (§10). `data_loss_suspected` carries the §8
-/// visibility rule (only whole-file quarantine is user-visible) so Swift
-/// does not re-implement the policy.
+/// What `open` found and did (§10). The policy bits are computed on the
+/// Rust side so Swift stays purely presentational: `data_loss_suspected`
+/// carries the §8 visibility rule (only whole-file quarantine is
+/// user-visible), `clean` the "nothing noteworthy happened" rule.
 #[derive(uniffi::Record)]
 pub struct LexHistoryOpenReport {
     pub checkpoint_state: LexHistoryCheckpointState,
@@ -169,6 +170,7 @@ pub struct LexHistoryOpenReport {
     pub frames_skipped: u64,
     pub quarantined_paths: Vec<String>,
     pub data_loss_suspected: bool,
+    pub clean: bool,
 }
 
 impl From<&OpenReport> for LexHistoryOpenReport {
@@ -200,6 +202,7 @@ impl From<&OpenReport> for LexHistoryOpenReport {
                 .map(|p| p.display().to_string())
                 .collect(),
             data_loss_suspected: r.data_loss_suspected(),
+            clean: r.is_clean(),
         }
     }
 }
@@ -255,7 +258,6 @@ impl LexUserHistory {
             path: cp.with_file_name("commit-log.jsonl"),
             file: None,
         };
-        let compaction_recommended = report.compaction_recommended;
         let this = Arc::new(Self {
             inner: Arc::new(RwLock::new(history)),
             wal: Mutex::new(wal),
@@ -270,7 +272,7 @@ impl LexUserHistory {
         // checkpoint covers memory, so the truncation that follows it
         // restores appendable v2 form — without this, appends would keep
         // failing and threshold-based compaction would never trigger.
-        if compaction_recommended {
+        if this.report.compaction_recommended {
             this.spawn_compact();
         }
         Ok(this)
@@ -344,11 +346,20 @@ impl LexUserHistory {
             }
         }
 
-        let mut tombstone_written = false;
-        let mut append_failed = false;
+        // One flag decides the compaction mode below; both causes need the
+        // same immediate gated run:
+        // - Tombstone written: physical scrub (§5.4) — the deleted strings
+        //   still sit in the old checkpoint and past Committed frames until
+        //   a compaction rewrites the checkpoint and truncates the WAL.
+        // - Append failure: the WAL may be frozen; only a post-checkpoint
+        //   truncation restores appendable form (heal), and the entry-count
+        //   threshold can no longer reach it.
+        let mut scrub = false;
+        let mut needs_threshold_compact = false;
         if !wal_records.is_empty() {
             let mut wal = lock_recover(&self.wal);
-            let mut sequenced: Vec<(WalRecord, u64)> = Vec::with_capacity(wal_records.len());
+            let mut sequenced: Vec<(WalRecord, Option<u64>)> =
+                Vec::with_capacity(wal_records.len());
             for record in wal_records {
                 if let WalRecord::Tombstone { segments, .. } = &record {
                     // No-op deletion: pruning a candidate that was never
@@ -359,14 +370,10 @@ impl LexUserHistory {
                     if !read_recover(&self.inner).contains_entries(segments) {
                         continue;
                     }
+                    scrub = true;
                 }
                 match wal.append_record(&record) {
-                    Ok(seq) => {
-                        if matches!(record, WalRecord::Tombstone { .. }) {
-                            tombstone_written = true;
-                        }
-                        sequenced.push((record, seq));
-                    }
+                    Ok(seq) => sequenced.push((record, Some(seq))),
                     // Frame on disk, durability unconfirmed: apply with the
                     // real seq — leaving an on-disk frame uncovered would
                     // stall conditional truncation indefinitely (AppendError
@@ -375,31 +382,26 @@ impl LexUserHistory {
                     // scheduled below persists it in full.
                     Err(AppendError::SyncFailed { seq, source }) => {
                         warn!("tombstone durability sync failed (checkpoint fallback): {source}");
-                        tombstone_written = true;
-                        append_failed = true;
-                        sequenced.push((record, seq));
+                        scrub = true;
+                        sequenced.push((record, Some(seq)));
                     }
                     // Frame not on disk: memory still applies — a confirmed
                     // conversion that stops boosting is an immediate quality
                     // regression (§5.2) — but applied_seq must not advance
-                    // (seq 0 is a no-op for the monotonic max). The next
-                    // checkpoint is a full snapshot, so a recovered disk
-                    // picks the effect up; the frame's absence makes
-                    // double-apply impossible.
+                    // (None), or a checkpoint would claim coverage of a
+                    // frame that cannot replay. The next checkpoint is a
+                    // full snapshot, so a recovered disk picks the effect
+                    // up; the frame's absence makes double-apply impossible.
                     Err(e @ AppendError::Io(_)) => {
                         warn!("{e}");
-                        append_failed = true;
-                        sequenced.push((record, 0));
+                        scrub = true;
+                        sequenced.push((record, None));
                     }
                 }
             }
+            needs_threshold_compact = wal.needs_compact();
             if !sequenced.is_empty() {
-                let mut hist = write_recover(&self.inner);
-                for (record, seq) in &sequenced {
-                    hist.apply(record, *seq);
-                }
-                // Batched apply settles capacity once, like replay (§5.1-4).
-                hist.evict();
+                write_recover(&self.inner).apply_batch(&sequenced);
             }
         }
 
@@ -407,16 +409,10 @@ impl LexUserHistory {
             self.append_commit_log(line);
         }
 
-        // Tombstone: schedule the physical scrub (§5.4) — the deleted
-        // strings still sit in the old checkpoint and in past Committed
-        // frames until a compaction rewrites the checkpoint and truncates
-        // the WAL. Append failure: the WAL may be frozen; only a
-        // post-checkpoint truncation restores appendable form (heal), and
-        // the entry-count threshold can no longer reach it.
-        if tombstone_written || append_failed {
+        if scrub {
             self.spawn_compact();
-        } else {
-            self.maybe_compact();
+        } else if needs_threshold_compact {
+            self.spawn_threshold_compact();
         }
     }
 
@@ -463,7 +459,7 @@ impl LexUserHistory {
             // state unknown) and surface the failure.
             warn!("clear: WAL truncation failed: {e}");
             wal.freeze();
-            deferred = Some(e.into());
+            deferred.get_or_insert(e.into());
         }
 
         {
@@ -513,12 +509,10 @@ impl LexUserHistory {
         }
     }
 
-    /// Acquire the compaction gate, recovering through poisoning: the gate
-    /// protects no data (see the field docs).
-    fn lock_gate(&self) -> std::sync::MutexGuard<'_, ()> {
-        self.compact_gate
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    /// Acquire the compaction gate. Poison recovery is trivially safe here:
+    /// the gate protects no data (see the field docs).
+    fn lock_gate(&self) -> MutexGuard<'_, ()> {
+        lock_recover(&self.compact_gate)
     }
 
     /// Append one JSONL line to the commit log. Failures are logged and
@@ -536,11 +530,9 @@ impl LexUserHistory {
         }
     }
 
-    /// Spawn background compaction if threshold is reached.
-    pub(super) fn maybe_compact(self: &Arc<Self>) {
-        if !lock_recover(&self.wal).needs_compact() {
-            return;
-        }
+    /// Spawn a threshold compaction (the caller has already observed
+    /// `needs_compact()` under the wal lock).
+    fn spawn_threshold_compact(self: &Arc<Self>) {
         // §4: threshold compactions skip when one is in flight — the
         // threshold stays exceeded and the next commit retries. Advisory
         // pre-check to avoid spawning a thread per commit while a
@@ -1234,7 +1226,12 @@ mod tests {
 
         // Quiesce: the gate is free only when no compaction is running;
         // parked ones finish before our acquisition returns.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timeout waiting for compactions to quiesce"
+            );
             let gate = hist.lock_gate();
             if !hist.scrub_pending.load(Ordering::SeqCst) {
                 // Holding the gate: no compaction can start; writers are

--- a/engine/src/api/session.rs
+++ b/engine/src/api/session.rs
@@ -224,120 +224,15 @@ impl LexSession {
         Some(convert_to_events(resp, epoch))
     }
 
+    /// Persist a batch of learning records. The whole protocol — WAL-ahead
+    /// append, in-memory apply, commit log, compaction scheduling — lives
+    /// in [`LexUserHistory::apply_records`] (§5.2).
     fn record_history(&self, records: &[LearningRecord]) {
         if records.is_empty() {
             return;
         }
-        let Some(ref h) = self.history else {
-            return;
-        };
-
-        // Phase 1: in-memory update (write lock)
-        let now = crate::user_history::now_epoch();
-        let mut wal_entries: Vec<Vec<(String, String)>> = Vec::new();
-        let mut needs_compact = false;
-        let mut log_lines: Vec<String> = Vec::new();
-        if let Ok(mut hist) = h.inner.write() {
-            for r in records {
-                match r {
-                    LearningRecord::Committed {
-                        reading,
-                        surface,
-                        segments,
-                        rank,
-                        top1,
-                        auto,
-                        learn,
-                    } => {
-                        if *learn {
-                            let segs = vec![(reading.clone(), surface.clone())];
-                            hist.record_at(&segs, now);
-                            wal_entries.push(segs);
-                            if let Some(sub_segs) = segments {
-                                hist.record_at(sub_segs, now);
-                                wal_entries.push(sub_segs.clone());
-                            }
-                        }
-                        log_lines.push(commit_log_line(
-                            now,
-                            reading,
-                            surface,
-                            *rank,
-                            top1.as_deref(),
-                            *auto,
-                        ));
-                    }
-                    LearningRecord::Deletion { segments } => {
-                        if hist.remove_entries(segments) {
-                            needs_compact = true;
-                        }
-                    }
-                }
-            }
+        if let Some(ref h) = self.history {
+            h.apply_records(records);
         }
-
-        // Phase 2: WAL append (write lock released, wal mutex only)
-        for segments in &wal_entries {
-            h.append_wal(segments, now);
-        }
-        for line in &log_lines {
-            h.append_commit_log(line);
-        }
-
-        // Phase 3: persist deletion immediately, or background compaction
-        if needs_compact {
-            h.force_compact();
-        } else {
-            h.maybe_compact();
-        }
-    }
-}
-
-/// Serialize one commit event as a JSONL line for the commit log.
-/// `top1` and `auto` are omitted at their defaults to keep lines lean.
-fn commit_log_line(
-    now: u64,
-    reading: &str,
-    surface: &str,
-    rank: usize,
-    top1: Option<&str>,
-    auto: bool,
-) -> String {
-    let mut obj = serde_json::json!({
-        "t": now,
-        "reading": reading,
-        "surface": surface,
-        "rank": rank,
-    });
-    if let Some(t1) = top1 {
-        obj["top1"] = serde_json::Value::String(t1.to_string());
-    }
-    if auto {
-        obj["auto"] = serde_json::Value::Bool(true);
-    }
-    obj.to_string()
-}
-
-#[cfg(test)]
-mod commit_log_tests {
-    use super::commit_log_line;
-
-    #[test]
-    fn test_commit_log_line_shape() {
-        // Manual pick: top1 present, auto omitted
-        let line = commit_log_line(42, "きょう", "京", 2, Some("今日"), false);
-        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
-        assert_eq!(v["t"], 42);
-        assert_eq!(v["reading"], "きょう");
-        assert_eq!(v["surface"], "京");
-        assert_eq!(v["rank"], 2);
-        assert_eq!(v["top1"], "今日");
-        assert!(v.get("auto").is_none());
-
-        // Auto-commit acceptance: top1 omitted, auto present
-        let line = commit_log_line(42, "きょう", "今日", 0, None, true);
-        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
-        assert!(v.get("top1").is_none());
-        assert_eq!(v["auto"], true);
     }
 }


### PR DESCRIPTION
## LXUD v2 PR2 — 学習履歴 書き込みプロトコル刷新 (lex_engine + Swift)

設計 SSoT: LXUD v2 設計メモ §5.2/§5.4/§5.5/§10/§12。PR1 (#281) の reader/format 基盤の上に writer プロトコルを載せる。plan-review 5 軸通過済。

### 何を変えたか

- **`apply_records` へ集約 + WAL-ahead 反転** (resources.rs): session.rs の 3 フェーズ (メモリ先行) を廃し、WAL append → in-memory apply を **1 つの wal-mutex クリティカルセクションで結合**。`applied_seq = S ⇒ seq ≤ S は全適用済み` を構造で保証 (マルチセッションの apply 順逆転を排除)。旧 `append_wal` / `force_compact` / `clear_locked` を削除。
- **`AppendError::{Io, SyncFailed{seq}}`** (wal.rs): frame 未着 (freeze + 欠番) と、frame 有効・耐久化のみ失敗 を型で区別。前者は `applied_seq` を進めず、後者は実 seq で apply (on-disk frame を uncovered にすると条件付き truncate が無期限停止するため)。
- **Tombstone 削除 + 非同期スクラブ** (§5.4): append 時 F_FULLFSYNC、直後に scrub compaction 即スケジュール。`force_compact` の spin-wait + 同期 checkpoint 書き込みを撲滅。no-op 削除 (`contains_entries` で判定) には F_FULLFSYNC を払わない。
- **clear 空checkpoint先行プロトコル** (§5.5): 空 cp (applied_seq = last_appended_seq) の rename がコミットポイント。以後どのクラッシュ点でも空履歴に収束 (復活窓ゼロ)。truncate 失敗は freeze + heal + **Err 伝播**。
- **compact_gate Mutex 化** (決定 #11) + **scrub_pending** (§5.3 step 5)。
- **OpenReport の UniFFI 化** (§10): `open_report()` + `LexHistoryOpenReport`。policy bit (`data_loss_suspected` / `clean`) は Rust 側計算、Swift は presentational。
- **Swift**: `EngineInitFailure.historyDataLoss` (学習継続・過去分喪失)、EngineContainer が openReport 消費 (data loss → メニュー導線、migration/tail は NSLog)。

### レビュー

このセッションで前回 spend limit で中断した /code-review max の 7 finder (correctness A-E + efficiency + altitude) を **Workflow で再実行 → 各 finding を effort max で敵対的検証**。

- **concurrency / crash-consistency / efficiency 角度は clean** (zero findings)。
- 検出された findings は clear/commit-log ライフサイクルと dead code に集中。修正済:
  - clear の commit-log 削除失敗に truncate-to-zero スクラブ fallback (unlink 不可でも private 入力を消す)
  - Swift `resetAll` が clear の Err を可視化 (alert)・完全成功時のみ再起動 (§10 never-silent)
  - dead `LexUserHistory::clear` UniFFI method 削除 / `HistoryWal::append` を #[cfg(test)] 化 / SyncFailed arm の冗長 scrub を debug_assert 化
- **lexime-review** (5 軸 design gate): Axis 3 (構造的正しさ) / Axis 4 (UniFFI 境界) は **zero findings** (全不変条件が構造で防御されていることを確認)。Axis 5 (文脈整合) で SPEC.md の force_compact drift を検出 → 修正 (bc01e08)。Axis 1/2 は expected-yield=0 (dict/cost/corpus/converter 不変) で skip。

### accuracy

変換パス (converter/viterbi/cost/dict/reranker) 不変につき **accuracy 影響なし**。参考: 前セッションの Stage 2 で 108 pass / 28 skip・history 7/7 = before と同一を確認済。

### 既知の pre-existing 低優先 gap (本 PR スコープ外、別途 follow-up 候補)

- **evicted-but-checkpointed delete resurrection** (mod.rs): メモリから evict 済だが on-disk checkpoint に残るエントリの ForwardDelete が no-op になり、次回 compaction 前クラッシュで復活し得る。v1 から同一挙動 (本 PR 導入ではない)。
- **commit-log 再作成 race** (resources.rs): clear の commit-log 削除と並行 apply_records の commit-log append の microscopic window。1 診断行のみ残存、履歴復活はしない。clear_locked から継承。
- **compound spawn-failure** (resources.rs): clear truncate 失敗 + spawn_compact スレッド生成の持続的失敗 = セッション内 memory-only 窓。次回起動の compaction で heal (永久損失なし)。

### Test plan

- [x] Rust: fmt / clippy -D warnings clean、584 tests pass (lex_core 410 / lex_session 80 / lex_cli 71 / lex_engine 23)
- [x] Swift: build (bindings 再生成で dead clear binding 消滅を確認) + 139 tests pass
- [x] MSRV 1.88.0 green (前セッション)
- [x] 実ファイル migration 検証済 (§14-4、前セッション): 開発機の実 v1 で unigram/bigram 完全一致・二重適用なし
- [x] §14-2 lock-hold profile 実測済 (前セッション、ignored test)
- [ ] Swift 実機確認: 破損ファイル起動で学習継続 + メニュー historyDataLoss 可視化

🤖 Generated with [Claude Code](https://claude.com/claude-code)
