### PR TITLE
refactor(persist): extract shared durable-write + quarantine primitives

### DIFF
--- a/engine/crates/lex-core/src/lib.rs
+++ b/engine/crates/lex-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dict;
 #[cfg(feature = "neural")]
 pub mod neural;
 pub(crate) mod numeric;
+pub(crate) mod persist;
 pub mod romaji;
 pub mod settings;
 pub mod snippets;

--- a/engine/crates/lex-core/src/persist.rs
+++ b/engine/crates/lex-core/src/persist.rs
@@ -1,0 +1,226 @@
+//! Shared on-disk persistence primitives for the durable stores in this crate
+//! (`user_history` LXUD, `user_dict` LXUW).
+//!
+//! These are the canonical, single-source implementations of three concerns
+//! that any durable store here needs, so the stores cannot drift apart on the
+//! privacy/durability details (the kind of drift that once left `user_dict`
+//! with an unsynced write and a stray-`.tmp` bug that LXUD had already fixed):
+//!
+//! - **Atomic durable write** ([`write_atomic`]): tmp → fsync → rename → dir
+//!   fsync, so a rename can never become durable before the file contents.
+//! - **Quarantine** ([`quarantine`] / [`rotate_quarantined`]): rename a corrupt
+//!   file aside as `<name>.corrupt-<ts>` instead of deleting it, so the bytes
+//!   stay rescuable, and cap how many accumulate.
+//! - **bincode config** ([`bincode_reader`] / [`bincode_reader_v1`]): a fixint
+//!   reader with an explicit allocation cap; trailing-byte tolerance is the one
+//!   knob that differs, and the choice is format-dependent (see below).
+//!
+//! The module has no dependency on any store's domain types or clock: every
+//! function takes only paths, bytes, and (for quarantine) an injected `ts`, so
+//! it is a leaf both stores depend on rather than a peer of either.
+
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use bincode::Options as _;
+use tracing::warn;
+
+/// bincode config matching the wire format of `bincode::serialize` (fixint
+/// encoding) plus an explicit allocation cap. The plain `bincode::deserialize`
+/// is unlimited: a corrupt length prefix inside the body could trigger a giant
+/// allocation before any data is read.
+///
+/// Trailing bytes are **rejected**. Use this for length- and CRC-framed bodies
+/// (LXUD v2 checkpoint / WAL payloads), which are exact-length by construction,
+/// so leftovers can only mean a writer bug or corruption that happened to keep
+/// the CRC — surface it instead of silently succeeding. For a no-CRC / v1-class
+/// format use [`bincode_reader_v1`] instead.
+pub(crate) fn bincode_reader(limit: usize) -> impl bincode::Options {
+    bincode::options()
+        .with_fixint_encoding()
+        .with_limit(limit as u64)
+}
+
+/// Like [`bincode_reader`] but **tolerates trailing bytes**. Use this for
+/// no-CRC / v1-class formats (LXUD v1 checkpoint bodies, LXUW user_dict): the
+/// original readers were the plain `bincode::deserialize`, which tolerates
+/// trailing bytes, and without a CRC there is no way to tell benign residue
+/// from corruption — staying lenient avoids quarantining data the old code
+/// recovered. The `with_limit` cap is still applied.
+pub(crate) fn bincode_reader_v1(limit: usize) -> impl bincode::Options {
+    bincode::options()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+        .with_limit(limit as u64)
+}
+
+/// `create_dir_all` for the parent, tolerating bare relative paths whose
+/// parent is "" (the current directory — nothing to create).
+pub(crate) fn ensure_parent_dir(path: &Path) -> io::Result<()> {
+    match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => fs::create_dir_all(p),
+        _ => Ok(()),
+    }
+}
+
+/// Atomic write with content durability: tmp → sync_all (F_FULLFSYNC on
+/// macOS) → rename → best-effort parent-dir fsync. Without the tmp sync, the
+/// rename can become durable before the file contents, manufacturing a corrupt
+/// file on power loss. The parent-dir fsync only makes the rename itself
+/// durable; per the LXUD design (§6) it is deliberately best-effort and
+/// log-only — APFS journals renames, and the worst case of an unsynced rename
+/// is rolling back to the previous file, never corruption. The tmp name
+/// appends `.tmp` to the full file name ([`suffixed`]); `with_extension` would
+/// strip the store's extension and leave a stray sibling `<stem>.tmp`.
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = suffixed(path, ".tmp");
+    ensure_parent_dir(path)?;
+    let mut f = File::create(&tmp)?;
+    f.write_all(bytes)?;
+    f.sync_all()?;
+    drop(f);
+    fs::rename(&tmp, path)?;
+    if !sync_parent_dir(path) {
+        warn!("parent dir sync failed; rename durability unconfirmed (best-effort, by design)");
+    }
+    Ok(())
+}
+
+/// Best-effort fsync of the parent directory so the rename itself is durable.
+/// APFS likely journals renames already; this is POSIX practice on a background
+/// path, so it costs nothing and failures are non-fatal. Returns whether the
+/// sync succeeded (callers only log on failure).
+pub(crate) fn sync_parent_dir(path: &Path) -> bool {
+    let parent = match path.parent() {
+        // A bare relative path ("history.lxud") has parent "" — that means the
+        // current directory, and File::open("") would fail.
+        Some(p) if p.as_os_str().is_empty() => Path::new("."),
+        Some(p) => p,
+        None => return false,
+    };
+    match File::open(parent) {
+        Ok(dir) => dir.sync_all().is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// Append `suffix` to the full file name (`user_history.lxud` + `.corrupt-1` →
+/// `user_history.lxud.corrupt-1`). Unlike `Path::with_extension`, this keeps
+/// the store's own extension so the artifact stays within the file family.
+pub(crate) fn suffixed(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(suffix);
+    path.with_file_name(name)
+}
+
+/// Outcome of [`quarantine`]. `Renamed`/`Removed` both leave the path clear so
+/// a later save can recreate it; `Failed` means the corrupt file is still in
+/// place (a later save will try to overwrite it).
+pub(crate) enum Quarantine {
+    /// Renamed aside as `<name>.corrupt-<ts>[-n]`; bytes preserved for rescue.
+    Renamed(PathBuf),
+    /// Rename failed; the corrupt file was removed as a last resort.
+    Removed,
+    /// Both rename and removal failed; the file remains in place.
+    Failed,
+}
+
+/// Rename `path` aside as `<name>.corrupt-<ts>[-n]`, preserving the bytes for
+/// manual rescue. If the rename fails, removal is attempted as a last resort —
+/// clearing the path so subsequent saves can recreate it is prioritized over
+/// byte preservation at that point (in practice rename and removal need the
+/// same directory permission, so a byte-destroying fallback is nearly
+/// unreachable); if even that fails, the file stays in place and later saves
+/// will try to overwrite it. `ts` (epoch secs) is injected by the caller so
+/// this primitive stays clock-free and independent of any store's clock.
+pub(crate) fn quarantine(path: &Path, ts: u64) -> Quarantine {
+    for n in 0..10 {
+        let suffix = if n == 0 {
+            format!(".corrupt-{ts}")
+        } else {
+            format!(".corrupt-{ts}-{n}")
+        };
+        let dest = suffixed(path, &suffix);
+        if dest.exists() {
+            continue;
+        }
+        return match fs::rename(path, &dest) {
+            Ok(()) => Quarantine::Renamed(dest),
+            Err(rename_err) => match fs::remove_file(path) {
+                Ok(()) => {
+                    warn!("quarantine rename failed ({rename_err}); removed corrupt file instead");
+                    Quarantine::Removed
+                }
+                Err(remove_err) => {
+                    warn!(
+                        "quarantine failed (rename: {rename_err}, remove: {remove_err}); continuing"
+                    );
+                    Quarantine::Failed
+                }
+            },
+        };
+    }
+    Quarantine::Failed
+}
+
+/// All `<name>.corrupt-*` files in the same directory as `path`.
+pub(crate) fn quarantined_files(path: &Path) -> Vec<PathBuf> {
+    let parent = match path.parent() {
+        // Bare relative name ("history.lxud"): parent is "" = the current
+        // directory; read_dir("") would fail and hide quarantine files from
+        // rotation and the clear() privacy wipe.
+        Some(p) if p.as_os_str().is_empty() => Path::new("."),
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+    let Some(prefix) = path.file_name().and_then(|n| n.to_str()) else {
+        return Vec::new();
+    };
+    let Ok(entries) = fs::read_dir(parent) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(prefix) && name.contains(".corrupt-"))
+        })
+        .map(|e| e.path())
+        .collect()
+}
+
+/// Keep only the newest `keep` quarantined files (by epoch in the file name) so
+/// repeated corruption cannot accumulate junk forever.
+pub(crate) fn rotate_quarantined(path: &Path, keep: usize) {
+    let mut files = quarantined_files(path);
+    if files.len() <= keep {
+        return;
+    }
+    // `.corrupt-<epoch>[-n]`: sort newest first; unparsable names sort oldest
+    // and get cleaned up.
+    files.sort_by_key(|p| {
+        let key = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|name| name.rsplit_once(".corrupt-"))
+            .and_then(|(_, suffix)| {
+                let (epoch, n) = match suffix.split_once('-') {
+                    Some((e, n)) => (e, n.parse::<u64>().unwrap_or(0)),
+                    None => (suffix, 0),
+                };
+                epoch.parse::<u64>().ok().map(|e| (e, n))
+            })
+            .unwrap_or((0, 0));
+        std::cmp::Reverse(key)
+    });
+    for old in &files[keep..] {
+        if let Err(e) = fs::remove_file(old) {
+            warn!(
+                "failed to rotate old quarantine file {}: {e}",
+                old.display()
+            );
+        }
+    }
+}

