### PR TITLE
feat(user_dict): durable save + recovering open (LXUW hardening)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,16 @@ what a generic reviewer misses:
   back to the previous checkpoint, never corruption). Findings that couple
   rename-durability confirmation to WAL truncation or other behavior
   re-litigate a settled design decision — do not raise them.
+- **User-dictionary recovery visibility (settled)**: a corrupt user_dict is
+  quarantined and started empty (open no longer throws on corruption), and
+  Swift records it as a dedicated `.userDictionaryDataLoss` case distinct from
+  `.userDictionary` (which now means an environmental read failure → dict
+  unavailable). This mirrors the merged `.history` / `.historyDataLoss` split:
+  "registration keeps working but the registered words were lost" is a
+  different state with different remediation than "dictionary unavailable". It
+  supersedes design §10's earlier "reuse the existing `.userDictionary` case"
+  note, which predates the history split. Findings proposing to collapse the
+  two cases re-litigate a settled decision — do not raise them.
 - Prioritize conversion correctness and boundary safety over naming/style
   nits.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -419,9 +419,11 @@ decay = 1.0 / (1.0 + hours_elapsed / 168.0)
 
 - **データ構造**: `RwLock<HashMap<String, Vec<UserEntry>>>`（reading → entries）
 - **POS ID**: 1852（名詞,一般）、cost: -1（システム辞書より常に優先）
-- **形式**: LXUW（マジック `LXUW` + version 1 + bincode）、アトミック書き込み
+- **形式**: LXUW（マジック `LXUW` + version 1 + bincode）。LXUD と共有する persistence primitive で耐久アトミック書き込み（tmp + `sync_all` + rename + 親 dir fsync（best-effort・log-only））。読み込みは alloc 上限（`with_limit`）つきで巨大 alloc を防ぐ。フォーマットは CRC なし・単一ファイル・WAL なしのまま（数十エントリ・明示 `save` 駆動のため最小ハードニングに留める、design §9）
 - **場所**: `~/Library/Application Support/Lexime/user_dict.lxuw`
 - **操作**: `register` / `unregister` は write lock、`Dictionary` trait（lookup / predict 等）は read lock
+- **起動時（エンジン経路）**: `UserDictionary::open_recovering` — 破損（マジック / version / bincode / 長さ）は `.corrupt-<epoch>` へ隔離（直近 3 個保持）して空辞書で継続 + report 記録。破損ファイルが残存して毎起動 throw し登録語が永久に失われる経路を塞ぐ。Err は EACCES 等の環境障害のみ
+- **オフラインツール経路**: `UserDictionary::open` は無副作用・厳格エラーのまま（CLI の監査ツールが稼働中 IME のファイルを rename しない）
 - **CLI**: `dictool user-dict add/remove/list`
 
 ## 設定の外部化

