### PR TITLE
fix(bench): repair lex-core benches and gate all targets in clippy

### DIFF
--- a/.claude/skills/external-review/project.md
+++ b/.claude/skills/external-review/project.md
@@ -11,7 +11,7 @@ invoked from this repo. The multi-round loop variant's calibration
 
 ## build_verify
 
-`cd engine && cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace --all-features`
+`cd engine && cargo fmt --all --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features`
 
 Per CLAUDE.md「ビルド・テスト」. When a fix touches any accuracy-impacting
 input — dictionary sources (dict_source / `engine/data/`) / connection

--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -28,7 +28,7 @@ cd engine && cargo fmt --all
 **順序規則: screen-before-build**。依存変更 (CI で screen + audit が走る変更) がある場合、build を伴う cargo (clippy / test / check) より**先に** `mise run audit` を回す — cargo は依存の build.rs をコンパイル・実行するので、screen が拒否すべき build.rs を base verify が先に実行してはならない (CI の `screen` job ゲートと同じ不変条件)。
 
 ```sh
-cd engine && cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace --all-features
+cd engine && cargo fmt --all --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features
 ```
 
 条件付き追加 (diff に該当パスがあれば必須):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,13 @@ jobs:
           shared-key: engine
 
       - run: cd engine && cargo fmt --all --check
-      - run: cd engine && cargo clippy --workspace --all-features -- -D warnings
+
+      # --all-targets is load-bearing: without it clippy checks only lib+bins,
+      # so benches / examples compile in no gate at all and rot silently
+      # (issue #299 — lex-core benches had been uncompilable for some time).
+      # `cargo test` does not cover them either: both benches are
+      # `harness = false`, which excludes them from the test target set.
+      - run: cd engine && cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   msrv:
     needs: [changes, screen]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,10 @@ jobs:
       # bump or code change that needs a newer Rust fails here even though every
       # other job builds on stable. Default features only — the optional
       # `neural` feature pulls candle, whose MSRV is tracked separately.
+      # Default *targets* only, for the same reason: do NOT propagate the
+      # `lint` job's --all-targets here. It would put criterion / proptest and
+      # first-party bench source under the MSRV constraint, so a dev-dep bump
+      # could turn CI red over code that never ships.
       - uses: dtolnay/rust-toolchain@1.88.0
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
       - run: cd engine && cargo fmt --all --check
 
       # --all-targets is load-bearing: without it clippy checks only lib+bins,
-      # so benches / examples compile in no gate at all and rot silently
-      # (issue #299 — lex-core benches had been uncompilable for some time).
-      # `cargo test` does not cover them either: both benches are
-      # `harness = false`, which excludes them from the test target set.
+      # which leaves benches in no gate at all — `cargo test` does not build
+      # `[[bench]]` targets either (they default to `test = false`; `harness`
+      # is not the lever). That is how #299 rotted unnoticed. Examples are
+      # already covered by `cargo test`, which does build them.
       - run: cd engine && cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,19 @@ jobs:
               - 'scripts/check-build-scripts.sh'
               - 'engine/supply-chain/**'
               - '.github/workflows/ci.yml'
+              # mise.toml defines the gates themselves ([tasks.lint] is the
+              # local twin of this workflow's lint job). Without this, an edit
+              # weakening a gate would skip the very jobs that would catch it.
+              - 'mise.toml'
             session:
               - 'engine/crates/lex-session/**'
+            # Root `lex_engine` package. examples/ and uniffi-bindgen.rs are
+            # cargo targets too, and lint now compiles them via --all-targets;
+            # unfiltered they would merge green and fail on someone else's PR.
             ffi:
               - 'engine/src/**'
+              - 'engine/examples/**'
+              - 'engine/uniffi-bindgen.rs'
             cli:
               - 'engine/crates/lex-cli/**'
             corpus:
@@ -103,11 +112,10 @@ jobs:
 
       - run: cd engine && cargo fmt --all --check
 