--- a/engine/crates/lex-core/src/user_history/persistence.rs
+++ b/engine/crates/lex-core/src/user_history/persistence.rs
@@ -19,12 +19,13 @@
 //!
 //! v1 (retained reader, ~30 lines): `LXUD` + version byte `1` + bincode body.
 
-use std::fs::{self, File};
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+use std::fs;
+use std::io;
+use std::path::Path;
 
 use bincode::Options as _;
-use tracing::warn;
+
+use crate::persist::{bincode_reader, bincode_reader_v1, write_atomic};
 
 use super::{BigramRecord, HistoryEntry, UnigramRecord, UserHistory, UserHistoryData};
 
@@ -32,32 +33,6 @@ pub(super) const MAGIC: &[u8; 4] = b"LXUD";
 pub(super) const VERSION_V1: u8 = 1;
 pub(super) const VERSION: u8 = 2;
 pub(super) const HEADER_LEN: usize = 32;
-
-/// bincode config matching the wire format of `bincode::serialize` (fixint
-/// encoding) plus an explicit allocation cap. The plain
-/// `bincode::deserialize` is unlimited: a corrupt length prefix inside the
-/// body could trigger a giant allocation before any data is read.
-///
-/// Trailing bytes are rejected: v2 checkpoint bodies and WAL payloads are
-/// exact-length by construction (length fields + CRC), so leftovers can
-/// only mean a writer bug or corruption that happened to keep the CRC —
-/// surface it instead of silently succeeding.
-pub(super) fn bincode_reader(limit: usize) -> impl bincode::Options {
-    bincode::options()
-        .with_fixint_encoding()
-        .with_limit(limit as u64)
-}
-
-/// v1 reader config: the original v1 reader was `bincode::deserialize`,
-/// which tolerates trailing bytes — keep that parity so degraded-but-
-/// parseable v1 files still migrate (v1 has no CRC; strictness here would
-/// quarantine data the old code recovered).
-fn bincode_reader_v1(limit: usize) -> impl bincode::Options {
-    bincode::options()
-        .with_fixint_encoding()
-        .allow_trailing_bytes()
-        .with_limit(limit as u64)
-}
 
 fn invalid(msg: impl Into<String>) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, msg.into())