--- a/Sources/EngineContainer.swift
+++ b/Sources/EngineContainer.swift
@@ -6,7 +6,13 @@ enum EngineInitFailure {
     /// System dictionary failed to load. Fatal: the engine cannot start.
     case dictionary(detail: String)
     /// User dictionary file could not be opened (entries unavailable).
+    /// Environmental read failures only (e.g. permissions) — corruption no
+    /// longer throws (it quarantines; see `.userDictionaryDataLoss`).
     case userDictionary(detail: String)
+    /// User dictionary recovery quarantined a corrupt file: registration keeps
+    /// working (empty dictionary), but the previously registered words were
+    /// lost (bytes preserved in `.corrupt-*` when the rename succeeded).
+    case userDictionaryDataLoss(detail: String)
     /// Composite (system + user) dictionary creation failed;
     /// user dictionary entries are not reflected in conversion.
     case compositeDictionary(detail: String)
@@ -91,6 +97,20 @@ final class EngineContainer {
         do {
             let ud = try LexUserDictionary.open(path: userDictPath)
             NSLog("Lexime: User dictionary loaded from %@", userDictPath)
+            // Recovery report: quarantine = user-visible data loss
+            // (registration keeps working with an empty dict; the corrupt
+            // bytes are preserved). Recorded here on the SUCCESS path, NOT in
+            // `catch`: corruption no longer throws — only environmental read
+            // failures do (which land in `.userDictionary` below).
+            let report = ud.openReport()
+            if report.dataLossSuspected {
+                var detail = "user dictionary corrupt; registered words lost"
+                if !report.quarantinedPaths.isEmpty {
+                    detail += ", quarantined: \(report.quarantinedPaths.joined(separator: ", "))"
+                }
+                NSLog("Lexime: %@", detail)
+                failures.append(.userDictionaryDataLoss(detail: detail))
+            }
             userDict = ud
         } catch {
             NSLog("Lexime: Failed to open user dictionary at %@: %@", userDictPath, "\(error)")

--- a/Sources/LeximeInputController.swift
+++ b/Sources/LeximeInputController.swift
@@ -190,6 +190,10 @@ class LeximeInputController: IMKInputController {
             return NSLocalizedString(
                 "⚠️ ユーザ辞書の読み込みに失敗",
                 comment: "Degraded status: user dictionary failed")
+        case .userDictionaryDataLoss:
+            return NSLocalizedString(
+                "⚠️ ユーザ辞書が破損していました（登録語を失いましたが登録は継続中）",
+                comment: "Degraded status: user dictionary quarantined, words lost, registration continues")
         case .compositeDictionary:
             return NSLocalizedString(
                 "⚠️ ユーザ辞書が変換に反映されていません",

--- a/engine/crates/lex-core/src/user_dict/mod.rs
+++ b/engine/crates/lex-core/src/user_dict/mod.rs
@@ -10,15 +10,28 @@ mod tests;
 use std::collections::HashMap;
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
+use bincode::Options as _;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::dict::{DictEntry, Dictionary, SearchResult};
 
 const MAGIC: &[u8; 4] = b"LXUW";
+/// On-disk format version. LXUW is intentionally CRC-less and single-file (a
+/// few-dozen-entry store with explicit `save`), so a future field addition
+/// bumps this byte. Per the LXUD version-bump policy (design §7), an unknown
+/// version must never hard-fail startup: [`open_recovering`] treats it as
+/// corruption → quarantine + empty (the bytes are preserved for a downgrade),
+/// and a bumped release must ship a reader + one-time rewrite for the old
+/// version.
 const VERSION: u8 = 1;
+
+/// How many quarantined (`.corrupt-*`) user-dict files to retain, matching the
+/// history store (design §8). Repeated corruption cannot accumulate junk.
+const QUARANTINE_KEEP: usize = 3;
 
 /// POS ID for 名詞,一般 (from id.def).
 const USER_POS_ID: u16 = 1852;
@@ -119,7 +132,13 @@ impl UserDictionary {
                 "unsupported version",
             ));
         }
-        let records: Vec<UserWordRecord> = bincode::deserialize(&bytes[5..])
+        // LXUW is a no-CRC / v1-class format, so use the trailing-tolerant
+        // reader (matches the original plain `bincode::deserialize`) with an
+        // allocation cap: a corrupt length prefix must not trigger a giant
+        // allocation before any data is read.
+        let body = &bytes[5..];
+        let records: Vec<UserWordRecord> = crate::persist::bincode_reader_v1(body.len())
+            .deserialize(body)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         let mut map: HashMap<String, Vec<DictEntry>> = HashMap::new();
@@ -133,25 +152,87 @@ impl UserDictionary {
         })
     }
 
-    /// Atomic write: write to .tmp then rename.
+    /// Durable atomic write: tmp → fsync → rename → best-effort dir fsync (via
+    /// the shared [`crate::persist::write_atomic`]). Registration is off the
+    /// hot path, so the F_FULLFSYNC is free; without it a rename could become
+    /// durable before the contents (the self-inflicted corruption LXUD fixed),
+    /// and the old `with_extension("tmp")` also left a stray `<stem>.tmp`
+    /// outside the file family.
     pub fn save(&self, path: &Path) -> Result<(), io::Error> {
         let bytes = self.to_bytes()?;
-        let tmp = path.with_extension("tmp");
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&tmp, &bytes)?;
-        fs::rename(&tmp, path)?;
-        Ok(())
+        crate::persist::write_atomic(path, &bytes)
     }
 
-    /// Open from file, returning empty UserDictionary if file doesn't exist.
+    /// Strict open (no side effects, corrupt = `Err`), for offline tooling
+    /// (the CLI): an audit tool must never rename a live user's file. The
+    /// engine uses [`open_recovering`](Self::open_recovering) instead. Returns
+    /// an empty dictionary if the file doesn't exist.
     pub fn open(path: &Path) -> Result<Self, io::Error> {
         match fs::read(path) {
             Ok(bytes) => Self::from_bytes(&bytes),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::new()),
             Err(e) => Err(e),
         }