-      # --all-targets is load-bearing: without it clippy checks only lib+bins,
-      # which leaves benches in no gate at all — `cargo test` does not build
-      # `[[bench]]` targets either (they default to `test = false`; `harness`
-      # is not the lever). That is how #299 rotted unnoticed. Examples are
-      # already covered by `cargo test`, which does build them.
+      # --all-targets is load-bearing: clippy otherwise checks only lib+bins,
+      # leaving benches in no gate at all — `cargo test` skips `[[bench]]`
+      # targets too (they default to `test = false`; `harness` is not the
+      # lever). That is how #299 rotted unnoticed.
       - run: cd engine && cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   msrv:
@@ -125,11 +133,10 @@ jobs:
       # `rust-version` in engine/Cargo.toml ([workspace.package]): a dependency
       # bump or code change that needs a newer Rust fails here even though every
       # other job builds on stable. Default features only — the optional
-      # `neural` feature pulls candle, whose MSRV is tracked separately.
-      # Default *targets* only, for the same reason: do NOT propagate the
-      # `lint` job's --all-targets here. It would put criterion / proptest and
-      # first-party bench source under the MSRV constraint, so a dev-dep bump
-      # could turn CI red over code that never ships.
+      # `neural` feature pulls candle, whose MSRV is tracked separately, and
+      # default targets only — do NOT propagate the `lint` job's --all-targets
+      # here, or criterion / proptest and bench source come under the MSRV
+      # constraint and a dev-dep bump turns CI red over code that never ships.
       - uses: dtolnay/rust-toolchain@1.88.0
 
       - uses: Swatinem/rust-cache@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 
 ```bash
 # Rust lint + test
-cd engine && cargo fmt --all --check && cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace --all-features
+cd engine && cargo fmt --all --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features
 
 # アプリビルド・インストール
 mise run build && mise run install && mise run reload

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 ## ビルド・テスト
 
 ```bash
-# Rust lint + test
+# Rust lint + test (--all-targets は必須: bench はこれ以外のゲートに載らない — #299)
 cd engine && cargo fmt --all --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace --all-features
 
 # アプリビルド・インストール

--- a/SPEC.md
+++ b/SPEC.md
@@ -611,8 +611,8 @@ macOS で動作する最小限の IME を構築。
 | `conn` | 接続行列のコンパイル |
 | `test-swift` | Swift UniFFI ラウンドトリップテスト |
 | `test` | lint + `cargo test --workspace --all-features` |
-| `lint` | `cargo fmt --check` + `cargo clippy` |
-| `audit` | cargo-audit（脆弱性）+ cargo-machete（未使用 deps） |
+| `lint` | `cargo fmt --check` + `cargo clippy --all-targets` |
+| `audit` | quarantine / build.rs スクリーニング + `--locked` 検証 + cargo-deny + cargo-vet + cargo-machete（未使用 deps） |
 | `log` | ログストリーミング |
 | `trace-log` | トレース JSONL ストリーミング |
 | `icon` | アイコンアセット生成 |
@@ -637,16 +637,19 @@ macOS で動作する最小限の IME を構築。
 
 | ジョブ | 環境 | 条件 | 内容 |
 |---|---|---|---|
-| `changes` | ubuntu-latest | 常時 | パスフィルタ検出（core / session / ffi / cli / swift） |
-| `lint` | ubuntu-latest | Rust 変更時 | `cargo fmt --check` + `cargo clippy` |
+| `changes` | ubuntu-latest | 常時 | パスフィルタ検出（core / session / ffi / cli / corpus / swift） |
+| `screen` | ubuntu-latest | 常時 | quarantine + build.rs ベースライン検査。cargo は依存の build.rs を実行するので、cargo を呼ぶ全ジョブをこれが gate する |
+| `lint` | ubuntu-latest | Rust 変更時 | `cargo fmt --check` + `cargo clippy --all-targets` |
+| `msrv` | ubuntu-latest | Rust 変更時 | `cargo check --workspace --locked`（宣言 MSRV。デフォルト features / targets） |
 | `test-core` | ubuntu-latest | core 変更時 | `cargo test -p lex-core --features trace,neural` |
 | `test-session` | ubuntu-latest | session/core 変更時 | `cargo test -p lex-session --features trace` |
 | `test-engine` | ubuntu-latest | core/session/ffi 変更時 | `cargo test -p lex_engine --features trace` |
 | `test-cli` | ubuntu-latest | core/cli 変更時 | `cargo test -p lex-cli` |