@@ -100,63 +75,6 @@ pub(super) fn load_checkpoint(path: &Path) -> io::Result<CheckpointLoaded> {
         v => Ok(CheckpointLoaded::Corrupt(invalid(format!(
             "unsupported version {v}"
         )))),
-    }
-}
-
-/// `create_dir_all` for the parent, tolerating bare relative paths whose
-/// parent is "" (the current directory — nothing to create).
-pub(super) fn ensure_parent_dir(path: &Path) -> io::Result<()> {
-    match path.parent() {
-        Some(p) if !p.as_os_str().is_empty() => fs::create_dir_all(p),
-        _ => Ok(()),
-    }
-}
-
-/// Atomic write with content durability: tmp → sync_all (F_FULLFSYNC on
-/// macOS) → rename → best-effort parent-dir fsync. Without the tmp sync,
-/// the rename can become durable before the file contents, manufacturing a
-/// corrupt checkpoint on power loss. The parent-dir fsync only makes the
-/// rename itself durable; per the design (§6) it is deliberately
-/// best-effort and log-only — APFS journals renames, and the worst case of
-/// an unsynced rename is rolling back to the previous checkpoint, never
-/// corruption. The tmp name appends `.tmp` to the full file name
-/// (`with_extension` would strip `.lxud` and leave a stray
-/// `user_history.tmp`).
-pub(super) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    let tmp = tmp_path(path);
-    ensure_parent_dir(path)?;
-    let mut f = File::create(&tmp)?;
-    f.write_all(bytes)?;
-    f.sync_all()?;
-    drop(f);
-    fs::rename(&tmp, path)?;
-    if !sync_parent_dir(path) {
-        warn!("parent dir sync failed; rename durability unconfirmed (best-effort, by design)");
-    }
-    Ok(())
-}
-
-fn tmp_path(path: &Path) -> PathBuf {
-    let mut name = path.file_name().unwrap_or_default().to_os_string();
-    name.push(".tmp");
-    path.with_file_name(name)
-}
-
-/// Best-effort fsync of the parent directory so the rename itself is
-/// durable. APFS likely journals renames already; this is POSIX practice on
-/// a background path, so it costs nothing and failures are non-fatal.
-/// Returns whether the sync succeeded (callers only log on failure).
-pub(super) fn sync_parent_dir(path: &Path) -> bool {
-    let parent = match path.parent() {
-        // A bare relative path ("history.lxud") has parent "" — that means
-        // the current directory, and File::open("") would fail.
-        Some(p) if p.as_os_str().is_empty() => Path::new("."),
-        Some(p) => p,
-        None => return false,
-    };
-    match File::open(parent) {
-        Ok(dir) => dir.sync_all().is_ok(),
-        Err(_) => false,
     }
 }
 