+    }
+
+    /// Engine-side open with recovery: a corrupt file is quarantined (renamed
+    /// aside as `<name>.corrupt-<ts>`, bytes preserved) and an empty dictionary
+    /// is returned, so corruption never permanently disables user-word
+    /// registration (the pre-hardening path threw, leaving the corrupt file in
+    /// place to re-throw every startup — registered words lost forever). `Err`
+    /// is reserved for environmental read failures (EACCES etc.): visible
+    /// degradation, not a silent stop. Quarantine-rename failure is **not** an
+    /// `Err` — an empty usable dictionary is still returned and the next `save`
+    /// overwrites the file; the report still flags the loss.
+    pub fn open_recovering(path: &Path) -> Result<(Self, UserDictOpenReport), io::Error> {
+        match fs::read(path) {
+            Ok(bytes) => match Self::from_bytes(&bytes) {
+                Ok(dict) => Ok((dict, UserDictOpenReport::default())),
+                Err(e) => {
+                    warn!("user dictionary corrupt ({e}); quarantining");
+                    let mut report = UserDictOpenReport {
+                        quarantined: true,
+                        quarantined_paths: Vec::new(),
+                    };
+                    if let crate::persist::Quarantine::Renamed(dest) =
+                        crate::persist::quarantine(path, crate::user_history::now_epoch())
+                    {
+                        report.quarantined_paths.push(dest);
+                    }
+                    crate::persist::rotate_quarantined(path, QUARANTINE_KEEP);
+                    Ok((Self::new(), report))
+                }
+            },
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                Ok((Self::new(), UserDictOpenReport::default()))
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// What [`UserDictionary::open_recovering`] found and did. The user dictionary
+/// has a single recovery event — corruption → quarantine — so the report is a
+/// flag plus the rescued path(s); policy (`data_loss_suspected`) is computed
+/// here so the Swift side stays presentational (mirrors the history report).
+#[derive(Default)]
+pub struct UserDictOpenReport {
+    /// The file was corrupt and quarantined (renamed aside, or removed if the
+    /// rename failed); an empty dictionary was returned and the previously
+    /// registered words are lost. Set regardless of whether the rename
+    /// succeeded, so a byte-destroying fallback is still surfaced.
+    pub quarantined: bool,
+    /// Where the corrupt bytes were preserved (`.corrupt-<ts>`), when the
+    /// rename succeeded. Empty if the file was removed as a last resort.
+    pub quarantined_paths: Vec<PathBuf>,
+}
+
+impl UserDictOpenReport {
+    /// Whether registered words were lost in a way the user should hear about.
+    /// Any quarantine qualifies (the corrupt file is gone from the live path),
+    /// including the byte-destroying `Removed`/`Failed` fallback.
+    pub fn data_loss_suspected(&self) -> bool {
+        self.quarantined
     }
 }
 

--- a/engine/crates/lex-core/src/user_dict/tests.rs
+++ b/engine/crates/lex-core/src/user_dict/tests.rs
@@ -159,3 +159,120 @@ fn from_bytes_too_short() {
     let bytes = b"LX";
     assert!(UserDictionary::from_bytes(bytes).is_err());
 }
+
+// --- Hardening: durable save + recovering open (design §9) ---
+
+/// `.corrupt-*` quarantine files in `dir`.
+fn corrupt_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(".corrupt-"))
+        })
+        .collect()
+}
+
+#[test]
+fn open_recovering_quarantines_corrupt() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("user_dict.lxuw");
+    let corrupt = b"BADX not a real lxuw file".to_vec();
+    std::fs::write(&path, &corrupt).unwrap();
+
+    let (dict, report) = UserDictionary::open_recovering(&path).unwrap();
+
+    // Empty but usable; data loss surfaced.
+    assert!(dict.list().is_empty());
+    assert!(report.data_loss_suspected());
+    assert_eq!(report.quarantined_paths.len(), 1);
+
+    // Original path cleared; bytes preserved verbatim in the quarantine file.
+    assert!(!path.exists());
+    let quarantined = corrupt_files(dir.path());
+    assert_eq!(quarantined.len(), 1);
+    assert_eq!(std::fs::read(&quarantined[0]).unwrap(), corrupt);
+}
+
+#[test]
+fn open_recovering_nonexistent_is_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("user_dict.lxuw");
+    let (dict, report) = UserDictionary::open_recovering(&path).unwrap();
+    assert!(dict.list().is_empty());
+    assert!(!report.data_loss_suspected());
+}
+
+#[test]
+fn open_recovering_valid_is_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("user_dict.lxuw");
+    let dict = UserDictionary::new();
+    dict.register("しゅうじ", "週次");
+    dict.save(&path).unwrap();
+
+    let (loaded, report) = UserDictionary::open_recovering(&path).unwrap();
+    assert!(!report.data_loss_suspected());
+    assert_eq!(loaded.lookup("しゅうじ")[0].surface, "週次");
+    assert!(corrupt_files(dir.path()).is_empty());
+}
+
+#[test]
+fn strict_open_corrupt_errors_without_side_effects() {
+    // The CLI's strict open must NOT quarantine — an audit tool must never
+    // rename a live user's file.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("user_dict.lxuw");
+    std::fs::write(&path, b"BADX corrupt").unwrap();
+
+    assert!(UserDictionary::open(&path).is_err());
+    assert!(path.exists()); // untouched, not renamed aside
+    assert!(corrupt_files(dir.path()).is_empty());
+}
+
+#[test]
+fn save_leaves_no_stray_tmp() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("user_dict.lxuw");
+    let dict = UserDictionary::new();
+    dict.register("かき", "柿");
+    dict.save(&path).unwrap();
+
+    // The durable write removes its tmp via rename and never leaves a stray
+    // sibling (the old `with_extension("tmp")` produced `user_dict.tmp`).
+    let mut names: Vec<String> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["user_dict.lxuw".to_string()]);
+}
+
+#[test]
+fn from_bytes_rejects_oversized_length() {
+    // Valid header + a bincode Vec length prefix claiming u64::MAX elements.
+    // The allocation cap must reject it (fast Err), never attempt a giant
+    // allocation.
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(MAGIC);
+    bytes.push(VERSION);
+    bytes.extend_from_slice(&[0xFF; 8]);
+    assert!(UserDictionary::from_bytes(&bytes).is_err());
+}
+
+#[test]
+fn open_recovering_rotates_quarantine() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("user_dict.lxuw");
+    // Each corrupt open quarantines then rotates; only the newest are kept.
+    for _ in 0..(QUARANTINE_KEEP + 1) {
+        std::fs::write(&path, b"BADX corrupt").unwrap();
+        let (_dict, report) = UserDictionary::open_recovering(&path).unwrap();
+        assert!(report.data_loss_suspected());
+    }
+    assert_eq!(corrupt_files(dir.path()).len(), QUARANTINE_KEEP);
+}