-| `audit` | ubuntu-latest | core 変更時 | `cargo-audit` + `cargo-machete` |
-| `swift` | macos-latest | engine + Swift 両方変更時 | `mise run test-swift` |
+| `accuracy` | ubuntu-latest | core/cli/corpus 変更時 | `mise run accuracy` + `mise run accuracy-history`（Mozc スナップショットは `mozc-pin.txt` で固定） |
+| `audit` | ubuntu-latest | core 変更時 | `--locked` 検証 + `cargo-deny` + `cargo-vet` + `cargo-machete` |
+| `swift` | macos-latest | engine または Swift 変更時 | `mise run test-swift` |
 
-全 Rust ジョブは `Swatinem/rust-cache@v2` で `shared-key: engine` キャッシュを共有。
+Rust ジョブは `Swatinem/rust-cache@v2` を使い、多くは `shared-key: engine` を共有する（`msrv` / `accuracy` は別プロファイルをビルドするため専用キー、`screen` は unlocked な `cargo metadata` が `--locked` 検査より先に Cargo.lock を繕ってしまうため意図的にキャッシュなし）。
 
 ## 未決事項
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -605,6 +605,8 @@ macOS で動作する最小限の IME を構築。
 | `install` | `~/Library/Input Methods` へコピー |
 | `reload` | Lexime プロセスを再起動 |
 | `fetch-dict-mozc` | Mozc 辞書データのダウンロード |
+| `fetch-dict-symbols` | バンドル記号 TSV の生成（ギリシャ文字・数学記号） |
+| `fetch-dict-extras` | curated ドメイン TSV の生成（IT / 食 / 地理 ほか） |
 | `dict-mozc` | Mozc 辞書バイナリのコンパイル |
 | `dict` | 辞書のコピー |
 | `dict-clean` | コンパイル済み辞書の削除（次回ビルドで再コンパイル） |
@@ -612,7 +614,7 @@ macOS で動作する最小限の IME を構築。
 | `test-swift` | Swift UniFFI ラウンドトリップテスト |
 | `test` | lint + `cargo test --workspace --all-features` |
 | `lint` | `cargo fmt --check` + `cargo clippy --all-targets` |
-| `audit` | quarantine / build.rs スクリーニング + `--locked` 検証 + cargo-deny + cargo-vet + cargo-machete（未使用 deps） |
+| `audit` | quarantine / build.rs スクリーニング + `--locked` 検証 + cargo-deny（脆弱性・ライセンス）+ cargo-vet + cargo-machete（未使用 deps） |
 | `log` | ログストリーミング |
 | `trace-log` | トレース JSONL ストリーミング |
 | `icon` | アイコンアセット生成 |
@@ -622,6 +624,7 @@ macOS で動作する最小限の IME を構築。
 | `diff-snapshot` | スナップショット差分比較 |
 | `accuracy` | 変換精度テスト（accuracy-corpus.toml） |
 | `accuracy-history` | 履歴込み変換精度テスト（accuracy-corpus-history.toml） |
+| `history-audit` | 学習履歴を素のエンジン top-1 と突き合わせて監査 |
 | `bench` | criterion ベンチマーク |
 | `fetch-model` | Zenzai GGUF モデルダウンロード |
 | `neural-score` | ニューラルスコアリングベンチマーク |
@@ -638,7 +641,7 @@ macOS で動作する最小限の IME を構築。
 | ジョブ | 環境 | 条件 | 内容 |
 |---|---|---|---|
 | `changes` | ubuntu-latest | 常時 | パスフィルタ検出（core / session / ffi / cli / corpus / swift） |
-| `screen` | ubuntu-latest | 常時 | quarantine + build.rs ベースライン検査。cargo は依存の build.rs を実行するので、cargo を呼ぶ全ジョブをこれが gate する |
+| `screen` | ubuntu-latest | 常時 | quarantine + build.rs ベースライン検査。cargo を呼ぶ全ジョブをこれが gate する |
 | `lint` | ubuntu-latest | Rust 変更時 | `cargo fmt --check` + `cargo clippy --all-targets` |
 | `msrv` | ubuntu-latest | Rust 変更時 | `cargo check --workspace --locked`（宣言 MSRV。デフォルト features / targets） |
 | `test-core` | ubuntu-latest | core 変更時 | `cargo test -p lex-core --features trace,neural` |