--- a/engine/crates/lex-core/src/user_history/recovery.rs
+++ b/engine/crates/lex-core/src/user_history/recovery.rs
@@ -19,6 +19,8 @@ use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
 
+use crate::persist;
+
 use super::persistence::{load_checkpoint, CheckpointLoaded};
 use super::wal::{
     classify_wal, legacy_valid_prefix, scan_legacy, scan_v2, wal_path_for, HistoryWal, WalFormat,
@@ -340,7 +342,7 @@ pub fn open_recovering(
         || wal.is_frozen();
 
     // --- 5. quarantine rotation + v1-backup GC ---
-    rotate_quarantined(checkpoint_path);
+    persist::rotate_quarantined(checkpoint_path, QUARANTINE_KEEP);
     gc_v1_backup(checkpoint_path);
 
     Ok((history, wal, report))
@@ -370,7 +372,7 @@ fn gc_v1_backup(checkpoint_path: &Path) {
 
 /// Path of the best-effort v1 checkpoint backup (`<name>.v1.bak`).
 pub fn v1_backup_path(checkpoint_path: &Path) -> PathBuf {
-    suffixed(checkpoint_path, ".v1.bak")
+    persist::suffixed(checkpoint_path, ".v1.bak")
 }
 
 /// Remove recovery artifacts (`.v1.bak`, `.corrupt-*`, stray `.tmp`) for
@@ -379,7 +381,7 @@ pub fn v1_backup_path(checkpoint_path: &Path) -> PathBuf {
 pub fn remove_recovery_artifacts(checkpoint_path: &Path) -> io::Result<()> {
     for path in [
         v1_backup_path(checkpoint_path),
-        suffixed(checkpoint_path, ".tmp"),
+        persist::suffixed(checkpoint_path, ".tmp"),
         // The v1 writer used `with_extension("tmp")` (`user_history.tmp`):
         // a pre-upgrade crash before rename can leave a full serialized
         // history copy under that name.
@@ -391,7 +393,7 @@ pub fn remove_recovery_artifacts(checkpoint_path: &Path) -> io::Result<()> {
             Err(e) => return Err(e),
         }
     }
-    for path in quarantined_files(checkpoint_path) {
+    for path in persist::quarantined_files(checkpoint_path) {
         match fs::remove_file(&path) {
             Ok(()) => {}
             Err(e) if e.kind() == io::ErrorKind::NotFound => {}
@@ -401,52 +403,19 @@ pub fn remove_recovery_artifacts(checkpoint_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn suffixed(path: &Path, suffix: &str) -> PathBuf {
-    let mut name = path.file_name().unwrap_or_default().to_os_string();
-    name.push(suffix);
-    path.with_file_name(name)
-}
-
-/// Rename `path` aside as `<name>.corrupt-<epoch>[-n]`, preserving the
-/// bytes for manual rescue. If the rename fails, removal is attempted as a
-/// last resort — clearing the path so subsequent saves can recreate it is
-/// prioritized over byte preservation at that point (in practice rename and
-/// removal need the same directory permission, so a byte-destroying
-/// fallback is nearly unreachable); if even that fails, the file stays in
-/// place and later saves will try to overwrite it. Returns whether `path`
-/// is now clear.
+/// Adapter over [`persist::quarantine`] for the checkpoint/WAL recovery
+/// path: injects the recovery clock, records the rescued path in the report,
+/// and reports whether `path` is now clear (both rename and remove failing
+/// leaves it in place, which the WAL branch turns into a `freeze()`).
 fn quarantine(path: &Path, quarantined: &mut Vec<PathBuf>) -> bool {
-    let ts = super::now_epoch();
-    for n in 0..10 {
-        let suffix = if n == 0 {
-            format!(".corrupt-{ts}")
-        } else {
-            format!(".corrupt-{ts}-{n}")
-        };
-        let dest = suffixed(path, &suffix);
-        if dest.exists() {
-            continue;
+    match persist::quarantine(path, super::now_epoch()) {
+        persist::Quarantine::Renamed(dest) => {
+            quarantined.push(dest);
+            true
         }
-        return match fs::rename(path, &dest) {
-            Ok(()) => {
-                quarantined.push(dest);
-                true
-            }
-            Err(rename_err) => match fs::remove_file(path) {
-                Ok(()) => {
-                    warn!("quarantine rename failed ({rename_err}); removed corrupt file instead");
-                    true
-                }
-                Err(remove_err) => {
-                    warn!(
-                        "quarantine failed (rename: {rename_err}, remove: {remove_err}); continuing"
-                    );
-                    false
-                }
-            },
-        };
+        persist::Quarantine::Removed => true,
+        persist::Quarantine::Failed => false,
     }
-    false
 }
 
 /// Copy the v1 checkpoint bytes aside before migration overwrites the path.
@@ -484,66 +453,6 @@ fn reinitialize(wal: &mut HistoryWal, history: &UserHistory) -> bool {
             wal.adopt_empty(history.applied_seq());
             wal.freeze();
             false
-        }
-    }
-}
-
-fn quarantined_files(checkpoint_path: &Path) -> Vec<PathBuf> {
-    let parent = match checkpoint_path.parent() {
-        // Bare relative name ("history.lxud"): parent is "" = the current
-        // directory; read_dir("") would fail and hide quarantine files from
-        // rotation and the clear() privacy wipe.
-        Some(p) if p.as_os_str().is_empty() => Path::new("."),
-        Some(p) => p,
-        None => return Vec::new(),
-    };
-    let Some(prefix) = checkpoint_path.file_name().and_then(|n| n.to_str()) else {
-        return Vec::new();
-    };
-    let Ok(entries) = fs::read_dir(parent) else {
-        return Vec::new();
-    };
-    entries
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with(prefix) && name.contains(".corrupt-"))
-        })
-        .map(|e| e.path())
-        .collect()
-}
-
-/// Keep only the newest [`QUARANTINE_KEEP`] quarantined files (by epoch in
-/// the file name) so repeated corruption cannot accumulate junk forever.
-fn rotate_quarantined(checkpoint_path: &Path) {
-    let mut files = quarantined_files(checkpoint_path);
-    if files.len() <= QUARANTINE_KEEP {
-        return;
-    }
-    // `.corrupt-<epoch>[-n]`: sort newest first; unparsable names sort
-    // oldest and get cleaned up.
-    files.sort_by_key(|p| {
-        let key = p
-            .file_name()
-            .and_then(|n| n.to_str())
-            .and_then(|name| name.rsplit_once(".corrupt-"))
-            .and_then(|(_, suffix)| {
-                let (epoch, n) = match suffix.split_once('-') {
-                    Some((e, n)) => (e, n.parse::<u64>().unwrap_or(0)),
-                    None => (suffix, 0),
-                };
-                epoch.parse::<u64>().ok().map(|e| (e, n))
-            })
-            .unwrap_or((0, 0));
-        std::cmp::Reverse(key)
-    });
-    for old in &files[QUARANTINE_KEEP..] {
-        if let Err(e) = fs::remove_file(old) {
-            warn!(
-                "failed to rotate old quarantine file {}: {e}",
-                old.display()
-            );
         }
     }
 }

--- a/engine/crates/lex-core/src/user_history/wal.rs
+++ b/engine/crates/lex-core/src/user_history/wal.rs
@@ -35,7 +35,8 @@ use bincode::Options as _;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use super::persistence::bincode_reader;
+use crate::persist::bincode_reader;
+
 use super::UserHistory;
 
 pub(super) const WAL_MAGIC: &[u8; 4] = b"LXWL";
@@ -140,7 +141,7 @@ struct FileWalIo {
     file: Option<File>,
 }
 
-use super::persistence::ensure_parent_dir;
+use crate::persist::ensure_parent_dir;
 
 impl FileWalIo {
     fn open_file(&mut self) -> io::Result<&mut File> {
@@ -168,7 +169,7 @@ impl FileWalIo {
                 // A freshly created file's directory entry needs a parent
                 // fsync to be durable — otherwise a power loss could drop
                 // the whole file, frames included, past the barrier bound.
-                if !super::persistence::sync_parent_dir(&self.path) {
+                if !crate::persist::sync_parent_dir(&self.path) {
                     warn!("WAL parent dir sync failed; new file's durability unconfirmed");
                 }
             } else {
@@ -245,7 +246,7 @@ impl WalIo for FileWalIo {
         f.sync_data()?;
         // If create() made a new directory entry (file was removed
         // externally), it needs a parent fsync to be durable.
-        if !super::persistence::sync_parent_dir(&self.path) {
+        if !crate::persist::sync_parent_dir(&self.path) {
             warn!("WAL parent dir sync failed after truncation; durability unconfirmed");
         }
         Ok(())


### PR DESCRIPTION
## What

Extract the on-disk persistence primitives that `user_history` (LXUD) already
uses into a new crate-internal `crate::persist` module, and redirect the three
consumers (`persistence.rs`, `recovery.rs`, `wal.rs`) to it:

- **atomic durable write** — tmp → `sync_all` (F_FULLFSYNC) → rename → best-effort dir fsync
- **quarantine + rotation** — rename a corrupt file aside as `<name>.corrupt-<ts>` (preserve bytes, never delete), cap retained copies
- **fixint bincode readers** — with an allocation cap; strict (reject-trailing) for CRC-framed bodies vs lenient (allow-trailing) for no-CRC/v1-class formats

## Why

This is the prerequisite for hardening the **user dictionary** (LXUW) without a
second, drift-prone copy of privacy/durability-critical code. Those primitives
were `pub(super)`/private inside `user_history`, unreachable by the other
durable store — the gap that left `user_dict::save` with an unsynced write and
the stray-`.tmp` bug that LXUD had already fixed (an unfixed copy of the same
bug = the exact drift `CLAUDE.md`'s 「同種処理は単一の正準形に収束させる」 targets).
Centralizing makes the durability/quarantine invariants hold **by construction**
for both stores.

## Scope — parity-only

- **No behavior change**, **no on-disk format change**, **no FFI change**, no
  dict/corpus/hot-path touch. `user_dict` is deliberately **not** wired to
  `crate::persist` here — that adoption (plus fsync/quarantine/`with_limit`) is
  the follow-up **PR3b**.
- The primitives **move verbatim**. Two deliberate generalizations, both
  behavior-preserving:
  - `quarantine` returns an outcome enum (`Renamed`/`Removed`/`Failed`) and takes
    an injected `ts`, so it is a clock-free leaf with no dependency on any
    store's domain types or clock. `recovery.rs` keeps a thin adapter mapping the
    outcome back to its old `bool` + report-path-push (exact isomorphism).
  - `rotate_quarantined(path, keep)` takes the retention count as a parameter;
    `QUARANTINE_KEEP = 3` stays the caller's policy in `recovery.rs`.
- `now_epoch` stays in `user_history` (already the crate-wide time util, 34 call
  sites incl. the FFI crate) and is injected into `quarantine`.

Net: `crate::persist` (+226) centralizes what the three consumers shed (−198).

## Why split (PR3a / PR3b)

Design-lens adjudicated this session (and passed `/lexime-plan-review`):
単一正準形 → extract; 束ね規律 → split the parity-only refactor of freshly-merged
crash-critical code (recovery/WAL from #281/#285) from the risk-bearing
user_dict hardening. PR3a carries one invariant set — *did `user_history` stay
byte-for-byte identical* — whose whole proof is the green regression suite; PR3b
carries *is the new user_dict recovery correct*. Isolating them keeps either
independently bisectable/revertible.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test --workspace --all-features` — **587 tests, 0 failed** (incl. the
  51KB `tests_recovery.rs` recovery matrix, the authoritative parity oracle)
- msrv `cargo +1.88.0 check --workspace --locked`; supply-chain screen
  (quarantine / build.rs baseline) + `cargo deny`/`vet`/`machete`
- Pre-push design gate: `/simplify` (4 agents) + `/code-review high` (correctness
  + conventions) + `/lexime-review` (Axis 3 structural + Axis 5 context) — **all 0 findings**

## Test plan

- [x] Full workspace test suite green (parity oracle)
- [x] clippy `-D warnings` clean — every `pub(crate)` item live, no dead code / unused imports
- [x] msrv 1.88.0, screen, audit green
- [ ] CI green (accuracy + swift deferred to CI: zero conversion-path / FFI-surface, unchanged by construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