--- a/engine/src/api/user_dict.rs
+++ b/engine/src/api/user_dict.rs
@@ -1,23 +1,65 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::user_dict::UserDictionary;
+use crate::user_dict::{UserDictOpenReport, UserDictionary};
 
 use super::{LexError, LexUserWord};
 
 #[derive(uniffi::Object)]
 pub struct LexUserDictionary {
     pub(crate) inner: Arc<UserDictionary>,
+    report: UserDictOpenReport,
+}
+
+/// What `open` found and did. `data_loss_suspected` is computed on the Rust
+/// side so Swift stays presentational (mirrors `LexHistoryOpenReport`).
+#[derive(uniffi::Record)]
+pub struct LexUserDictOpenReport {
+    /// Display-only paths where corrupt bytes were preserved (`.corrupt-<ts>`).
+    pub quarantined_paths: Vec<String>,
+    /// Registered words were lost: the file was corrupt and quarantined.
+    pub data_loss_suspected: bool,
+}
+
+impl From<&UserDictOpenReport> for LexUserDictOpenReport {
+    fn from(r: &UserDictOpenReport) -> Self {
+        Self {
+            // Lossy on purpose: display-only, and a non-UTF-8 path must not
+            // panic at the FFI boundary.
+            quarantined_paths: r
+                .quarantined_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+            data_loss_suspected: r.data_loss_suspected(),
+        }
+    }
 }
 
 #[uniffi::export]
 impl LexUserDictionary {
     #[uniffi::constructor]
     fn open(path: String) -> Result<Arc<Self>, LexError> {
-        let dict = UserDictionary::open(Path::new(&path))?;
+        // Recovery-mode open: corruption is quarantined instead of failing, so
+        // a corrupt file never permanently disables user-word registration.
+        // Err = environmental read failure only (EACCES etc.). Swift consumes
+        // the report via `open_report()`; the log here covers headless/CLI.
+        let (dict, report) = UserDictionary::open_recovering(Path::new(&path))?;
+        if report.data_loss_suspected() {
+            tracing::warn!(
+                "user dictionary recovered with data loss (quarantined: {:?})",
+                report.quarantined_paths
+            );
+        }
         Ok(Arc::new(Self {
             inner: Arc::new(dict),
+            report,
         }))
+    }
+
+    /// What recovery found and did at open time (data loss on quarantine).
+    fn open_report(&self) -> LexUserDictOpenReport {
+        (&self.report).into()
     }
 
     fn register(&self, reading: String, surface: String) -> bool {


### PR DESCRIPTION
## What

Harden the user dictionary (LXUW) with the same durability/recovery discipline
as the learning history (LXUD), using the shared `crate::persist` primitives
extracted in #289. This is the **minimal, format-invariant** hardening from
design §9 — deliberately **no WAL/seq/migration** (a few-dozen-entry store with
explicit `save`, where that machinery earns nothing).

- **save** → `persist::write_atomic` (tmp → F_FULLFSYNC → rename → best-effort
  dir fsync). Fixes the unsynced write **and** the `with_extension("tmp")` stray
  `user_dict.tmp` — the two bugs LXUD had already fixed in its own copy.
- **from_bytes** → `persist::bincode_reader_v1` (allow-trailing, matching the
  original plain `bincode::deserialize`, for this no-CRC/v1-class format) with an
  allocation cap so a corrupt length prefix can't trigger a giant allocation.
- **open_recovering** — corruption (bad magic / version / bincode / length) is
  quarantined (`.corrupt-<ts>`, bytes preserved, newest 3 kept) and an empty
  dictionary is returned. Closes the path where a corrupt file re-threw every
  startup and registered words were lost forever. `Err` is reserved for
  environmental read failures (EACCES); quarantine-rename failure still yields an
  empty usable dict (loss still surfaced via the report). The strict,
  side-effect-free `open` stays for the CLI (an audit tool must never rename a
  live user's file — enforced by construction, pinned by a test).
- **FFI/Swift** — `LexUserDictionary::open` no longer throws on corruption;
  `open_report()` surfaces `data_loss_suspected` (computed Rust-side).
  `EngineContainer` records it on the **success** path (not `catch`, where it
  would never fire) as a new `.userDictionaryDataLoss` case, distinct from
  `.userDictionary` (env failure → dict unavailable) — mirroring the merged
  `.history` / `.historyDataLoss` split. This supersedes design §10's older
  "reuse `.userDictionary`" note (recorded as settled in `AGENTS.md`).

## Scope / compatibility

- **On-disk format unchanged** (LXUW magic + version 1 + bincode) — `to_bytes` is
  untouched, output byte-identical, **no migration owed**.
- Depends on #289 (the `crate::persist` extraction); this is PR3b of that 2-PR
  split. Diff here is the user_dict hardening only.
- SPEC.md gains the symmetric user_dict recovery / offline-tool lines; the
  version-bump policy (§7) is documented on the `VERSION` const.

## Verification (local pre-push gate)

- `cargo fmt --all --check`, `clippy --workspace --all-features -D warnings`
- `cargo test --workspace --all-features` — **594 tests, 0 failed** (7 new
  user_dict tests: quarantine, rotation, strict-open-no-side-effect,
  no-stray-tmp, oversized-length cap, clean/nonexistent)
- `mise run build` (Swift bindings regenerated) + `mise run test-swift` —
  **139 Swift tests, 0 failed**
- msrv 1.88.0, supply-chain screen, `cargo deny`/`vet`/`machete`
- Design gate: `/simplify` (4 agents) + `/code-review high` (correctness +
  conventions) + `/lexime-review` (Axis 3 structural / 4 UniFFI / 5 context) —
  **all 0 findings**

## Test plan

- [x] Rust workspace + Swift suites green
- [x] Corrupt file → quarantined (`.corrupt-*`, bytes preserved) + empty usable dict + report flags loss
- [x] Strict `open` (CLI) still errors on corruption without renaming
- [x] Durable save leaves no stray `.tmp`; oversized length prefix rejected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