@@ -649,7 +652,9 @@ macOS で動作する最小限の IME を構築。
 | `audit` | ubuntu-latest | core 変更時 | `--locked` 検証 + `cargo-deny` + `cargo-vet` + `cargo-machete` |
 | `swift` | macos-latest | engine または Swift 変更時 | `mise run test-swift` |
 
-Rust ジョブは `Swatinem/rust-cache@v2` を使い、多くは `shared-key: engine` を共有する（`msrv` / `accuracy` は別プロファイルをビルドするため専用キー、`screen` は unlocked な `cargo metadata` が `--locked` 検査より先に Cargo.lock を繕ってしまうため意図的にキャッシュなし）。
+Rust ジョブは `Swatinem/rust-cache@v2` を使い、多くは `shared-key: engine` を共有する（`msrv` は toolchain 固定、`accuracy` は release プロファイルのため専用キー、`screen` は意図的にキャッシュなし）。理由は各ジョブのコメント参照。
+
+> この表と上の mise タスク表は**概観**であり正準ではない。正準は `.github/workflows/ci.yml` と `mise.toml`（`mise tasks` で一覧できる）。齟齬があれば向こうが正 — 書き写しは drift するので、ジョブやタスクの増減をここへ反映し忘れても壊れない前提で読むこと。
 
 ## 未決事項
 

--- a/engine/crates/lex-core/benches/candidates.rs
+++ b/engine/crates/lex-core/benches/candidates.rs
@@ -280,7 +280,7 @@ fn bench_standard(c: &mut Criterion) {
     let mut group = c.benchmark_group("candidates/standard");
     for &(label, kana) in INPUTS {
         group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
-            b.iter(|| generate_candidates(&dict, None, None, kana, 20));
+            b.iter(|| generate_candidates(&*dict, None, None, kana, 20));
         });
     }
     group.finish();
@@ -291,7 +291,7 @@ fn bench_predictive(c: &mut Criterion) {
     let mut group = c.benchmark_group("candidates/predictive");
     for &(label, kana) in INPUTS {
         group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
-            b.iter(|| generate_prediction_candidates(&dict, None, None, kana, 20));
+            b.iter(|| generate_prediction_candidates(&*dict, None, None, kana, 20));
         });
     }
     group.finish();

--- a/engine/crates/lex-core/benches/candidates.rs
+++ b/engine/crates/lex-core/benches/candidates.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use lex_core::candidates::{generate_candidates, generate_prediction_candidates};
-use lex_core::dict::{DictEntry, Dictionary, TrieDictionary};
+use lex_core::dict::{DictEntry, TrieDictionary};
 
-fn bench_dict() -> Arc<dyn Dictionary> {
+fn bench_dict() -> TrieDictionary {
     let entries = vec![
         (
             "きょう".into(),
@@ -266,7 +264,7 @@ fn bench_dict() -> Arc<dyn Dictionary> {
             }],
         ),
     ];
-    Arc::new(TrieDictionary::from_entries(entries))
+    TrieDictionary::from_entries(entries)
 }
 
 static INPUTS: &[(&str, &str)] = &[
@@ -280,7 +278,7 @@ fn bench_standard(c: &mut Criterion) {
     let mut group = c.benchmark_group("candidates/standard");
     for &(label, kana) in INPUTS {
         group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
-            b.iter(|| generate_candidates(&*dict, None, None, kana, 20));
+            b.iter(|| generate_candidates(&dict, None, None, kana, 20));
         });
     }
     group.finish();
@@ -291,7 +289,7 @@ fn bench_predictive(c: &mut Criterion) {
     let mut group = c.benchmark_group("candidates/predictive");
     for &(label, kana) in INPUTS {
         group.bench_with_input(BenchmarkId::new(label, kana.len()), &kana, |b, &kana| {
-            b.iter(|| generate_prediction_candidates(&*dict, None, None, kana, 20));
+            b.iter(|| generate_prediction_candidates(&dict, None, None, kana, 20));
         });
     }
     group.finish();

--- a/mise.toml
+++ b/mise.toml
@@ -381,8 +381,8 @@ run = "cd engine && cargo bench -p lex-core"
 description = "Run cargo fmt --check and clippy"
 run = [
   "cd engine && cargo fmt --all --check",
-  # --all-targets keeps benches / examples compiling: they are in no other
-  # gate (`harness = false` benches are excluded from `cargo test`). See #299.
+  # --all-targets keeps benches compiling: they are in no other gate, since
+  # `cargo test` skips `[[bench]]` targets (`test` defaults to false). See #299.
   "cd engine && cargo clippy --workspace --all-targets --all-features -- -D warnings",
 ]
 

--- a/mise.toml
+++ b/mise.toml
@@ -381,7 +381,9 @@ run = "cd engine && cargo bench -p lex-core"
 description = "Run cargo fmt --check and clippy"
 run = [
   "cd engine && cargo fmt --all --check",
-  "cd engine && cargo clippy --workspace --all-features -- -D warnings",
+  # --all-targets keeps benches / examples compiling: they are in no other
+  # gate (`harness = false` benches are excluded from `cargo test`). See #299.
+  "cd engine && cargo clippy --workspace --all-targets --all-features -- -D warnings",
 ]
 
 [tasks.audit]

--- a/mise.toml
+++ b/mise.toml
@@ -381,8 +381,8 @@ run = "cd engine && cargo bench -p lex-core"
 description = "Run cargo fmt --check and clippy"
 run = [
   "cd engine && cargo fmt --all --check",
-  # --all-targets keeps benches compiling: they are in no other gate, since
-  # `cargo test` skips `[[bench]]` targets (`test` defaults to false). See #299.
+  # --all-targets is load-bearing — see the lint job in .github/workflows/ci.yml
+  # for why (benches are in no other gate). Keep the two in step. #299.
   "cd engine && cargo clippy --workspace --all-targets --all-features -- -D warnings",
 ]
 


### PR DESCRIPTION
Closes #299.

## 問題

`cargo check -p lex-core --benches --all-features` が E0277 で落ちていた。`bench_dict()` が `Arc<dyn Dictionary>` を返す一方、候補生成側は `&dyn Dictionary` を取るため `&dict` が `&Arc<...>` になり coerce しない。

腐った理由は **bench をコンパイルするゲートが 1 つも無かった**こと。clippy は `--all-targets` 無しだと lib+bins しか見ず、`cargo test` も `[[bench]]` ターゲットをビルドしない（bench の `test` が既定 `false`。`harness` はレバーではない — `harness = false` のまま `test = true` を足すと `cargo test` が bench をビルドすることを mutation で確認済み）。

## 修正

**1. 根本原因を直す（呼び出し側の deref ではなく）**

双子の `converter.rs::bench_dict()` は具体型 `TrieDictionary` を返しており、`candidates.rs` 側の `Arc` は `38b0148`（`Arc<dyn Dictionary>` 一括変更）が片方だけ触った残骸。clone も共有も保存もされない死んだラッパーで、これが `&dict` の coerce を止めていた唯一の理由。具体型に戻して両呼び出し元を自然な `&dict` に戻し、兄弟を単一の正準形に収束させた（CLAUDE.md 設計規律）。`generate_candidates` は `&dyn Dictionary` を取るのでディスパッチは不変、`Arc::new` は計測区間の外だった。

**2. `--all-targets` を正準 clippy に追加**

書き下してある 5 箇所すべて（CI `lint` job / `mise run lint` / CLAUDE.md / `/pre-push` SKILL.md / external-review overlay）。CI と CLAUDE.md だけだとローカルゲートが同じ腐敗を見逃す。

**3. paths-filter の穴を塞ぐ（レビューで発見）**

`engine/examples/**` と `engine/uniffi-bindgen.rs` はどの `changes` フィルタにもマッチしていなかった。どちらもルート `lex_engine` パッケージの cargo ターゲット。これらだけを触る PR は全フィルタ false で 11 job 全部スキップし、main は保護なしなので green でマージされる。

**`--all-targets` はこれを悪化させる**: examples が「`cargo test` で通ればいい」から「`-D warnings` で clean」に格上げされるため、壊れたものが静かにマージされ**次に lint を発火させた無関係な PR で爆発**する。#299 と同じ誤帰属モード。両パスを `ffi` に追加した。

同クラスで `mise.toml` も `corpus` にしか無く `lint` が発火しなかった（`[tasks.lint]` からフラグを消す PR が、それを検出すべき job をスキップして通る）。`core` にも追加。

**4. SPEC の非正準マーカー**

CI job 表が 11 job 中 8 個しか列挙しておらず（`screen` / `msrv` / `accuracy` 欠落）、`audit` は動いていない cargo-audit を名指し、`swift` の条件が AND になっていた。修正したが、その resync 自体がまた新しい誤り（msrv の cache key 理由）を生んだので、`pre-push/SKILL.md:36` が既に下していた判断「書き写しは drift する」に合わせ両表に非正準マーカーを付けた。

## コスト実測

issue の「lint は約 3m13s」は PR #294 の cold cache 時の外れ値。実測は 21s / 22s / 24s / 49s / 62s / 66s / 66s とばらつき、支配要因は rust-cache のヒット率。

`--all-targets` の差分は **6.9s → 13.6s**（依存 warm・workspace cold = CI と同条件、target dir 分離で計測）。うち新規チェックは約 3 CPU-s で、残りは criterion / proptest の初回コンパイル。`--benches` への絞り込みは無意味（`--benches` が既に proptest 一式を引くため `--tests` / `--examples` の上乗せは 0.09 CPU-s）。

`msrv` は意図的に default targets のまま（criterion / proptest と bench ソースが MSRV 制約に入り、出荷されないコードで CI が赤くなるため）。理由をフラグの隣に記録した。

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` green（フラグを戻すと赤くなることも mutation で確認）
- [x] `cargo test --workspace --all-features` — 617 pass / 0 fail
- [x] `cargo bench -p lex-core -- --test` — candidates 6 本 + converter 全ケース実走 green（コンパイルだけでなく動作確認）
- [x] `mise run test-swift` — 144 pass
- [x] msrv `cargo +1.88.0 check --workspace --locked` green
- [x] `mise run audit`（screen + audit）green
- [x] `mise run accuracy` — 108 pass / 0 fail / 28 skip（ベースライン一致）
- [x] `mise run accuracy-history` — 7/7 pass
- [x] paths-filter の内側 YAML がコメント除去後も再パースし全パターン健在（core 11 / ffi 3、11 job）
- [x] `engine/` `scripts/` の全 tracked ファイルをフィルタに突き合わせ、cargo ターゲットの未マッチがゼロであることを確認

accuracy は変換パス・コスト・辞書ソースいずれも触っていないので本来必須ではないが、`mise.toml` が `corpus` フィルタに入るため CI で走る＝ローカル等価も回した。

## 補足

`mise run bench` は `cargo bench -p lex-core` で全 bench をビルドし 1 つでも失敗すると中断するため、**converter の bench も道連れで 160 日間（2026-02-18〜）実行不能だった**。この窓は 2026-04-05 のベースライン以降の perf 系変更（SoA Lattice #214 / `Arc<Lattice>` / viterbi_nbest 単相化 / #238）を全部含む。#299 の記述より影響範囲が広い。

## 見送り（マージ後に issue 化を検討）

- paths-filter の網羅性を by-construction で担保する仕組み（今回は 2 インスタンスを塞いだだけ）
- `scripts/fetch-mozc-dict.sh` が参照ゼロの死にコード（#266 で dictool に移行済み）
- 正準コマンドの 5 箇所重複（CI を `mise run lint` に寄せる案。mise-action は accuracy / swift job で既に使用中）
- `test-* needs: lint` が lint をクリティカルパスに置く件 + `shared-key: engine` の save 競合で lint の依存が毎回 cold
- bench が `--all-features` でしかゲートされない（`mise run bench` は default features）／bench fixture の 264 行重複

🤖 Generated with [Claude Code](https://claude.com/claude-code)